### PR TITLE
refactor(core): clean up domain consistency issues

### DIFF
--- a/packages/core/src/domain/common/json.utils.ts
+++ b/packages/core/src/domain/common/json.utils.ts
@@ -6,7 +6,17 @@ function toCanonicalJsonValue(value: unknown): unknown {
   if (value !== null && typeof value === "object" && !(value instanceof Date)) {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .sort(([currentKey], [nextKey]) => currentKey.localeCompare(nextKey))
+        .sort(([currentKey], [nextKey]) => {
+          if (currentKey < nextKey) {
+            return -1;
+          }
+
+          if (currentKey > nextKey) {
+            return 1;
+          }
+
+          return 0;
+        })
         .map(([key, nestedValue]) => [key, toCanonicalJsonValue(nestedValue)]),
     );
   }

--- a/packages/core/src/domain/device/device.ts
+++ b/packages/core/src/domain/device/device.ts
@@ -4,7 +4,7 @@ import type { VersionVector } from "../sync/version-vector.type";
 export type DeviceProfile = {
   id: string; // random
   name: string; // user given name
-  createdAt: Date;
+  createdAt: number;
   versionVector: VersionVector;
 };
 

--- a/packages/core/src/domain/sync/index.ts
+++ b/packages/core/src/domain/sync/index.ts
@@ -2,7 +2,6 @@ export * from "./remote-vault-snapshot-descriptor.type";
 export * from "./sync-config.type";
 export * from "./version-vector.type";
 export * from "./version-vector.utils";
-export * from "./vault-snapshot-version.type";
 export * from "./vault-snapshot-version.utils";
 export * from "./vault-sync-review.type";
 export * from "./vault-sync-review.utils";

--- a/packages/core/src/domain/sync/vault-snapshot-version.type.ts
+++ b/packages/core/src/domain/sync/vault-snapshot-version.type.ts
@@ -1,5 +1,0 @@
-export type LocalRemoteSnapshotVersionRelation =
-  | "equal"
-  | "local_ahead"
-  | "remote_ahead"
-  | "diverged";

--- a/packages/core/src/domain/sync/vault-snapshot-version.utils.ts
+++ b/packages/core/src/domain/sync/vault-snapshot-version.utils.ts
@@ -2,12 +2,12 @@ import type { RemoteVaultSnapshotDescriptor } from "./remote-vault-snapshot-desc
 import type { VaultSnapshot } from "../snapshot/vault-snapshot";
 import type { Vault } from "../vault/vault";
 import { compareVersionVectors } from "./version-vector.utils";
-import type { LocalRemoteSnapshotVersionRelation } from "./vault-snapshot-version.type";
+import type { VersionVectorRelation } from "./version-vector.type";
 
 export function compareLocalAndRemoteSnapshotDescriptors(
   local: RemoteVaultSnapshotDescriptor,
   remote: RemoteVaultSnapshotDescriptor,
-): LocalRemoteSnapshotVersionRelation {
+): VersionVectorRelation {
   return compareVersionVectors(local.versionVector, remote.versionVector);
 }
 

--- a/packages/core/src/domain/sync/vault-sync-review.utils.test.ts
+++ b/packages/core/src/domain/sync/vault-sync-review.utils.test.ts
@@ -43,7 +43,7 @@ function createDeviceProfile(
   return {
     id,
     name,
-    createdAt: new Date(1),
+    createdAt: 1,
     versionVector,
   };
 }

--- a/packages/core/src/domain/vault/index.ts
+++ b/packages/core/src/domain/vault/index.ts
@@ -2,4 +2,5 @@ export * from "./local-vault-descriptor";
 export * from "./unlocked-vault";
 export * from "./unlocked-vault-session";
 export * from "./vault";
+export * from "./vault-entry.errors";
 export * from "./vault-entry-mutations.utils";

