### PR TITLE
fix(core): guard stale snapshot persistence

### DIFF
--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -1,5 +1,7 @@
 import { vi } from "vitest";
+import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
 import type { PasswordEntry } from "../../domain/entry/password-entry.type";
+import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { Tag } from "../../domain/entry/tag.type";
 import type { UnlockedVault } from "../../domain/vault/unlocked-vault";
 import type { UnlockedVaultSession } from "../../domain/vault/unlocked-vault-session";
@@ -109,8 +111,44 @@ export function saveUnlockedVaultWithEntries(
 export function createVaultSnapshotServiceMock(
   values: CoreTestValues,
 ): VaultSnapshotService {
+  const currentVaultSnapshot: VaultSnapshot = {
+    metadata: {
+      id: values.vaultId,
+      schemaVersion: 1,
+      vaultCreationTimestamp: values.timestamp - 1_000,
+      revisionTimestamp: values.timestamp,
+      revision: 1,
+      algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
+      createdByDeviceId: values.deviceId,
+    },
+    trustedDevices: [
+      {
+        id: values.deviceId,
+        publicKeys: {
+          signingKey: values.devicePublicSignKey,
+        },
+      },
+    ],
+    keySlots: {
+      deviceSlots: [
+        {
+          deviceId: values.deviceId,
+          protectedVaultMasterKey: values.protectedDeviceVaultMasterKey,
+        },
+      ],
+      recoveryKeySlot: {
+        protectedVaultMasterKey: values.protectedRecoveryVaultMasterKey,
+      },
+    },
+    content: values.encryptedVault,
+    signature: values.snapshotSignature,
+  };
+
   return {
     assertCanPersistUnlockedVault: vi.fn(async () => undefined),
+    getCurrentVaultSnapshotForUnlockedMutation: vi.fn(
+      async () => currentVaultSnapshot,
+    ),
     persistUnlockedVault: vi.fn(async () => ({
       revision: 2,
       revisionTimestamp: values.timestamp + 1,

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -110,6 +110,7 @@ export function createVaultSnapshotServiceMock(
   values: CoreTestValues,
 ): VaultSnapshotService {
   return {
+    assertCanPersistUnlockedVault: vi.fn(async () => undefined),
     persistUnlockedVault: vi.fn(async () => ({
       revision: 2,
       revisionTimestamp: values.timestamp + 1,

--- a/packages/core/src/application/errors/vault-snapshot.errors.ts
+++ b/packages/core/src/application/errors/vault-snapshot.errors.ts
@@ -6,3 +6,16 @@ export class PersistedVaultMismatchError extends Error {
     this.name = "PersistedVaultMismatchError";
   }
 }
+
+export class VaultSnapshotRevisionMismatchError extends Error {
+  constructor(params: {
+    readonly vaultId: string;
+    readonly expectedRevision: number;
+    readonly actualRevision: number;
+  }) {
+    super(
+      `Vault "${params.vaultId}" local snapshot revision ${params.actualRevision} does not match unlocked session revision ${params.expectedRevision}.`,
+    );
+    this.name = "VaultSnapshotRevisionMismatchError";
+  }
+}

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
@@ -124,6 +124,24 @@ describe("VaultSnapshotService", () => {
     });
   });
 
+  it("returns the current snapshot for an unlocked mutation without saving", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.service.getCurrentVaultSnapshotForUnlockedMutation(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
+    ).resolves.toBe(ctx.currentSnapshot);
+
+    expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
   it("preflights unlocked vault persistence without saving a snapshot", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
@@ -13,7 +13,10 @@ import {
   VaultSnapshotNotFoundError,
   VaultSnapshotSignerNotTrustedError,
 } from "../errors/unlock-vault.errors";
-import { PersistedVaultMismatchError } from "../errors/vault-snapshot.errors";
+import {
+  PersistedVaultMismatchError,
+  VaultSnapshotRevisionMismatchError,
+} from "../errors/vault-snapshot.errors";
 import { VaultSnapshotService } from "./vault-snapshot.service";
 
 describe("VaultSnapshotService", () => {
@@ -81,6 +84,7 @@ describe("VaultSnapshotService", () => {
     const result = await ctx.service.persistUnlockedVault(
       ctx.values.vaultId,
       ctx.unlockedVault,
+      ctx.currentSnapshot.metadata.revision,
     );
 
     expect(result).toEqual({
@@ -120,11 +124,31 @@ describe("VaultSnapshotService", () => {
     });
   });
 
+  it("preflights unlocked vault persistence without saving a snapshot", async () => {
+    const ctx = createContext();
+
+    await ctx.service.assertCanPersistUnlockedVault(
+      ctx.values.vaultId,
+      ctx.unlockedVault,
+      ctx.currentSnapshot.metadata.revision,
+    );
+
+    expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
   it("fails when the unlocked vault belongs to another vault", async () => {
     const ctx = createContext();
 
     await expect(
-      ctx.service.persistUnlockedVault("another-vault-id", ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        "another-vault-id",
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(PersistedVaultMismatchError);
 
     expect(
@@ -140,8 +164,29 @@ describe("VaultSnapshotService", () => {
     ctx.saved.vaultSnapshot = undefined;
 
     await expect(
-      ctx.service.persistUnlockedVault(ctx.values.vaultId, ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(VaultSnapshotNotFoundError);
+
+    expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("fails when the current local snapshot revision does not match the session source revision", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision - 1,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRevisionMismatchError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
@@ -160,7 +205,11 @@ describe("VaultSnapshotService", () => {
     };
 
     await expect(
-      ctx.service.persistUnlockedVault(ctx.values.vaultId, ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(UnsupportedAlgorithmSuiteError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
@@ -177,7 +226,11 @@ describe("VaultSnapshotService", () => {
     };
 
     await expect(
-      ctx.service.persistUnlockedVault(ctx.values.vaultId, ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(VaultSnapshotSignerNotTrustedError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
@@ -195,7 +248,11 @@ describe("VaultSnapshotService", () => {
     ).mockRejectedValueOnce(error);
 
     await expect(
-      ctx.service.persistUnlockedVault(ctx.values.vaultId, ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(error);
 
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
@@ -211,7 +268,11 @@ describe("VaultSnapshotService", () => {
     vi.mocked(ctx.ports.crypto.signVaultSnapshot).mockRejectedValueOnce(error);
 
     await expect(
-      ctx.service.persistUnlockedVault(ctx.values.vaultId, ctx.unlockedVault),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision,
+      ),
     ).rejects.toThrow(error);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).toHaveBeenCalledWith(

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
@@ -158,6 +158,24 @@ describe("VaultSnapshotService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("fails preflight when the current local snapshot revision does not match the session source revision", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.service.assertCanPersistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.currentSnapshot.metadata.revision - 1,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRevisionMismatchError);
+
+    expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
   it("fails when the unlocked vault belongs to another vault", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.test.ts
@@ -167,7 +167,7 @@ describe("VaultSnapshotService", () => {
         ctx.unlockedVault,
         ctx.currentSnapshot.metadata.revision - 1,
       ),
-    ).rejects.toBeInstanceOf(VaultSnapshotRevisionMismatchError);
+    ).rejects.toThrow(VaultSnapshotRevisionMismatchError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
@@ -222,7 +222,7 @@ describe("VaultSnapshotService", () => {
         ctx.unlockedVault,
         ctx.currentSnapshot.metadata.revision - 1,
       ),
-    ).rejects.toBeInstanceOf(VaultSnapshotRevisionMismatchError);
+    ).rejects.toThrow(VaultSnapshotRevisionMismatchError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.ts
@@ -11,7 +11,10 @@ import {
   VaultSnapshotNotFoundError,
   VaultSnapshotSignerNotTrustedError,
 } from "../errors/unlock-vault.errors";
-import { PersistedVaultMismatchError } from "../errors/vault-snapshot.errors";
+import {
+  PersistedVaultMismatchError,
+  VaultSnapshotRevisionMismatchError,
+} from "../errors/vault-snapshot.errors";
 
 export type PersistUnlockedVaultResult = {
   revision: number;
@@ -34,43 +37,28 @@ export class VaultSnapshotService {
     this.vaultLocalRepository = vaultLocalRepository;
   }
 
+  async assertCanPersistUnlockedVault(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotRevision: number,
+  ): Promise<void> {
+    await this.getCurrentVaultSnapshotForPersist(
+      vaultId,
+      unlockedVault,
+      sourceSnapshotRevision,
+    );
+  }
+
   async persistUnlockedVault(
     vaultId: string,
     unlockedVault: UnlockedVault,
+    sourceSnapshotRevision: number,
   ): Promise<PersistUnlockedVaultResult> {
-    if (unlockedVault.vaultId !== vaultId) {
-      throw new PersistedVaultMismatchError(vaultId, unlockedVault.vaultId);
-    }
-
-    const currentVaultSnapshot =
-      await this.vaultLocalRepository.getVaultSnapshot(vaultId);
-
-    if (currentVaultSnapshot === null) {
-      throw new VaultSnapshotNotFoundError(vaultId);
-    }
-
-    if (
-      currentVaultSnapshot.metadata.algorithmSuiteId !==
-      this.crypto.algorithmSuite.id
-    ) {
-      throw new UnsupportedAlgorithmSuiteError({
-        vaultId,
-        artifact: "vault snapshot",
-        expectedAlgorithmSuiteId: this.crypto.algorithmSuite.id,
-        actualAlgorithmSuiteId: currentVaultSnapshot.metadata.algorithmSuiteId,
-      });
-    }
-
-    const signerDevice = currentVaultSnapshot.trustedDevices.find(
-      (device) => device.id === unlockedVault.deviceId,
+    const currentVaultSnapshot = await this.getCurrentVaultSnapshotForPersist(
+      vaultId,
+      unlockedVault,
+      sourceSnapshotRevision,
     );
-
-    if (signerDevice === undefined) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        vaultId,
-        unlockedVault.deviceId,
-      );
-    }
 
     const revisionTimestamp = this.clock.now();
 
@@ -104,5 +92,55 @@ export class VaultSnapshotService {
       revisionTimestamp: vaultSnapshot.metadata.revisionTimestamp,
       deviceId: vaultSnapshot.metadata.createdByDeviceId,
     };
+  }
+
+  private async getCurrentVaultSnapshotForPersist(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotRevision: number,
+  ): Promise<VaultSnapshot> {
+    if (unlockedVault.vaultId !== vaultId) {
+      throw new PersistedVaultMismatchError(vaultId, unlockedVault.vaultId);
+    }
+
+    const currentVaultSnapshot =
+      await this.vaultLocalRepository.getVaultSnapshot(vaultId);
+
+    if (currentVaultSnapshot === null) {
+      throw new VaultSnapshotNotFoundError(vaultId);
+    }
+
+    if (currentVaultSnapshot.metadata.revision !== sourceSnapshotRevision) {
+      throw new VaultSnapshotRevisionMismatchError({
+        vaultId,
+        expectedRevision: sourceSnapshotRevision,
+        actualRevision: currentVaultSnapshot.metadata.revision,
+      });
+    }
+
+    if (
+      currentVaultSnapshot.metadata.algorithmSuiteId !==
+      this.crypto.algorithmSuite.id
+    ) {
+      throw new UnsupportedAlgorithmSuiteError({
+        vaultId,
+        artifact: "vault snapshot",
+        expectedAlgorithmSuiteId: this.crypto.algorithmSuite.id,
+        actualAlgorithmSuiteId: currentVaultSnapshot.metadata.algorithmSuiteId,
+      });
+    }
+
+    const signerDevice = currentVaultSnapshot.trustedDevices.find(
+      (device) => device.id === unlockedVault.deviceId,
+    );
+
+    if (signerDevice === undefined) {
+      throw new VaultSnapshotSignerNotTrustedError(
+        vaultId,
+        unlockedVault.deviceId,
+      );
+    }
+
+    return currentVaultSnapshot;
   }
 }

--- a/packages/core/src/application/vault-snapshots/vault-snapshot.service.ts
+++ b/packages/core/src/application/vault-snapshots/vault-snapshot.service.ts
@@ -42,7 +42,7 @@ export class VaultSnapshotService {
     unlockedVault: UnlockedVault,
     sourceSnapshotRevision: number,
   ): Promise<void> {
-    await this.getCurrentVaultSnapshotForPersist(
+    await this.getCurrentVaultSnapshotForUnlockedMutation(
       vaultId,
       unlockedVault,
       sourceSnapshotRevision,
@@ -54,11 +54,12 @@ export class VaultSnapshotService {
     unlockedVault: UnlockedVault,
     sourceSnapshotRevision: number,
   ): Promise<PersistUnlockedVaultResult> {
-    const currentVaultSnapshot = await this.getCurrentVaultSnapshotForPersist(
-      vaultId,
-      unlockedVault,
-      sourceSnapshotRevision,
-    );
+    const currentVaultSnapshot =
+      await this.getCurrentVaultSnapshotForUnlockedMutation(
+        vaultId,
+        unlockedVault,
+        sourceSnapshotRevision,
+      );
 
     const revisionTimestamp = this.clock.now();
 
@@ -94,7 +95,7 @@ export class VaultSnapshotService {
     };
   }
 
-  private async getCurrentVaultSnapshotForPersist(
+  async getCurrentVaultSnapshotForUnlockedMutation(
     vaultId: string,
     unlockedVault: UnlockedVault,
     sourceSnapshotRevision: number,

--- a/packages/core/src/ports/sync/sync-provider.port.ts
+++ b/packages/core/src/ports/sync/sync-provider.port.ts
@@ -3,6 +3,12 @@ import type { SyncConfig } from "../../domain/sync/sync-config.type";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 
 export interface SyncProviderPort {
+  /**
+   * Validates and normalizes user-provided sync credentials/configuration for
+   * encrypted vault storage. Implementations must not create, update, or delete
+   * remote vault state here; remote snapshot changes belong to upload/download/
+   * removal operations.
+   */
   setup: (syncConfig: SyncConfig) => Promise<SyncConfig>;
   getLatestVaultSnapshotDescriptor: (
     syncConfig: SyncConfig,

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../application/errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../application/errors/vault-session.errors";
 import { VaultSnapshotRevisionMismatchError } from "../../application/errors/vault-snapshot.errors";
+import { VaultSnapshotService } from "../../application/vault-snapshots/vault-snapshot.service";
 import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
 import type { DevicePublicSignKey } from "../../domain/device/brand-keys";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
@@ -104,6 +105,11 @@ function createVaultSnapshot(values: CoreTestValues): VaultSnapshot {
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
+  const snapshotService = new VaultSnapshotService(
+    ports.crypto,
+    ports.clock,
+    ports.vaultLocalRepository,
+  );
   const vault = createVault(values);
   const vaultSnapshot = createVaultSnapshot(values);
 
@@ -125,11 +131,13 @@ function createContext() {
     saved: ports.saved,
     vault,
     vaultSnapshot,
+    snapshotService,
     useCase: new RevokeDeviceUseCase(
       ports.clock,
       ports.crypto,
       ports.sessionServices.unlockedVaultSession,
       ports.vaultLocalRepository,
+      snapshotService,
     ),
   };
 }

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -442,6 +442,9 @@ describe("RevokeDeviceUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(VaultSnapshotSignerNotTrustedError);
 
+    expect(
+      ctx.ports.crypto.verifyVaultSnapshotSignature,
+    ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshot,

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -13,6 +13,7 @@ import {
   VaultSnapshotSignerNotTrustedError,
 } from "../../application/errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../application/errors/vault-session.errors";
+import { VaultSnapshotRevisionMismatchError } from "../../application/errors/vault-snapshot.errors";
 import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
 import type { DevicePublicSignKey } from "../../domain/device/brand-keys";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
@@ -305,6 +306,31 @@ describe("RevokeDeviceUseCase", () => {
         deviceId: revokedDeviceId,
       }),
     ).rejects.toBeInstanceOf(VaultSnapshotNotFoundError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultSnapshotSignature,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("fails when the local snapshot revision no longer matches the unlocked session", async () => {
+    const ctx = createContext();
+    ctx.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        revision: ctx.vaultSnapshot.metadata.revision + 1,
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        deviceId: revokedDeviceId,
+      }),
+    ).rejects.toBeInstanceOf(VaultSnapshotRevisionMismatchError);
 
     expect(
       ctx.ports.crypto.verifyVaultSnapshotSignature,

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -4,16 +4,14 @@ import type {
 } from "../../domain/snapshot/vault-snapshot";
 import type { Vault } from "../../domain/vault/vault";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device-mutations.utils";
-import { UnsupportedAlgorithmSuiteError } from "../../application/errors/algorithm-suite.errors";
 import {
   DeviceKeySlotNotFoundError,
-  VaultSnapshotNotFoundError,
   VaultSnapshotSignatureVerificationFailedError,
   VaultSnapshotSignerNotTrustedError,
 } from "../../application/errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../application/errors/vault-session.errors";
-import { VaultSnapshotRevisionMismatchError } from "../../application/errors/vault-snapshot.errors";
 import type { UnlockedVaultSessionService } from "../../application/vault-session/unlocked-vault-session.service";
+import type { VaultSnapshotService } from "../../application/vault-snapshots/vault-snapshot.service";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
@@ -40,17 +38,20 @@ export class RevokeDeviceUseCase {
   private readonly crypto: CryptoPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultSnapshot: VaultSnapshotService;
 
   constructor(
     clock: ClockPort,
     crypto: CryptoPort,
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultLocalRepository: VaultLocalRepositoryPort,
+    vaultSnapshot: VaultSnapshotService,
   ) {
     this.clock = clock;
     this.crypto = crypto;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultSnapshot = vaultSnapshot;
   }
 
   async execute(
@@ -76,31 +77,11 @@ export class RevokeDeviceUseCase {
     // Start from the current local snapshot and verify its provenance before
     // using its trust and key-slot state as the basis for the new snapshot.
     const currentVaultSnapshot =
-      await this.vaultLocalRepository.getVaultSnapshot(params.vaultId);
-
-    if (currentVaultSnapshot === null) {
-      throw new VaultSnapshotNotFoundError(params.vaultId);
-    }
-
-    if (currentVaultSnapshot.metadata.revision !== sourceSnapshotRevision) {
-      throw new VaultSnapshotRevisionMismatchError({
-        vaultId: params.vaultId,
-        expectedRevision: sourceSnapshotRevision,
-        actualRevision: currentVaultSnapshot.metadata.revision,
-      });
-    }
-
-    if (
-      currentVaultSnapshot.metadata.algorithmSuiteId !==
-      this.crypto.algorithmSuite.id
-    ) {
-      throw new UnsupportedAlgorithmSuiteError({
-        vaultId: params.vaultId,
-        artifact: "vault snapshot",
-        expectedAlgorithmSuiteId: this.crypto.algorithmSuite.id,
-        actualAlgorithmSuiteId: currentVaultSnapshot.metadata.algorithmSuiteId,
-      });
-    }
+      await this.vaultSnapshot.getCurrentVaultSnapshotForUnlockedMutation(
+        params.vaultId,
+        unlockedVault,
+        sourceSnapshotRevision,
+      );
 
     const signerDevice = currentVaultSnapshot.trustedDevices.find(
       (device) => device.id === currentVaultSnapshot.metadata.createdByDeviceId,
@@ -122,19 +103,8 @@ export class RevokeDeviceUseCase {
       throw new VaultSnapshotSignatureVerificationFailedError(params.vaultId);
     }
 
-    // The local unlocked device must still be trusted, and the target must
-    // exist in every trust surface we are about to remove it from.
-    const isCurrentDeviceTrusted = currentVaultSnapshot.trustedDevices.some(
-      (device) => device.id === unlockedVault.deviceId,
-    );
-
-    if (!isCurrentDeviceTrusted) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        params.vaultId,
-        unlockedVault.deviceId,
-      );
-    }
-
+    // The target must exist in every trust surface we are about to remove it
+    // from.
     const isRevokedDeviceTrusted = currentVaultSnapshot.trustedDevices.some(
       (device) => device.id === params.deviceId,
     );

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -12,6 +12,7 @@ import {
   VaultSnapshotSignerNotTrustedError,
 } from "../../application/errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../application/errors/vault-session.errors";
+import { VaultSnapshotRevisionMismatchError } from "../../application/errors/vault-snapshot.errors";
 import type { UnlockedVaultSessionService } from "../../application/vault-session/unlocked-vault-session.service";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
@@ -58,11 +59,15 @@ export class RevokeDeviceUseCase {
     // Revoke can only be performed by the currently unlocked vault, and a
     // device cannot revoke the local identity it is actively using.
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "revoke device");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     if (params.deviceId === unlockedVault.deviceId) {
       throw new CannotRevokeCurrentDeviceError(params.vaultId, params.deviceId);
@@ -75,6 +80,14 @@ export class RevokeDeviceUseCase {
 
     if (currentVaultSnapshot === null) {
       throw new VaultSnapshotNotFoundError(params.vaultId);
+    }
+
+    if (currentVaultSnapshot.metadata.revision !== sourceSnapshotRevision) {
+      throw new VaultSnapshotRevisionMismatchError({
+        vaultId: params.vaultId,
+        expectedRevision: sourceSnapshotRevision,
+        actualRevision: currentVaultSnapshot.metadata.revision,
+      });
     }
 
     if (

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../__tests__/fixtures/vault-entries";
 import { SyncNotConfiguredError } from "../../application/errors/sync.errors";
 import { VaultMustBeUnlockedError } from "../../application/errors/vault-session.errors";
+import { VaultSnapshotRevisionMismatchError } from "../../application/errors/vault-snapshot.errors";
 import { DisableSyncUseCase } from "./disable-sync";
 
 function createContext(syncConfigured = true) {
@@ -59,9 +60,27 @@ describe("DisableSyncUseCase", () => {
     const persistedUnlockedVault = vi.mocked(
       ctx.vaultSnapshot.persistUnlockedVault,
     ).mock.calls[0]?.[1];
+    const sourceSnapshotRevision = vi.mocked(
+      ctx.vaultSnapshot.persistUnlockedVault,
+    ).mock.calls[0]?.[2];
 
     expect(persistedUnlockedVault).toBeDefined();
     expect("syncConfig" in persistedUnlockedVault!.vault).toBe(false);
+    expect(sourceSnapshotRevision).toBe(1);
+    expect(
+      ctx.vaultSnapshot.assertCanPersistUnlockedVault,
+    ).toHaveBeenCalledWith(
+      ctx.values.vaultId,
+      persistedUnlockedVault,
+      sourceSnapshotRevision,
+    );
+    expect(
+      vi.mocked(ctx.vaultSnapshot.assertCanPersistUnlockedVault).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
+        .invocationCallOrder[0],
+    );
     expect(
       vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
         .invocationCallOrder[0],
@@ -103,6 +122,34 @@ describe("DisableSyncUseCase", () => {
 
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("does not remove remote snapshots when local snapshot preflight fails", async () => {
+    const ctx = createContext();
+    const error = new VaultSnapshotRevisionMismatchError({
+      vaultId: ctx.values.vaultId,
+      expectedRevision: 1,
+      actualRevision: 2,
+    });
+
+    vi.mocked(
+      ctx.vaultSnapshot.assertCanPersistUnlockedVault,
+    ).mockRejectedValueOnce(error);
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+      }),
+    ).rejects.toBe(error);
+
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commit,
+    ).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
+      ctx.values.syncConfig,
+    );
   });
 
   it("does not remove local sync config when remote removal fails", async () => {

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -25,19 +25,21 @@ export class DisableSyncUseCase {
 
   async execute(params: DisableSyncCommandParams): Promise<void> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "disable sync");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     const syncConfig = unlockedVault.vault.syncConfig;
 
     if (syncConfig === undefined) {
       throw new SyncNotConfiguredError(params.vaultId, "disable sync");
     }
-
-    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
 
     const updatedVault = {
       ...unlockedVault.vault,
@@ -50,9 +52,18 @@ export class DisableSyncUseCase {
       vault: updatedVault,
     };
 
+    await this.vaultSnapshot.assertCanPersistUnlockedVault(
+      params.vaultId,
+      updatedUnlockedVault,
+      sourceSnapshotRevision,
+    );
+
+    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
+
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/sync/remove-local-sync-credentials.test.ts
+++ b/packages/core/src/use-cases/sync/remove-local-sync-credentials.test.ts
@@ -54,6 +54,7 @@ describe("RemoveLocalSyncCredentialsUseCase", () => {
     expect(ctx.vaultSnapshot.persistUnlockedVault).toHaveBeenCalledWith(
       ctx.values.vaultId,
       expect.objectContaining({}),
+      1,
     );
     const persistedUnlockedVault = vi.mocked(
       ctx.vaultSnapshot.persistUnlockedVault,

--- a/packages/core/src/use-cases/sync/remove-local-sync-credentials.ts
+++ b/packages/core/src/use-cases/sync/remove-local-sync-credentials.ts
@@ -23,14 +23,18 @@ export class RemoveLocalSyncCredentialsUseCase {
     params: RemoveLocalSyncCredentialsCommandParams,
   ): Promise<void> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(
         params.vaultId,
         "remove local sync credentials",
       );
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     if (unlockedVault.vault.syncConfig === undefined) {
       throw new SyncNotConfiguredError(
@@ -53,6 +57,7 @@ export class RemoveLocalSyncCredentialsUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/sync/resolve-sync-conflict.test.ts
+++ b/packages/core/src/use-cases/sync/resolve-sync-conflict.test.ts
@@ -110,6 +110,7 @@ function createContext() {
     ports.clock,
     ports.vaultLocalRepository,
   );
+  const persistUnlockedVault = vi.spyOn(vaultSnapshot, "persistUnlockedVault");
   ports.saved.unlockedVaultSession = {
     unlockedVault: {
       ...createUnlockedVaultWithEntries(values, []),
@@ -124,6 +125,7 @@ function createContext() {
     ports,
     saved: ports.saved,
     localSnapshot,
+    persistUnlockedVault,
     useCase: new ResolveSyncConflictUseCase(
       ports.syncProvider,
       ports.sessionServices.unlockedVaultSession,
@@ -215,6 +217,18 @@ describe("ResolveSyncConflictUseCase", () => {
           },
         },
       ],
+    );
+    expect(ctx.persistUnlockedVault).toHaveBeenCalledWith(
+      ctx.values.vaultId,
+      expect.objectContaining({
+        vault: expect.objectContaining({
+          versionVector: {
+            [ctx.values.deviceId]: 4,
+            "remote-device-id": 1,
+          },
+        }),
+      }),
+      3,
     );
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.syncConfig,

--- a/packages/core/src/use-cases/sync/resolve-sync-conflict.ts
+++ b/packages/core/src/use-cases/sync/resolve-sync-conflict.ts
@@ -62,11 +62,15 @@ export class ResolveSyncConflictUseCase {
     params: ResolveSyncConflictCommandParams,
   ): Promise<ResolveSyncConflictResult> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "resolve sync");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     if (params.remoteSnapshotDescriptor.vaultId !== params.vaultId) {
       throw new InvalidSyncResolutionError(
@@ -163,6 +167,7 @@ export class ResolveSyncConflictUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/sync/setup-sync.test.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.test.ts
@@ -57,6 +57,7 @@ describe("SetupSyncUseCase", () => {
           syncConfig: ctx.values.syncConfig,
         }),
       }),
+      1,
     );
     expect(
       vi.mocked(ctx.ports.syncProvider.setup).mock.invocationCallOrder[0],

--- a/packages/core/src/use-cases/sync/setup-sync.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.ts
@@ -27,11 +27,15 @@ export class SetupSyncUseCase {
 
   async execute(params: SetupSyncCommandParams): Promise<void> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "setup sync");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     let syncConfig: SyncConfig;
 
@@ -52,6 +56,7 @@ export class SetupSyncUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -79,6 +79,7 @@ describe("AddEntryUseCase", () => {
           entries: ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries,
         }),
       }),
+      1,
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock

--- a/packages/core/src/use-cases/vault-entries/add-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.ts
@@ -41,11 +41,15 @@ export class AddEntryUseCase {
 
   async execute(params: AddEntryCommandParams): Promise<AddEntryResult> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "add entry");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     let sanitizedUrl: string;
 
@@ -81,6 +85,7 @@ export class AddEntryUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
@@ -57,6 +57,7 @@ describe("RemoveEntryUseCase", () => {
           entries: ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries,
         }),
       }),
+      1,
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock

--- a/packages/core/src/use-cases/vault-entries/remove-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.ts
@@ -34,11 +34,15 @@ export class RemoveEntryUseCase {
 
   async execute(params: RemoveEntryCommandParams): Promise<RemoveEntryResult> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "remove entry");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     const entryExists = unlockedVault.vault.entries.some(
       (entry) => entry.id === params.entryId,
@@ -61,6 +65,7 @@ export class RemoveEntryUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -82,6 +82,7 @@ describe("UpdateEntryUseCase", () => {
           entries: ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries,
         }),
       }),
+      1,
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock

--- a/packages/core/src/use-cases/vault-entries/update-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.ts
@@ -41,11 +41,15 @@ export class UpdateEntryUseCase {
 
   async execute(params: UpdateEntryCommandParams): Promise<UpdateEntryResult> {
     const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (
+      unlockedVaultSession === null ||
+      unlockedVaultSession.unlockedVault.vaultId !== params.vaultId
+    ) {
       throw new VaultMustBeUnlockedError(params.vaultId, "update entry");
     }
+
+    const { sourceSnapshotRevision, unlockedVault } = unlockedVaultSession;
 
     const entryIndex = unlockedVault.vault.entries.findIndex(
       (entry) => entry.id === params.entryId,
@@ -87,6 +91,7 @@ export class UpdateEntryUseCase {
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
+      sourceSnapshotRevision,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vault snapshot revision validation to detect when local snapshots conflict with unlocked session state, preventing data loss from concurrent modifications.

* **Bug Fixes**
  * Enhanced unlocked session validation across vault mutation operations for improved error handling and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->