--- a/packages/core/src/domain/vault/vault-entry-mutations.utils.test.ts
+++ b/packages/core/src/domain/vault/vault-entry-mutations.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Vault } from "./vault";
+import { DuplicateVaultEntryError } from "./vault-entry.errors";
 import {
   addPasswordEntryToVault,
   removePasswordEntryFromVault,
@@ -71,7 +72,7 @@ describe("vault entry mutation utils", () => {
         },
         "A",
       ),
-    ).toThrow('Entry "entry-id" already exists.');
+    ).toThrow(DuplicateVaultEntryError);
   });
 
   it("updates an entry and increments vault and entry vectors for the device", () => {

--- a/packages/core/src/domain/vault/vault-entry-mutations.utils.test.ts
+++ b/packages/core/src/domain/vault/vault-entry-mutations.utils.test.ts
@@ -60,7 +60,8 @@ describe("vault entry mutation utils", () => {
   });
 
   it("rejects adding an active entry with an existing id", () => {
-    expect(() =>
+    expect.assertions(2);
+    try {
       addPasswordEntryToVault(
         createVault(),
         "entry-id",
@@ -71,8 +72,11 @@ describe("vault entry mutation utils", () => {
           tags: [],
         },
         "A",
-      ),
-    ).toThrow(DuplicateVaultEntryError);
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateVaultEntryError);
+      expect((error as DuplicateVaultEntryError).entryId).toBe("entry-id");
+    }
   });
 
   it("updates an entry and increments vault and entry vectors for the device", () => {

--- a/packages/core/src/domain/vault/vault-entry-mutations.utils.ts
+++ b/packages/core/src/domain/vault/vault-entry-mutations.utils.ts
@@ -4,6 +4,7 @@ import type {
 } from "../entry/password-entry.type";
 import { incrementVersionVector } from "../sync/version-vector.utils";
 import type { Vault } from "./vault";
+import { DuplicateVaultEntryError } from "./vault-entry.errors";
 
 export function addPasswordEntryToVault(
   vault: Vault,
@@ -12,7 +13,7 @@ export function addPasswordEntryToVault(
   deviceId: string,
 ): Vault {
   if (vault.entries.some((entry) => entry.id === entryId)) {
-    throw new Error(`Entry "${entryId}" already exists.`);
+    throw new DuplicateVaultEntryError(entryId);
   }
 
   const versionVector = incrementVersionVector(vault.versionVector, deviceId);

--- a/packages/core/src/domain/vault/vault-entry.errors.ts
+++ b/packages/core/src/domain/vault/vault-entry.errors.ts
@@ -1,0 +1,10 @@
+export class DuplicateVaultEntryError extends Error {
+  public readonly entryId: string;
+
+  constructor(entryId: string) {
+    super(`Entry "${entryId}" already exists.`);
+    this.name = "DuplicateVaultEntryError";
+    this.entryId = entryId;
+    Object.setPrototypeOf(this, DuplicateVaultEntryError.prototype);
+  }
+}

--- a/packages/core/src/use-cases/sync/sync-download.ts
+++ b/packages/core/src/use-cases/sync/sync-download.ts
@@ -3,7 +3,7 @@ import {
   areRemoteVaultSnapshotDescriptorsEqual,
   compareLocalAndRemoteSnapshotDescriptors,
 } from "../../domain/sync/vault-snapshot-version.utils";
-import type { LocalRemoteSnapshotVersionRelation } from "../../domain/sync/vault-snapshot-version.type";
+import type { VersionVectorRelation } from "../../domain/sync/version-vector.type";
 import { createVaultSyncReview } from "../../domain/sync/vault-sync-review.utils";
 import type { VaultSyncReview } from "../../domain/sync/vault-sync-review.type";
 import type { RemoteVaultSnapshotDescriptor } from "../../domain/sync/remote-vault-snapshot-descriptor.type";
@@ -28,7 +28,7 @@ export type SyncDownloadCommandParams = {
 
 export type SyncDownloadResult = {
   readonly remoteSnapshotDescriptor: RemoteVaultSnapshotDescriptor;
-  readonly relation: LocalRemoteSnapshotVersionRelation;
+  readonly relation: VersionVectorRelation;
   readonly review: VaultSyncReview;
 };
 

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -72,7 +72,7 @@ describe("InitializeVaultUseCase", () => {
         {
           id: ctx.values.deviceId,
           name: "Work laptop",
-          createdAt: new Date(ctx.values.timestamp),
+          createdAt: ctx.values.timestamp,
           versionVector: {
             [ctx.values.deviceId]: 1,
           },

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -120,7 +120,7 @@ export class InitializeVaultUseCase {
     const deviceProfile: DeviceProfile = {
       id: deviceId,
       name: initializeVaultCommandParams.deviceName,
-      createdAt: new Date(timestamp),
+      createdAt: timestamp,
       versionVector: {
         [deviceId]: 1,
       },


### PR DESCRIPTION
- use VersionVectorRelation directly for snapshot comparisons
- make canonical JSON key ordering locale-independent
- store device profile creation time as a numeric timestamp
- add DuplicateVaultEntryError for duplicate entry mutations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added dedicated error handling for duplicate vault entry creation.

* **Refactor**
  * Improved device profile timestamp storage.
  * Consolidated sync version relation types for consistency.
  * Enhanced JSON canonicalization for object key ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->