### PR TITLE
feat(core): protect vault trust chain from rollback

### DIFF
--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
   DevicePrivateSignKey,
+  DevicePublicSignKey,
   UnlockedVaultSessionPayloadKey,
   VaultMasterKey,
 } from "@lfspm/core";
@@ -57,6 +58,26 @@ function createMaterial() {
     vaultMasterKey: arrayBuffer(1, 2, 3) as VaultMasterKey,
     devicePrivateSignKey: arrayBuffer(4, 5, 6) as DevicePrivateSignKey,
     payloadKey: arrayBuffer(7, 8, 9) as UnlockedVaultSessionPayloadKey,
+    trustedSnapshotContext: {
+      snapshotDigest: "snapshot-digest",
+      trust: {
+        generation: 2,
+        certificateDigest: "certificate-digest",
+        trustedDevices: [
+          {
+            deviceId: "device-id",
+            publicSignKey: arrayBuffer(10, 11, 12) as DevicePublicSignKey,
+          },
+        ],
+      },
+    },
+    vaultTrustAnchor: {
+      version: 1 as const,
+      vaultId: "vault-id",
+      genesisDeviceId: "device-id",
+      genesisPublicSignKey: arrayBuffer(13, 14, 15) as DevicePublicSignKey,
+      genesisCertificateDigest: "genesis-certificate-digest",
+    },
   };
 }
 
@@ -79,6 +100,26 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
       vaultMasterKey: "AQID",
       devicePrivateSignKey: "BAUG",
       payloadKey: "BwgJ",
+      trustedSnapshotContext: {
+        snapshotDigest: "snapshot-digest",
+        trust: {
+          generation: 2,
+          certificateDigest: "certificate-digest",
+          trustedDevices: [
+            {
+              deviceId: "device-id",
+              publicSignKey: "CgsM",
+            },
+          ],
+        },
+      },
+      vaultTrustAnchor: {
+        version: 1,
+        vaultId: "vault-id",
+        genesisDeviceId: "device-id",
+        genesisPublicSignKey: "DQ4P",
+        genesisCertificateDigest: "genesis-certificate-digest",
+      },
     });
   });
 
@@ -94,6 +135,26 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
         vaultMasterKey: "AQID",
         devicePrivateSignKey: "BAUG",
         payloadKey: "BwgJ",
+        trustedSnapshotContext: {
+          snapshotDigest: "snapshot-digest",
+          trust: {
+            generation: 2,
+            certificateDigest: "certificate-digest",
+            trustedDevices: [
+              {
+                deviceId: "device-id",
+                publicSignKey: "CgsM",
+              },
+            ],
+          },
+        },
+        vaultTrustAnchor: {
+          version: 1,
+          vaultId: "vault-id",
+          genesisDeviceId: "device-id",
+          genesisPublicSignKey: "DQ4P",
+          genesisCertificateDigest: "genesis-certificate-digest",
+        },
       },
     });
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
@@ -1,9 +1,6 @@
 import type {
-  DevicePrivateSignKey,
+  UnlockedVaultSessionMaterial,
   UnlockedVaultSessionMaterialRepositoryPort,
-  UnlockedVaultSessionPayloadKey,
-  VersionVector,
-  VaultMasterKey,
 } from "@lfspm/core";
 import {
   deserializeUnlockedVaultSessionMaterial,
@@ -32,29 +29,15 @@ export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVau
     this.storageKey = storageKey;
   }
 
-  async saveUnlockedVaultSessionMaterial(material: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: VaultMasterKey;
-    readonly devicePrivateSignKey: DevicePrivateSignKey;
-    readonly payloadKey: UnlockedVaultSessionPayloadKey;
-  }): Promise<void> {
+  async saveUnlockedVaultSessionMaterial(
+    material: UnlockedVaultSessionMaterial,
+  ): Promise<void> {
     await this.storageArea.set({
       [this.storageKey]: serializeUnlockedVaultSessionMaterial(material),
     });
   }
 
-  async getUnlockedVaultSessionMaterial(): Promise<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: VaultMasterKey;
-    readonly devicePrivateSignKey: DevicePrivateSignKey;
-    readonly payloadKey: UnlockedVaultSessionPayloadKey;
-  } | null> {
+  async getUnlockedVaultSessionMaterial(): Promise<UnlockedVaultSessionMaterial | null> {
     const storedRecords = await this.storageArea.get(this.storageKey);
     const material = storedRecords[this.storageKey];
 

--- a/apps/extension/src/adapters/storage/indexeddb-encrypted-unlocked-vault-session-payload.repository.test.ts
+++ b/apps/extension/src/adapters/storage/indexeddb-encrypted-unlocked-vault-session-payload.repository.test.ts
@@ -1,6 +1,9 @@
 import "fake-indexeddb/auto";
 import { afterEach, describe, expect, it } from "vitest";
-import type { VersionVector } from "@lfspm/core";
+import type {
+  EncryptedUnlockedVaultSessionPayload,
+  VersionVector,
+} from "@lfspm/core";
 import type { Base64URLString } from "@lfspm/core/lib";
 import {
   ACTIVE_UNLOCKED_VAULT_SESSION_PAYLOAD_ID,
@@ -88,7 +91,9 @@ describe("IndexedDbEncryptedUnlockedVaultSessionPayloadRepository", () => {
   });
 });
 
-function createPayload(sourceSnapshotVersionVector: VersionVector) {
+function createPayload(
+  sourceSnapshotVersionVector: VersionVector,
+): EncryptedUnlockedVaultSessionPayload {
   const versionLabel = Object.entries(sourceSnapshotVersionVector)
     .map(([deviceId, version]) => `${deviceId}-${version}`)
     .join("-");

--- a/apps/extension/src/adapters/storage/indexeddb-encrypted-unlocked-vault-session-payload.repository.ts
+++ b/apps/extension/src/adapters/storage/indexeddb-encrypted-unlocked-vault-session-payload.repository.ts
@@ -1,8 +1,6 @@
 import type {
+  EncryptedUnlockedVaultSessionPayload,
   EncryptedUnlockedVaultSessionPayloadRepositoryPort,
-  SerializedEncrypted,
-  VersionVector,
-  Vault,
 } from "@lfspm/core";
 import {
   ACTIVE_UNLOCKED_VAULT_SESSION_PAYLOAD_ID,
@@ -17,28 +15,16 @@ export class IndexedDbEncryptedUnlockedVaultSessionPayloadRepository implements 
     this.database = database;
   }
 
-  async saveEncryptedUnlockedVaultSessionPayload(encryptedPayload: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: SerializedEncrypted<{
-      readonly vault: Vault;
-    }>;
-  }): Promise<void> {
+  async saveEncryptedUnlockedVaultSessionPayload(
+    encryptedPayload: EncryptedUnlockedVaultSessionPayload,
+  ): Promise<void> {
     await this.database.encryptedUnlockedVaultSessionPayloads.put({
       id: ACTIVE_UNLOCKED_VAULT_SESSION_PAYLOAD_ID,
       ...encryptedPayload,
     });
   }
 
-  async getEncryptedUnlockedVaultSessionPayload(): Promise<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: SerializedEncrypted<{
-      readonly vault: Vault;
-    }>;
-  } | null> {
+  async getEncryptedUnlockedVaultSessionPayload(): Promise<EncryptedUnlockedVaultSessionPayload | null> {
     const record =
       await this.database.encryptedUnlockedVaultSessionPayloads.get(
         ACTIVE_UNLOCKED_VAULT_SESSION_PAYLOAD_ID,

--- a/apps/extension/src/adapters/storage/unlocked-vault-session-material.codec.ts
+++ b/apps/extension/src/adapters/storage/unlocked-vault-session-material.codec.ts
@@ -4,13 +4,12 @@ import {
   type Base64URLString,
 } from "@lfspm/core/lib";
 import type {
-  DevicePrivateSignKey,
-  UnlockedVaultSessionPayloadKey,
-  VaultMasterKey,
+  DevicePublicSignKey,
+  UnlockedVaultSessionMaterial,
   VersionVector,
 } from "@lfspm/core";
 
-export type StoredUnlockedVaultSessionMaterial = {
+type StoredUnlockedVaultSessionMaterial = {
   sessionId: string;
   vaultId: string;
   sourceSnapshotVersionVector: VersionVector;
@@ -18,17 +17,29 @@ export type StoredUnlockedVaultSessionMaterial = {
   vaultMasterKey: Base64URLString;
   devicePrivateSignKey: Base64URLString;
   payloadKey: Base64URLString;
+  trustedSnapshotContext: {
+    snapshotDigest: string;
+    trust: {
+      generation: number;
+      certificateDigest: string;
+      trustedDevices: {
+        deviceId: string;
+        publicSignKey: Base64URLString;
+      }[];
+    };
+  };
+  vaultTrustAnchor: {
+    version: 1;
+    vaultId: string;
+    genesisDeviceId: string;
+    genesisPublicSignKey: Base64URLString;
+    genesisCertificateDigest: string;
+  };
 };
 
-export function serializeUnlockedVaultSessionMaterial(material: {
-  readonly sessionId: string;
-  readonly vaultId: string;
-  readonly sourceSnapshotVersionVector: VersionVector;
-  readonly deviceId: string;
-  readonly vaultMasterKey: VaultMasterKey;
-  readonly devicePrivateSignKey: DevicePrivateSignKey;
-  readonly payloadKey: UnlockedVaultSessionPayloadKey;
-}): StoredUnlockedVaultSessionMaterial {
+export function serializeUnlockedVaultSessionMaterial(
+  material: UnlockedVaultSessionMaterial,
+): StoredUnlockedVaultSessionMaterial {
   return {
     sessionId: material.sessionId,
     vaultId: material.vaultId,
@@ -37,18 +48,33 @@ export function serializeUnlockedVaultSessionMaterial(material: {
     vaultMasterKey: arrayBufferToBase64Url(material.vaultMasterKey),
     devicePrivateSignKey: arrayBufferToBase64Url(material.devicePrivateSignKey),
     payloadKey: arrayBufferToBase64Url(material.payloadKey),
+    trustedSnapshotContext: {
+      snapshotDigest: material.trustedSnapshotContext.snapshotDigest,
+      trust: {
+        generation: material.trustedSnapshotContext.trust.generation,
+        certificateDigest:
+          material.trustedSnapshotContext.trust.certificateDigest,
+        trustedDevices:
+          material.trustedSnapshotContext.trust.trustedDevices.map(
+            (device) => ({
+              deviceId: device.deviceId,
+              publicSignKey: arrayBufferToBase64Url(device.publicSignKey),
+            }),
+          ),
+      },
+    },
+    vaultTrustAnchor: {
+      ...material.vaultTrustAnchor,
+      genesisPublicSignKey: arrayBufferToBase64Url(
+        material.vaultTrustAnchor.genesisPublicSignKey,
+      ),
+    },
   };
 }
 
-export function deserializeUnlockedVaultSessionMaterial(material: unknown): {
-  readonly sessionId: string;
-  readonly vaultId: string;
-  readonly sourceSnapshotVersionVector: VersionVector;
-  readonly deviceId: string;
-  readonly vaultMasterKey: VaultMasterKey;
-  readonly devicePrivateSignKey: DevicePrivateSignKey;
-  readonly payloadKey: UnlockedVaultSessionPayloadKey;
-} {
+export function deserializeUnlockedVaultSessionMaterial(
+  material: unknown,
+): UnlockedVaultSessionMaterial {
   assertStoredMaterial(material);
 
   return {
@@ -58,13 +84,34 @@ export function deserializeUnlockedVaultSessionMaterial(material: unknown): {
     deviceId: material.deviceId,
     vaultMasterKey: base64UrlToArrayBuffer(
       material.vaultMasterKey,
-    ) as VaultMasterKey,
+    ) as UnlockedVaultSessionMaterial["vaultMasterKey"],
     devicePrivateSignKey: base64UrlToArrayBuffer(
       material.devicePrivateSignKey,
-    ) as DevicePrivateSignKey,
+    ) as UnlockedVaultSessionMaterial["devicePrivateSignKey"],
     payloadKey: base64UrlToArrayBuffer(
       material.payloadKey,
-    ) as UnlockedVaultSessionPayloadKey,
+    ) as UnlockedVaultSessionMaterial["payloadKey"],
+    trustedSnapshotContext: {
+      ...material.trustedSnapshotContext,
+      trust: {
+        ...material.trustedSnapshotContext.trust,
+        trustedDevices:
+          material.trustedSnapshotContext.trust.trustedDevices.map(
+            (device) => ({
+              deviceId: device.deviceId,
+              publicSignKey: base64UrlToArrayBuffer(
+                device.publicSignKey,
+              ) as DevicePublicSignKey,
+            }),
+          ),
+      },
+    },
+    vaultTrustAnchor: {
+      ...material.vaultTrustAnchor,
+      genesisPublicSignKey: base64UrlToArrayBuffer(
+        material.vaultTrustAnchor.genesisPublicSignKey,
+      ) as DevicePublicSignKey,
+    },
   };
 }
 
@@ -91,6 +138,52 @@ function assertStoredMaterial(
   assertStringField(material, "vaultMasterKey");
   assertStringField(material, "devicePrivateSignKey");
   assertStringField(material, "payloadKey");
+  assertTrustedSnapshotContext(material.trustedSnapshotContext);
+  assertVaultTrustAnchor(material.vaultTrustAnchor);
+}
+
+function assertTrustedSnapshotContext(
+  value: unknown,
+): asserts value is StoredUnlockedVaultSessionMaterial["trustedSnapshotContext"] {
+  if (!isRecord(value)) {
+    throw malformedField("trustedSnapshotContext");
+  }
+
+  assertStringField(value, "snapshotDigest");
+  const trust = value.trust;
+
+  if (!isRecord(trust)) {
+    throw malformedField("trustedSnapshotContext.trust");
+  }
+
+  assertNumberField(trust, "generation");
+  assertStringField(trust, "certificateDigest");
+
+  if (!Array.isArray(trust.trustedDevices)) {
+    throw malformedField("trustedSnapshotContext.trust.trustedDevices");
+  }
+
+  for (const device of trust.trustedDevices) {
+    if (!isRecord(device)) {
+      throw malformedField("trustedSnapshotContext.trust.trustedDevices");
+    }
+
+    assertStringField(device, "deviceId");
+    assertStringField(device, "publicSignKey");
+  }
+}
+
+function assertVaultTrustAnchor(
+  value: unknown,
+): asserts value is StoredUnlockedVaultSessionMaterial["vaultTrustAnchor"] {
+  if (!isRecord(value) || value.version !== 1) {
+    throw malformedField("vaultTrustAnchor");
+  }
+
+  assertStringField(value, "vaultId");
+  assertStringField(value, "genesisDeviceId");
+  assertStringField(value, "genesisPublicSignKey");
+  assertStringField(value, "genesisCertificateDigest");
 }
 
 function assertStringField(
@@ -102,6 +195,21 @@ function assertStringField(
       `Unlocked vault session material field "${fieldName}" is malformed.`,
     );
   }
+}
+
+function assertNumberField(
+  record: Record<string, unknown>,
+  fieldName: string,
+): void {
+  if (typeof record[fieldName] !== "number") {
+    throw malformedField(fieldName);
+  }
+}
+
+function malformedField(fieldName: string): Error {
+  return new Error(
+    `Unlocked vault session material field "${fieldName}" is malformed.`,
+  );
 }
 
 function assertVersionVectorField(

--- a/docs/report/5_tmp_findings.md.md
+++ b/docs/report/5_tmp_findings.md.md
@@ -1,0 +1,52 @@
+# Report nr 5
+
+## Purpose
+
+This report records current security design decisions made while implementing and reviewing the project. It supplements the earlier reports; it does not replace their original system-design or threat-model content.
+
+Each decision records the problem being addressed, the implemented control, the security property it provides, and any remaining limitation. Additional decisions can be added to this report as the review and implementation continue.
+
+## 1. Snapshot Trust and Local Rollback Protection
+
+### 1.1 Problem
+
+The encrypted vault snapshot, its device list, and the local database are attacker-controlled persisted data. A valid snapshot signature alone proves that a key signed the snapshot; it does not prove that the signing key was already trusted, nor that the snapshot is the latest state accepted by this device.
+
+Without an independent trust anchor, an attacker could construct a snapshot with an attacker-controlled device key, list that key as trusted, and sign the snapshot with it. An attacker who can restore persisted data could also replay an older valid snapshot and thereby restore removed vault content or a revoked device.
+
+### 1.2 Implemented decision
+
+The core uses three linked records:
+
+1. **Local genesis anchor** — created with the first vault state and protected as local device access material. It identifies the vault, the genesis device public signing key, and the digest of the exact first trust certificate.
+2. **Signed vault trust chain** — every device-trust change creates a certificate signed by a device trusted by the preceding certificate. Each certificate links to the digest of the preceding certificate.
+3. **Signed local checkpoint** — after accepting a snapshot, the device records its vault id, device id, accepted trust-chain position, snapshot version vector, and exact snapshot digest. The current device signs this record.
+
+When unlocking, recovering access, enrolling a device, or accepting a synced snapshot, the implementation verifies the trust chain from the protected genesis anchor before using its trusted device list to verify the snapshot signature. It then compares the candidate snapshot and its trust-chain history to the signed local checkpoint.
+
+The snapshot and checkpoint are persisted through one repository operation with an expected previous snapshot digest. An adapter must make that operation atomic: it must not leave a new snapshot with an old checkpoint, or the reverse, after an interruption.
+
+### 1.3 What this resolves
+
+- A snapshot cannot establish its own trusted signing key. Its signer must be present in a trust state verified from the protected genesis anchor.
+- An altered or fabricated trust chain is rejected unless it starts with the exact anchored genesis certificate and every later transition is signed by a device trusted immediately before that transition.
+- Replaying only an older snapshot is detected when its version vector is behind the locally checkpointed version vector.
+- Supplying a different snapshot with the same version vector is detected because its exact snapshot digest differs from the checkpointed digest.
+- Supplying a competing trust history is detected because the candidate chain must contain the exact checkpointed certificate digest at the checkpointed generation.
+- Changing a checkpoint by itself is ineffective because the checkpoint is signed by the local device key and is verified before it is used.
+
+### 1.4 What this does not resolve
+
+This is not a global anti-rollback guarantee. An attacker able to restore **all** local protected records to an earlier internally consistent state can restore the earlier snapshot, trust chain, genesis anchor, and checkpoint together. The device then has no local evidence that a newer state ever existed.
+
+Detecting that complete coordinated rollback would require an independent monotonic witness, for example a trusted remote service, a platform-provided monotonic store, or another device that remembers the newer state. The project deliberately does not depend on such a service or platform authority.
+
+### 1.5 Decision and residual risk
+
+The project accepts complete coordinated rollback as a limitation of its local-only, decentralised ownership model. The implemented controls still protect against the more common partial replay, tampering, self-authorised signer, and trust-fork attacks without adding an external server.
+
+Users remain responsible for protecting local browser-profile data and any transferred enrollment material. Future work, such as a companion phone application acting as an additional trusted device, may provide another independent copy of accepted state, but it is not a current security dependency.
+
+### 1.6 Implementation status
+
+Implemented in core through the vault-trust domain contracts, `VaultTrustService`, vault lifecycle and device-trust workflows, and focused regression tests. The guarantee depends on a storage adapter correctly implementing the atomic snapshot-and-checkpoint repository contract.

--- a/docs/report/5_tmp_findings.md.md
+++ b/docs/report/5_tmp_findings.md.md
@@ -50,3 +50,19 @@ Users remain responsible for protecting local browser-profile data and any trans
 ### 1.6 Implementation status
 
 Implemented in core through the vault-trust domain contracts, `VaultTrustService`, vault lifecycle and device-trust workflows, and focused regression tests. The guarantee depends on a storage adapter correctly implementing the atomic snapshot-and-checkpoint repository contract.
+
+## 2. Remote Sync Cleanup Is Retryable
+
+### 2.1 Problem
+
+Removing local sync configuration and deleting remote snapshots cannot be one atomic operation. A remote delete can fail after local state is saved, or succeed remotely while final local cleanup fails. Discarding the encrypted sync configuration too early would make a later retry impossible.
+
+### 2.2 Implemented decision
+
+Disabling sync first stores an encrypted `syncRemovalPending` marker beside the existing sync configuration. Normal sync, sync review, sync resolution, and new enrollment are blocked on the device performing cleanup while this marker exists. Remote cleanup can be retried using the retained encrypted configuration. Only after remote deletion succeeds does the core persist the final state that removes both the configuration and the marker.
+
+This is intentionally local to the active device. The project assumes a single user operates one device at a time; it does not distribute a temporary cleanup marker to other registered devices.
+
+### 2.3 Residual limitation
+
+Remote deletion has an inherently ambiguous failure mode: a request can succeed remotely but fail to return a response. Retrying is therefore safe only when the sync provider treats deletion of already-missing remote objects as success. This is an explicit `SyncProviderPort` contract that every future adapter must implement.

--- a/packages/core/src/__tests__/fixtures/change-master-password.ts
+++ b/packages/core/src/__tests__/fixtures/change-master-password.ts
@@ -26,6 +26,11 @@ export function createChangeMasterPasswordTestContext() {
       vault: values.decryptedVault,
       vaultMasterKey: values.vaultMasterKey,
       devicePrivateSignKey: values.devicePrivateSignKey,
+      trustedSnapshotContext: {
+        snapshotDigest: values.vaultSnapshotDigest,
+        trust: values.verifiedVaultTrustState,
+      },
+      vaultTrustAnchor: values.vaultTrustAnchor,
     },
     sourceSnapshotVersionVector: { [values.deviceId]: 1 },
   };

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -6,10 +6,12 @@ import type { DeviceAccessMaterial } from "../../domain/device-trust/device-acce
 import type { DeviceAccessRecoveryBackup } from "../../domain/device-trust/device-access-recovery-backup";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { LocalVaultDescriptor } from "../../domain/vault/local-vault-descriptor";
-import type { UnlockedVault } from "../../domain/session/unlocked-vault";
-import type { UnlockedVaultSessionPayloadKey } from "../../domain/session/unlocked-vault-session-payload-key";
+import type {
+  EncryptedUnlockedVaultSessionPayload,
+  UnlockedVaultSession,
+  UnlockedVaultSessionMaterial,
+} from "../../domain/session/unlocked-vault-session.type";
 import type { Vault } from "../../domain/vault/vault";
-import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { Bip39Port } from "../../ports/crypto/bip39.port";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
@@ -23,34 +25,17 @@ import type { UnlockedVaultSessionMaterialRepositoryPort } from "../../ports/ses
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import { createCoreTestValues, type CoreTestValues } from "./values";
-import type { SerializedEncrypted } from "../../domain";
+import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
 
 export type SavedCoreRecords = {
   localVaultDescriptor?: LocalVaultDescriptor;
   deviceAccessMaterial?: DeviceAccessMaterial;
   deviceAccessRecoveryBackup?: DeviceAccessRecoveryBackup;
   vaultSnapshot?: VaultSnapshot;
-  unlockedVaultSession?: {
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  };
-  unlockedVaultSessionMaterial?: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: UnlockedVault["vaultMasterKey"];
-    readonly devicePrivateSignKey: UnlockedVault["devicePrivateSignKey"];
-    readonly payloadKey: UnlockedVaultSessionPayloadKey;
-  };
-  encryptedUnlockedVaultSessionPayload?: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: SerializedEncrypted<{
-      readonly vault: Vault;
-    }>;
-  };
+  localVaultTrustCheckpoint?: LocalVaultTrustCheckpoint;
+  unlockedVaultSession?: UnlockedVaultSession;
+  unlockedVaultSessionMaterial?: UnlockedVaultSessionMaterial;
+  encryptedUnlockedVaultSessionPayload?: EncryptedUnlockedVaultSessionPayload;
   unlockedVaultSessionPayload?: {
     readonly vault: Vault;
   };
@@ -62,17 +47,11 @@ export function createCoreTestPorts(
   values: CoreTestValues = createCoreTestValues(),
 ) {
   const saved: SavedCoreRecords = {};
-  let unlockedVaultSessionMirror:
-    | {
-        readonly unlockedVault: UnlockedVault;
-        readonly sourceSnapshotVersionVector: VersionVector;
-      }
-    | undefined;
+  let unlockedVaultSessionMirror: UnlockedVaultSession | undefined;
 
-  function writeSplitUnlockedVaultSessionRecords(session: {
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  }): void {
+  function writeSplitUnlockedVaultSessionRecords(
+    session: UnlockedVaultSession,
+  ): void {
     const context = {
       sessionId: values.sessionId,
       vaultId: session.unlockedVault.vaultId,
@@ -84,6 +63,8 @@ export function createCoreTestPorts(
       deviceId: session.unlockedVault.deviceId,
       vaultMasterKey: session.unlockedVault.vaultMasterKey,
       devicePrivateSignKey: session.unlockedVault.devicePrivateSignKey,
+      trustedSnapshotContext: session.unlockedVault.trustedSnapshotContext,
+      vaultTrustAnchor: session.unlockedVault.vaultTrustAnchor,
       payloadKey: values.unlockedVaultSessionPayloadKey,
     };
     saved.encryptedUnlockedVaultSessionPayload = {
@@ -103,14 +84,7 @@ export function createCoreTestPorts(
 
   Object.defineProperty(saved, "unlockedVaultSession", {
     get: () => unlockedVaultSessionMirror,
-    set: (
-      session:
-        | {
-            readonly unlockedVault: UnlockedVault;
-            readonly sourceSnapshotVersionVector: VersionVector;
-          }
-        | undefined,
-    ) => {
+    set: (session: UnlockedVaultSession | undefined) => {
       unlockedVaultSessionMirror = session;
 
       if (session === undefined) {
@@ -193,6 +167,7 @@ export function createCoreTestPorts(
     unwrapLocalKeysPayload: vi.fn(async () => ({
       deviceSlotKey: values.deviceSlotKey,
       devicePrivateSignKey: values.devicePrivateSignKey,
+      vaultTrustAnchor: values.vaultTrustAnchor,
     })),
     wrapVaultMasterKey: vi.fn(async (_vaultMasterKey, protectionKey) => {
       if (protectionKey === values.enrollmentVaultMasterKeyProtectionKey) {
@@ -205,8 +180,10 @@ export function createCoreTestPorts(
     digestProtectedVaultMasterKey: vi.fn(
       async () => values.protectedEnrollmentVaultMasterKeyDigest,
     ),
-    digestDevicePublicSignKey: vi.fn(
-      async () => values.pendingDevicePublicSignKeyDigest,
+    digestDevicePublicSignKey: vi.fn(async (publicKey) =>
+      publicKey === values.pendingDevicePublicSignKey
+        ? values.pendingDevicePublicSignKeyDigest
+        : values.devicePublicSignKeyDigest,
     ),
     encryptVaultSnapshotContent: vi.fn(async () => values.encryptedVault),
     decryptVaultSnapshotContent: vi.fn(async () => values.decryptedVault),
@@ -224,6 +201,18 @@ export function createCoreTestPorts(
     signVaultSnapshot: vi.fn(async () => values.snapshotSignature),
     verifyVaultSnapshotSignature: vi.fn(async () => true),
     verifyDeviceSignKeyPair: vi.fn(async () => true),
+    digestVaultTrustCertificate: vi.fn(
+      async () => values.vaultTrustCertificateDigest,
+    ),
+    signVaultTrustCertificate: vi.fn(
+      async () => values.vaultTrustCertificateSignature,
+    ),
+    verifyVaultTrustCertificateSignature: vi.fn(async () => true),
+    digestVaultSnapshot: vi.fn(async () => values.vaultSnapshotDigest),
+    signLocalVaultTrustCheckpoint: vi.fn(
+      async () => values.localVaultTrustCheckpoint.signature,
+    ),
+    verifyLocalVaultTrustCheckpointSignature: vi.fn(async () => true),
     signDeviceEnrollmentAuthorization: vi.fn(
       async () => values.deviceEnrollmentAuthorizationSignature,
     ),
@@ -245,16 +234,18 @@ export function createCoreTestPorts(
 
   const vaultLocalRepository: VaultLocalRepositoryPort = {
     saveInitializedLocalVault: vi.fn(
-      async (
+      async ({
         descriptor,
         deviceAccessMaterial,
         deviceAccessRecoveryBackup,
         snapshot,
-      ) => {
+        checkpoint,
+      }) => {
         saved.localVaultDescriptor = descriptor;
         saved.deviceAccessMaterial = deviceAccessMaterial;
         saved.deviceAccessRecoveryBackup = deviceAccessRecoveryBackup;
         saved.vaultSnapshot = snapshot;
+        saved.localVaultTrustCheckpoint = checkpoint;
       },
     ),
     removePersistedLocalVault: vi.fn(async () => {
@@ -262,6 +253,7 @@ export function createCoreTestPorts(
       saved.deviceAccessMaterial = undefined;
       saved.deviceAccessRecoveryBackup = undefined;
       saved.vaultSnapshot = undefined;
+      saved.localVaultTrustCheckpoint = undefined;
     }),
     saveLocalVaultDescriptor: vi.fn(async (descriptor) => {
       saved.localVaultDescriptor = descriptor;
@@ -311,9 +303,6 @@ export function createCoreTestPorts(
     removeDeviceAccessRecoveryBackup: vi.fn(async () => {
       saved.deviceAccessRecoveryBackup = undefined;
     }),
-    saveVaultSnapshot: vi.fn(async (vaultSnapshot) => {
-      saved.vaultSnapshot = vaultSnapshot;
-    }),
     getVaultSnapshot: vi.fn(async (vaultId) => {
       const vaultSnapshot = saved.vaultSnapshot;
 
@@ -324,6 +313,23 @@ export function createCoreTestPorts(
       return vaultSnapshot.metadata.id === vaultId ? vaultSnapshot : null;
     }),
     removeVaultSnapshot: vi.fn(),
+    saveVaultSnapshotWithCheckpoint: vi.fn(async ({ snapshot, checkpoint }) => {
+      saved.vaultSnapshot = snapshot;
+      saved.localVaultTrustCheckpoint = checkpoint;
+    }),
+    saveLocalVaultTrustCheckpoint: vi.fn(async (checkpoint) => {
+      saved.localVaultTrustCheckpoint = checkpoint;
+    }),
+    getLocalVaultTrustCheckpoint: vi.fn(async (vaultId) => {
+      const checkpoint = saved.localVaultTrustCheckpoint;
+
+      return checkpoint !== undefined && checkpoint.payload.vaultId === vaultId
+        ? checkpoint
+        : null;
+    }),
+    removeLocalVaultTrustCheckpoint: vi.fn(async () => {
+      saved.localVaultTrustCheckpoint = undefined;
+    }),
   };
 
   const unlockedVaultSessionMaterialRepository: UnlockedVaultSessionMaterialRepositoryPort =

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -317,9 +317,6 @@ export function createCoreTestPorts(
       saved.vaultSnapshot = snapshot;
       saved.localVaultTrustCheckpoint = checkpoint;
     }),
-    saveLocalVaultTrustCheckpoint: vi.fn(async (checkpoint) => {
-      saved.localVaultTrustCheckpoint = checkpoint;
-    }),
     getLocalVaultTrustCheckpoint: vi.fn(async (vaultId) => {
       const checkpoint = saved.localVaultTrustCheckpoint;
 

--- a/packages/core/src/__tests__/fixtures/unlock-vault.ts
+++ b/packages/core/src/__tests__/fixtures/unlock-vault.ts
@@ -24,7 +24,7 @@ export function createUnlockVaultTestContext() {
   const vaultSnapshot: VaultSnapshot = {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -33,6 +33,7 @@ export function createUnlockVaultTestContext() {
       algorithmSuiteId: ports.crypto.algorithmSuite.id,
       createdByDeviceId: values.deviceId,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {
@@ -48,6 +49,7 @@ export function createUnlockVaultTestContext() {
 
   ports.saved.deviceAccessMaterial = deviceAccessMaterial;
   ports.saved.vaultSnapshot = vaultSnapshot;
+  ports.saved.localVaultTrustCheckpoint = values.localVaultTrustCheckpoint;
 
   const useCase = new UnlockVaultUseCase(
     ports.clock,

--- a/packages/core/src/__tests__/fixtures/values.ts
+++ b/packages/core/src/__tests__/fixtures/values.ts
@@ -22,6 +22,15 @@ import type { RecoverySecretKey } from "../../domain/recovery/brand-keys";
 import type { VaultMasterKey } from "../../domain/snapshot/brand-keys";
 import type { SyncConfig } from "../../domain/sync/sync-config.type";
 import type { DeviceEnrollmentAuthorizationPayload } from "../../domain/device-trust/device-enrollment-authorization";
+import type {
+  LocalVaultTrustCheckpoint,
+  LocalVaultTrustCheckpointPayload,
+  LocalVaultTrustAnchor,
+  VaultTrustCertificate,
+  VaultTrustCertificatePayload,
+  VaultTrustChain,
+  VerifiedVaultTrustState,
+} from "../../domain/device-trust";
 import type { UnsignedVaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { UnlockedVaultSessionPayloadKey } from "../../domain/session/unlocked-vault-session-payload-key";
 import type { Vault } from "../../domain/vault/vault";
@@ -32,6 +41,60 @@ export const b64 = (value: string) => value as Base64URLString;
 export type CoreTestValues = ReturnType<typeof createCoreTestValues>;
 
 export function createCoreTestValues() {
+  const devicePublicSignKey = bytes<DevicePublicSignKey>();
+  const devicePrivateSignKey = bytes<DevicePrivateSignKey>();
+  const vaultTrustCertificatePayload = {
+    version: 1,
+    vaultId: "vault-id",
+    generation: 0,
+    previousCertificateDigest: null,
+    authorizedByDeviceId: "device-id",
+    trustedDevices: [
+      {
+        deviceId: "device-id",
+        publicSignKey: devicePublicSignKey,
+      },
+    ],
+  } as const satisfies VaultTrustCertificatePayload;
+  const vaultTrustCertificateSignature = {
+    signature: b64("vault-trust-certificate-signature"),
+  } satisfies SerializedSignatureOf<VaultTrustCertificatePayload>;
+  const vaultTrustCertificate = {
+    payload: vaultTrustCertificatePayload,
+    signature: vaultTrustCertificateSignature,
+  } satisfies VaultTrustCertificate;
+  const vaultTrustCertificateDigest = "vault-trust-certificate-digest";
+  const vaultTrustChain = {
+    certificates: [vaultTrustCertificate],
+  } satisfies VaultTrustChain;
+  const vaultTrustAnchor = {
+    version: 1,
+    vaultId: "vault-id",
+    genesisDeviceId: "device-id",
+    genesisPublicSignKey: devicePublicSignKey,
+    genesisCertificateDigest: vaultTrustCertificateDigest,
+  } satisfies LocalVaultTrustAnchor;
+  const verifiedVaultTrustState = {
+    generation: 0,
+    certificateDigest: vaultTrustCertificateDigest,
+    trustedDevices: vaultTrustCertificatePayload.trustedDevices,
+  } satisfies VerifiedVaultTrustState;
+  const localVaultTrustCheckpointPayload = {
+    version: 1,
+    vaultId: "vault-id",
+    deviceId: "device-id",
+    trustGeneration: 0,
+    trustCertificateDigest: vaultTrustCertificateDigest,
+    snapshotVersionVector: { "device-id": 1 },
+    snapshotDigest: "vault-snapshot-digest",
+  } as const satisfies LocalVaultTrustCheckpointPayload;
+  const localVaultTrustCheckpoint = {
+    payload: localVaultTrustCheckpointPayload,
+    signature: {
+      signature: b64("local-vault-trust-checkpoint-signature"),
+    },
+  } satisfies LocalVaultTrustCheckpoint;
+
   return {
     masterPassword: "master-password" as RawMasterPassword,
     newMasterPassword: "new-master-password" as RawMasterPassword,
@@ -59,11 +122,22 @@ export function createCoreTestValues() {
     vaultMasterKey: bytes<VaultMasterKey>(),
     deviceSlotKey: bytes<DeviceSlotKey>(),
     deviceEnrollmentSecret: bytes<DeviceEnrollmentSecret>(),
-    devicePublicSignKey: bytes<DevicePublicSignKey>(),
-    devicePrivateSignKey: bytes<DevicePrivateSignKey>(),
+    devicePublicSignKey,
+    devicePrivateSignKey,
     pendingDevicePublicSignKey: bytes<DevicePublicSignKey>(),
     pendingDevicePrivateSignKey: bytes<DevicePrivateSignKey>(),
     pendingDevicePublicSignKeyDigest: "pending-device-public-sign-key-digest",
+    devicePublicSignKeyDigest: "device-public-sign-key-digest",
+    vaultTrustCertificatePayload,
+    vaultTrustCertificateSignature,
+    vaultTrustCertificate,
+    vaultTrustCertificateDigest,
+    vaultTrustChain,
+    vaultTrustAnchor,
+    verifiedVaultTrustState,
+    localVaultTrustCheckpointPayload,
+    localVaultTrustCheckpoint,
+    vaultSnapshotDigest: "vault-snapshot-digest",
     recoverySecretKey: bytes<RecoverySecretKey>(),
     rotatedRecoverySecretKey: bytes<RecoverySecretKey>(),
     unlockedVaultSessionPayloadKey: bytes<UnlockedVaultSessionPayloadKey>(),

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -81,6 +81,11 @@ export function createUnlockedVaultWithEntries(
     },
     vaultMasterKey: values.vaultMasterKey,
     devicePrivateSignKey: values.devicePrivateSignKey,
+    trustedSnapshotContext: {
+      snapshotDigest: values.vaultSnapshotDigest,
+      trust: values.verifiedVaultTrustState,
+    },
+    vaultTrustAnchor: values.vaultTrustAnchor,
   };
 }
 
@@ -115,7 +120,7 @@ export function createVaultSnapshotServiceMock(
   let savedVaultSnapshot: VaultSnapshot = {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -124,6 +129,7 @@ export function createVaultSnapshotServiceMock(
       algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
       createdByDeviceId: values.deviceId,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {
@@ -176,6 +182,11 @@ export function createVaultSnapshotServiceMock(
           snapshotVersionVector:
             savedVaultSnapshot.metadata.snapshotVersionVector,
           revisionTimestamp: savedVaultSnapshot.metadata.revisionTimestamp,
+          trustedSnapshotContext: {
+            snapshotDigest: values.vaultSnapshotDigest,
+            trust: values.verifiedVaultTrustState,
+          },
+          snapshot: savedVaultSnapshot,
         };
       },
     ),

--- a/packages/core/src/domain/device-trust/device-enrollment-bundle.ts
+++ b/packages/core/src/domain/device-trust/device-enrollment-bundle.ts
@@ -3,8 +3,8 @@ import type { VersionVector } from "../versioning/version-vector.type";
 import type {
   DeviceEnrollmentSecret,
   DevicePrivateSignKey,
-  DevicePublicSignKey,
 } from "./brand-keys";
+import type { LocalVaultTrustAnchor } from "./vault-trust";
 
 export type DeviceEnrollmentBundle = {
   readonly version: 1;
@@ -12,7 +12,7 @@ export type DeviceEnrollmentBundle = {
   readonly syncConfig: SyncConfig;
   readonly snapshotVersionVector: VersionVector;
   readonly revisionTimestamp: number;
-  readonly snapshotSignerPublicKey: DevicePublicSignKey;
   readonly enrollmentSecret: DeviceEnrollmentSecret;
   readonly pendingDevicePrivateSignKey: DevicePrivateSignKey;
+  readonly vaultTrustAnchor: LocalVaultTrustAnchor;
 };

--- a/packages/core/src/domain/device-trust/index.ts
+++ b/packages/core/src/domain/device-trust/index.ts
@@ -4,3 +4,5 @@ export * from "./device-access-recovery-backup";
 export * from "./device-enrollment-authorization";
 export * from "./device-enrollment-bundle";
 export * from "./local-protection.type";
+export * from "./local-vault-trust-checkpoint";
+export * from "./vault-trust";

--- a/packages/core/src/domain/device-trust/local-protection.type.ts
+++ b/packages/core/src/domain/device-trust/local-protection.type.ts
@@ -1,9 +1,11 @@
 import type { Brand } from "../common/brand-keys";
 import type { DevicePrivateSignKey, DeviceSlotKey } from "./brand-keys";
+import type { LocalVaultTrustAnchor } from "./vault-trust";
 
 export type LocalRootKey = Brand<ArrayBuffer, "LocalRootKey">;
 
 export type LocalKeysPayload = {
   readonly deviceSlotKey: DeviceSlotKey;
   readonly devicePrivateSignKey: DevicePrivateSignKey;
+  readonly vaultTrustAnchor: LocalVaultTrustAnchor;
 };

--- a/packages/core/src/domain/device-trust/local-vault-trust-checkpoint.ts
+++ b/packages/core/src/domain/device-trust/local-vault-trust-checkpoint.ts
@@ -1,0 +1,17 @@
+import type { SerializedSignatureOf } from "../crypto/protected-artifact";
+import type { VersionVector } from "../versioning/version-vector.type";
+
+export type LocalVaultTrustCheckpointPayload = {
+  readonly version: 1;
+  readonly vaultId: string;
+  readonly deviceId: string;
+  readonly trustGeneration: number;
+  readonly trustCertificateDigest: string;
+  readonly snapshotVersionVector: VersionVector;
+  readonly snapshotDigest: string;
+};
+
+export type LocalVaultTrustCheckpoint = {
+  readonly payload: LocalVaultTrustCheckpointPayload;
+  readonly signature: SerializedSignatureOf<LocalVaultTrustCheckpointPayload>;
+};

--- a/packages/core/src/domain/device-trust/vault-trust.ts
+++ b/packages/core/src/domain/device-trust/vault-trust.ts
@@ -1,0 +1,39 @@
+import type { SerializedSignatureOf } from "../crypto/protected-artifact";
+import type { DevicePublicSignKey } from "./brand-keys";
+
+export type DeviceTrustIdentity = {
+  readonly deviceId: string;
+  readonly publicSignKey: DevicePublicSignKey;
+};
+
+export type VaultTrustCertificatePayload = {
+  readonly version: 1;
+  readonly vaultId: string;
+  readonly generation: number;
+  readonly previousCertificateDigest: string | null;
+  readonly authorizedByDeviceId: string;
+  readonly trustedDevices: readonly DeviceTrustIdentity[];
+};
+
+export type VaultTrustCertificate = {
+  readonly payload: VaultTrustCertificatePayload;
+  readonly signature: SerializedSignatureOf<VaultTrustCertificatePayload>;
+};
+
+export type VaultTrustChain = {
+  readonly certificates: readonly VaultTrustCertificate[];
+};
+
+export type LocalVaultTrustAnchor = {
+  readonly version: 1;
+  readonly vaultId: string;
+  readonly genesisDeviceId: string;
+  readonly genesisPublicSignKey: DevicePublicSignKey;
+  readonly genesisCertificateDigest: string;
+};
+
+export type VerifiedVaultTrustState = {
+  readonly generation: number;
+  readonly certificateDigest: string;
+  readonly trustedDevices: readonly DeviceTrustIdentity[];
+};

--- a/packages/core/src/domain/session/index.ts
+++ b/packages/core/src/domain/session/index.ts
@@ -1,2 +1,3 @@
 export * from "./unlocked-vault";
 export * from "./unlocked-vault-session-payload-key";
+export * from "./unlocked-vault-session.type";

--- a/packages/core/src/domain/session/unlocked-vault-session.type.ts
+++ b/packages/core/src/domain/session/unlocked-vault-session.type.ts
@@ -1,0 +1,31 @@
+import type { SerializedEncrypted } from "../crypto/protected-artifact";
+import type { Vault } from "../vault/vault";
+import type { VersionVector } from "../versioning/version-vector.type";
+import type { UnlockedVault } from "./unlocked-vault";
+import type { UnlockedVaultSessionPayloadKey } from "./unlocked-vault-session-payload-key";
+
+export type UnlockedVaultSession = {
+  readonly unlockedVault: UnlockedVault;
+  readonly sourceSnapshotVersionVector: VersionVector;
+};
+
+export type UnlockedVaultSessionMaterial = {
+  readonly sessionId: string;
+  readonly vaultId: string;
+  readonly sourceSnapshotVersionVector: VersionVector;
+  readonly deviceId: string;
+  readonly vaultMasterKey: UnlockedVault["vaultMasterKey"];
+  readonly devicePrivateSignKey: UnlockedVault["devicePrivateSignKey"];
+  readonly payloadKey: UnlockedVaultSessionPayloadKey;
+  readonly trustedSnapshotContext: UnlockedVault["trustedSnapshotContext"];
+  readonly vaultTrustAnchor: UnlockedVault["vaultTrustAnchor"];
+};
+
+export type EncryptedUnlockedVaultSessionPayload = {
+  readonly sessionId: string;
+  readonly vaultId: string;
+  readonly sourceSnapshotVersionVector: VersionVector;
+  readonly content: SerializedEncrypted<{
+    readonly vault: Vault;
+  }>;
+};

--- a/packages/core/src/domain/session/unlocked-vault.ts
+++ b/packages/core/src/domain/session/unlocked-vault.ts
@@ -1,6 +1,13 @@
 import type { DevicePrivateSignKey } from "../device-trust/brand-keys";
 import type { VaultMasterKey } from "../snapshot/brand-keys";
 import type { Vault } from "../vault/vault";
+import type { VerifiedVaultTrustState } from "../device-trust/vault-trust";
+import type { LocalVaultTrustAnchor } from "../device-trust/vault-trust";
+
+export type TrustedSnapshotContext = {
+  readonly snapshotDigest: string;
+  readonly trust: VerifiedVaultTrustState;
+};
 
 export type UnlockedVault = {
   readonly vaultId: string;
@@ -8,4 +15,6 @@ export type UnlockedVault = {
   readonly vault: Vault;
   readonly vaultMasterKey: VaultMasterKey;
   readonly devicePrivateSignKey: DevicePrivateSignKey;
+  readonly trustedSnapshotContext: TrustedSnapshotContext;
+  readonly vaultTrustAnchor: LocalVaultTrustAnchor;
 };

--- a/packages/core/src/domain/snapshot/key-slot.ts
+++ b/packages/core/src/domain/snapshot/key-slot.ts
@@ -1,6 +1,7 @@
 import type {
   DeviceEnrollmentAuthorizationPayload,
   DevicePublicSignKey,
+  DeviceTrustIdentity,
 } from "../device-trust";
 import type {
   SerializedSignatureOf,
@@ -8,10 +9,8 @@ import type {
 } from "../crypto/protected-artifact";
 import type { VaultMasterKey } from "./brand-keys";
 
-export type DeviceKeySlot = {
-  deviceId: string;
+export type DeviceKeySlot = DeviceTrustIdentity & {
   protectedVaultMasterKey: SerializedWrapped<VaultMasterKey>;
-  publicSignKey: DevicePublicSignKey;
 };
 
 /**

--- a/packages/core/src/domain/snapshot/vault-snapshot.ts
+++ b/packages/core/src/domain/snapshot/vault-snapshot.ts
@@ -6,8 +6,9 @@ import type { CompletedDeviceEnrollmentProof } from "../device-trust";
 import type { Vault } from "../vault/vault";
 import type { VersionVector } from "../versioning/version-vector.type";
 import type { DeviceKeySlot, EnrollmentKeySlot } from "./key-slot";
+import type { VaultTrustChain } from "../device-trust/vault-trust";
 
-export type VaultSnapshotSchemaVersion = 1;
+export type VaultSnapshotSchemaVersion = 2;
 
 export type VaultSnapshotMetadata = {
   id: string; // random identifier
@@ -21,6 +22,7 @@ export type VaultSnapshotMetadata = {
 
 export type UnsignedVaultSnapshot = {
   metadata: VaultSnapshotMetadata;
+  trustChain: VaultTrustChain;
   keySlots: {
     deviceSlots: DeviceKeySlot[];
     enrollmentKeySlot?: EnrollmentKeySlot;

--- a/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Vault } from "./vault";
-import { removeVaultSyncConfig } from "./vault-sync-config.mutations";
+import {
+  markVaultSyncRemovalPending,
+  removeVaultSyncConfig,
+} from "./vault-sync-config.mutations";
 
 function createVault(overrides: Partial<Vault> = {}): Vault {
   return {
@@ -16,7 +19,7 @@ function createVault(overrides: Partial<Vault> = {}): Vault {
 }
 
 describe("vault sync config mutations", () => {
-  it("removes sync config without mutating the source vault", () => {
+  it("marks sync removal pending without removing sync config", () => {
     const vault = createVault({
       syncConfig: {
         provider: "aws-s3-v1",
@@ -26,9 +29,28 @@ describe("vault sync config mutations", () => {
       },
     });
 
+    const updatedVault = markVaultSyncRemovalPending(vault);
+
+    expect(updatedVault.syncRemovalPending).toBe(true);
+    expect(updatedVault.syncConfig).toEqual(vault.syncConfig);
+    expect(vault.syncRemovalPending).toBeUndefined();
+  });
+
+  it("removes sync config without mutating the source vault", () => {
+    const vault = createVault({
+      syncConfig: {
+        provider: "aws-s3-v1",
+        providerConfig: {
+          bucketName: "vault-bucket",
+        },
+      },
+      syncRemovalPending: true,
+    });
+
     const updatedVault = removeVaultSyncConfig(vault);
 
     expect("syncConfig" in updatedVault).toBe(false);
+    expect("syncRemovalPending" in updatedVault).toBe(false);
     expect(vault.syncConfig).toEqual({
       provider: "aws-s3-v1",
       providerConfig: {

--- a/packages/core/src/domain/vault/vault-sync-config.mutations.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.ts
@@ -1,8 +1,16 @@
 import type { Vault } from "./vault";
 
+export function markVaultSyncRemovalPending(vault: Vault): Vault {
+  return {
+    ...vault,
+    syncRemovalPending: true,
+  };
+}
+
 export function removeVaultSyncConfig(vault: Vault): Vault {
-  const { syncConfig, ...vaultWithoutSyncConfig } = vault;
+  const { syncConfig, syncRemovalPending, ...vaultWithoutSyncConfig } = vault;
   void syncConfig;
+  void syncRemovalPending;
 
   return vaultWithoutSyncConfig;
 }

--- a/packages/core/src/domain/vault/vault.ts
+++ b/packages/core/src/domain/vault/vault.ts
@@ -17,6 +17,7 @@ export interface Vault {
   deviceProfiles: DeviceProfile[];
   deletedDeviceProfiles: DeletedDeviceProfile[];
   syncConfig?: SyncConfig;
+  syncRemovalPending?: true;
   tags: Tag[];
   deletedTags: DeletedTag[];
 }

--- a/packages/core/src/errors/device-enrollment.errors.ts
+++ b/packages/core/src/errors/device-enrollment.errors.ts
@@ -42,9 +42,10 @@ export class DeviceEnrollmentAlreadyCompletedError extends Error {
 }
 
 export class DeviceEnrollmentIntegrityError extends Error {
-  constructor(vaultId: string, reason: string) {
+  constructor(vaultId: string, reason: string, options?: ErrorOptions) {
     super(
       `Vault "${vaultId}" device enrollment integrity check failed: ${reason}`,
+      options,
     );
     this.name = "DeviceEnrollmentIntegrityError";
   }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -13,3 +13,4 @@ export * from "./vault-device.errors";
 export * from "./vault-entry.errors";
 export * from "./vault-session.errors";
 export * from "./vault-snapshot.errors";
+export * from "./vault-trust.errors";

--- a/packages/core/src/errors/sync.errors.ts
+++ b/packages/core/src/errors/sync.errors.ts
@@ -21,6 +21,15 @@ export class SyncAlreadyConfiguredError extends Error {
   }
 }
 
+export class SyncRemovalPendingError extends Error {
+  constructor(vaultId: string, operation: string) {
+    super(
+      `Vault "${vaultId}" has remote sync cleanup pending and cannot ${operation}.`,
+    );
+    this.name = "SyncRemovalPendingError";
+  }
+}
+
 export class RemoteVaultSnapshotNotFoundError extends Error {
   constructor(vaultId: string) {
     super(`Remote vault snapshot for vault "${vaultId}" was not found.`);

--- a/packages/core/src/errors/vault-trust.errors.ts
+++ b/packages/core/src/errors/vault-trust.errors.ts
@@ -1,0 +1,33 @@
+export class VaultTrustStateInvalidError extends Error {
+  override readonly name = "VaultTrustStateInvalidError";
+
+  constructor(vaultId: string, reason: string) {
+    super(`Vault trust state for vault '${vaultId}' is invalid: ${reason}.`);
+  }
+}
+
+export class LocalVaultTrustCheckpointNotFoundError extends Error {
+  override readonly name = "LocalVaultTrustCheckpointNotFoundError";
+
+  constructor(vaultId: string) {
+    super(`Local vault trust checkpoint for vault '${vaultId}' was not found.`);
+  }
+}
+
+export class LocalVaultTrustCheckpointInvalidError extends Error {
+  override readonly name = "LocalVaultTrustCheckpointInvalidError";
+
+  constructor(vaultId: string, reason: string) {
+    super(
+      `Local vault trust checkpoint for vault '${vaultId}' is invalid: ${reason}.`,
+    );
+  }
+}
+
+export class VaultSnapshotRollbackDetectedError extends Error {
+  override readonly name = "VaultSnapshotRollbackDetectedError";
+
+  constructor(vaultId: string) {
+    super(`Vault snapshot rollback was detected for vault '${vaultId}'.`);
+  }
+}

--- a/packages/core/src/ports/crypto/crypto.port.ts
+++ b/packages/core/src/ports/crypto/crypto.port.ts
@@ -15,6 +15,12 @@ import type {
 } from "../../domain/device-trust/brand-keys";
 import type { DeviceEnrollmentAuthorizationPayload } from "../../domain/device-trust/device-enrollment-authorization";
 import type {
+  LocalVaultTrustCheckpoint,
+  LocalVaultTrustCheckpointPayload,
+  VaultTrustCertificate,
+  VaultTrustCertificatePayload,
+} from "../../domain/device-trust";
+import type {
   LocalKeysPayload,
   LocalRootKey,
 } from "../../domain/device-trust/local-protection.type";
@@ -151,6 +157,28 @@ export interface CryptoPort {
   verifyDeviceSignKeyPair: (
     publicKey: DevicePublicSignKey,
     privateKey: DevicePrivateSignKey,
+  ) => Promise<boolean>;
+
+  // Vault trust
+  digestVaultTrustCertificate: (
+    certificate: VaultTrustCertificate,
+  ) => Promise<string>;
+  signVaultTrustCertificate: (
+    payload: VaultTrustCertificatePayload,
+    privateKey: DevicePrivateSignKey,
+  ) => Promise<SerializedSignatureOf<VaultTrustCertificatePayload>>;
+  verifyVaultTrustCertificateSignature: (
+    certificate: VaultTrustCertificate,
+    publicKey: DevicePublicSignKey,
+  ) => Promise<boolean>;
+  digestVaultSnapshot: (snapshot: VaultSnapshot) => Promise<string>;
+  signLocalVaultTrustCheckpoint: (
+    payload: LocalVaultTrustCheckpointPayload,
+    privateKey: DevicePrivateSignKey,
+  ) => Promise<SerializedSignatureOf<LocalVaultTrustCheckpointPayload>>;
+  verifyLocalVaultTrustCheckpointSignature: (
+    checkpoint: LocalVaultTrustCheckpoint,
+    publicKey: DevicePublicSignKey,
   ) => Promise<boolean>;
 
   // Device enrollment authorization

--- a/packages/core/src/ports/session/encrypted-unlocked-vault-session-payload-repository.port.ts
+++ b/packages/core/src/ports/session/encrypted-unlocked-vault-session-payload-repository.port.ts
@@ -1,6 +1,4 @@
-import type { SerializedEncrypted } from "../../domain/crypto/protected-artifact";
-import type { Vault } from "../../domain/vault/vault";
-import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import type { EncryptedUnlockedVaultSessionPayload } from "../../domain/session/unlocked-vault-session.type";
 
 /**
  * Stores the encrypted active unlocked-vault session payload.
@@ -11,21 +9,9 @@ import type { VersionVector } from "../../domain/versioning/version-vector.type"
  * must remove it when the unlocked session is removed.
  */
 export interface EncryptedUnlockedVaultSessionPayloadRepositoryPort {
-  saveEncryptedUnlockedVaultSessionPayload: (encryptedPayload: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: SerializedEncrypted<{
-      readonly vault: Vault;
-    }>;
-  }) => Promise<void>;
-  getEncryptedUnlockedVaultSessionPayload: () => Promise<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: SerializedEncrypted<{
-      readonly vault: Vault;
-    }>;
-  } | null>;
+  saveEncryptedUnlockedVaultSessionPayload: (
+    encryptedPayload: EncryptedUnlockedVaultSessionPayload,
+  ) => Promise<void>;
+  getEncryptedUnlockedVaultSessionPayload: () => Promise<EncryptedUnlockedVaultSessionPayload | null>;
   removeEncryptedUnlockedVaultSessionPayload: () => Promise<void>;
 }

--- a/packages/core/src/ports/session/unlocked-vault-session-material-repository.port.ts
+++ b/packages/core/src/ports/session/unlocked-vault-session-material-repository.port.ts
@@ -1,7 +1,4 @@
-import type { DevicePrivateSignKey } from "../../domain/device-trust/brand-keys";
-import type { VaultMasterKey } from "../../domain/snapshot/brand-keys";
-import type { UnlockedVaultSessionPayloadKey } from "../../domain/session/unlocked-vault-session-payload-key";
-import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import type { UnlockedVaultSessionMaterial } from "../../domain/session/unlocked-vault-session.type";
 
 /**
  * Stores the active unlocked-vault session material.
@@ -11,23 +8,9 @@ import type { VersionVector } from "../../domain/versioning/version-vector.type"
  * volatile, session-scoped storage and expose only the active record.
  */
 export interface UnlockedVaultSessionMaterialRepositoryPort {
-  saveUnlockedVaultSessionMaterial: (material: {
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: VaultMasterKey;
-    readonly devicePrivateSignKey: DevicePrivateSignKey;
-    readonly payloadKey: UnlockedVaultSessionPayloadKey;
-  }) => Promise<void>;
-  getUnlockedVaultSessionMaterial: () => Promise<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: VaultMasterKey;
-    readonly devicePrivateSignKey: DevicePrivateSignKey;
-    readonly payloadKey: UnlockedVaultSessionPayloadKey;
-  } | null>;
+  saveUnlockedVaultSessionMaterial: (
+    material: UnlockedVaultSessionMaterial,
+  ) => Promise<void>;
+  getUnlockedVaultSessionMaterial: () => Promise<UnlockedVaultSessionMaterial | null>;
   removeUnlockedVaultSessionMaterial: () => Promise<void>;
 }

--- a/packages/core/src/ports/sync/sync-provider.port.ts
+++ b/packages/core/src/ports/sync/sync-provider.port.ts
@@ -23,6 +23,10 @@ export interface SyncProviderPort {
     vaultSnapshot: VaultSnapshot,
     expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
   ) => Promise<void>;
+  /**
+   * Removes all remote state for a vault. This operation must be idempotent:
+   * attempting to remove an already-absent vault is successful.
+   */
   removeVaultSnapshots: (
     syncConfig: SyncConfig,
     vaultId: string,

--- a/packages/core/src/ports/vault/vault-local-repository.port.ts
+++ b/packages/core/src/ports/vault/vault-local-repository.port.ts
@@ -2,6 +2,7 @@ import type { DeviceAccessMaterial } from "../../domain/device-trust/device-acce
 import type { DeviceAccessRecoveryBackup } from "../../domain/device-trust/device-access-recovery-backup";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { LocalVaultDescriptor } from "../../domain/vault/local-vault-descriptor";
+import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
 
 export interface VaultLocalRepositoryPort {
   /**
@@ -9,12 +10,13 @@ export interface VaultLocalRepositoryPort {
    * avoid leaving a partial descriptor/material/recovery-backup/snapshot set
    * when this rejects.
    */
-  saveInitializedLocalVault: (
-    descriptor: LocalVaultDescriptor,
-    deviceAccessMaterial: DeviceAccessMaterial,
-    deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup,
-    snapshot: VaultSnapshot,
-  ) => Promise<void>;
+  saveInitializedLocalVault: (params: {
+    readonly descriptor: LocalVaultDescriptor;
+    readonly deviceAccessMaterial: DeviceAccessMaterial;
+    readonly deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup;
+    readonly snapshot: VaultSnapshot;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+  }) => Promise<void>;
   removePersistedLocalVault: (vaultId: string) => Promise<void>;
 
   saveLocalVaultDescriptor: (descriptor: LocalVaultDescriptor) => Promise<void>;
@@ -48,7 +50,23 @@ export interface VaultLocalRepositoryPort {
   ) => Promise<DeviceAccessRecoveryBackup | null>;
   removeDeviceAccessRecoveryBackup: (vaultId: string) => Promise<void>;
 
-  saveVaultSnapshot: (vaultSnapshot: VaultSnapshot) => Promise<void>;
   getVaultSnapshot: (vaultId: string) => Promise<VaultSnapshot | null>;
   removeVaultSnapshot: (vaultId: string) => Promise<void>;
+
+  /**
+   * Atomically replaces the snapshot and signed rollback checkpoint only when
+   * the persisted snapshot still matches `expectedSnapshotDigest`.
+   */
+  saveVaultSnapshotWithCheckpoint: (params: {
+    readonly expectedSnapshotDigest: string;
+    readonly snapshot: VaultSnapshot;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+  }) => Promise<void>;
+  saveLocalVaultTrustCheckpoint: (
+    checkpoint: LocalVaultTrustCheckpoint,
+  ) => Promise<void>;
+  getLocalVaultTrustCheckpoint: (
+    vaultId: string,
+  ) => Promise<LocalVaultTrustCheckpoint | null>;
+  removeLocalVaultTrustCheckpoint: (vaultId: string) => Promise<void>;
 }

--- a/packages/core/src/ports/vault/vault-local-repository.port.ts
+++ b/packages/core/src/ports/vault/vault-local-repository.port.ts
@@ -62,9 +62,6 @@ export interface VaultLocalRepositoryPort {
     readonly snapshot: VaultSnapshot;
     readonly checkpoint: LocalVaultTrustCheckpoint;
   }) => Promise<void>;
-  saveLocalVaultTrustCheckpoint: (
-    checkpoint: LocalVaultTrustCheckpoint,
-  ) => Promise<void>;
   getLocalVaultTrustCheckpoint: (
     vaultId: string,
   ) => Promise<LocalVaultTrustCheckpoint | null>;

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -3,3 +3,4 @@ export * from "./randomness";
 export * from "./session";
 export * from "./snapshot";
 export * from "./sync";
+export * from "./trust";

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -10,7 +10,10 @@ import {
   UnlockedVaultSessionInvalidError,
   VaultMustBeUnlockedError,
 } from "../../errors/vault-session.errors";
-import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import type {
+  EncryptedUnlockedVaultSessionPayload,
+  UnlockedVaultSessionMaterial,
+} from "../../domain/session/unlocked-vault-session.type";
 import { UnlockedVaultSessionService } from "./unlocked-vault-session.service";
 
 function createContext() {
@@ -47,15 +50,7 @@ function createContext() {
 
 function createMaterial(
   ctx: ReturnType<typeof createContext>,
-  overrides: Partial<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly deviceId: string;
-    readonly vaultMasterKey: typeof ctx.values.vaultMasterKey;
-    readonly devicePrivateSignKey: typeof ctx.values.devicePrivateSignKey;
-    readonly payloadKey: typeof ctx.values.unlockedVaultSessionPayloadKey;
-  }> = {},
+  overrides: Partial<UnlockedVaultSessionMaterial> = {},
 ) {
   return {
     sessionId: ctx.values.sessionId,
@@ -65,18 +60,15 @@ function createMaterial(
     vaultMasterKey: ctx.values.vaultMasterKey,
     devicePrivateSignKey: ctx.values.devicePrivateSignKey,
     payloadKey: ctx.values.unlockedVaultSessionPayloadKey,
+    trustedSnapshotContext: ctx.session.unlockedVault.trustedSnapshotContext,
+    vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
     ...overrides,
   };
 }
 
 function createEncryptedPayload(
   ctx: ReturnType<typeof createContext>,
-  overrides: Partial<{
-    readonly sessionId: string;
-    readonly vaultId: string;
-    readonly sourceSnapshotVersionVector: VersionVector;
-    readonly content: typeof ctx.values.encryptedUnlockedVaultSessionPayload;
-  }> = {},
+  overrides: Partial<EncryptedUnlockedVaultSessionPayload> = {},
 ) {
   return {
     sessionId: ctx.values.sessionId,
@@ -149,6 +141,9 @@ describe("UnlockedVaultSessionService", () => {
         vault: ctx.values.decryptedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext:
+          ctx.session.unlockedVault.trustedSnapshotContext,
+        vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: ctx.sourceSnapshotVersionVector,
     });
@@ -183,6 +178,9 @@ describe("UnlockedVaultSessionService", () => {
         vault: ctx.values.decryptedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext:
+          ctx.session.unlockedVault.trustedSnapshotContext,
+        vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: ctx.sourceSnapshotVersionVector,
     });
@@ -345,6 +343,8 @@ describe("UnlockedVaultSessionService", () => {
       vaultMasterKey: ctx.values.vaultMasterKey,
       devicePrivateSignKey: ctx.values.devicePrivateSignKey,
       payloadKey: ctx.values.unlockedVaultSessionPayloadKey,
+      trustedSnapshotContext: ctx.session.unlockedVault.trustedSnapshotContext,
+      vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
     });
     expect(
       vi.mocked(
@@ -386,6 +386,8 @@ describe("UnlockedVaultSessionService", () => {
       vaultMasterKey: ctx.values.vaultMasterKey,
       devicePrivateSignKey: ctx.values.devicePrivateSignKey,
       payloadKey: ctx.values.unlockedVaultSessionPayloadKey,
+      trustedSnapshotContext: ctx.session.unlockedVault.trustedSnapshotContext,
+      vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
     });
   });
 

--- a/packages/core/src/services/session/unlocked-vault-session.service.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.ts
@@ -1,10 +1,11 @@
-import type { SerializedEncrypted } from "../../domain/crypto/protected-artifact";
-import type { DevicePrivateSignKey } from "../../domain/device-trust/brand-keys";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
-import type { UnlockedVaultSessionPayloadKey } from "../../domain/session/unlocked-vault-session-payload-key";
-import type { VaultMasterKey } from "../../domain/snapshot/brand-keys";
-import type { Vault } from "../../domain/vault/vault";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import type {
+  EncryptedUnlockedVaultSessionPayload,
+  UnlockedVaultSession,
+  UnlockedVaultSessionMaterial,
+} from "../../domain/session/unlocked-vault-session.type";
+import type { Vault } from "../../domain/vault/vault";
 import { compareVersionVectors } from "../../domain/versioning/version-vector.utils";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { IdPort } from "../../ports/system/id.port";
@@ -46,10 +47,7 @@ export class UnlockedVaultSessionService {
     }
   }
 
-  async get(): Promise<{
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  } | null> {
+  async get(): Promise<UnlockedVaultSession | null> {
     const material =
       await this.materialRepository.getUnlockedVaultSessionMaterial();
 
@@ -72,10 +70,7 @@ export class UnlockedVaultSessionService {
   async requireUnlockedVaultContext(
     vaultId: string,
     operation: string,
-  ): Promise<{
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  }> {
+  ): Promise<UnlockedVaultSession> {
     const unlockedVaultSession = await this.get();
 
     if (
@@ -139,10 +134,7 @@ export class UnlockedVaultSessionService {
     }
   }
 
-  private async save(session: {
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  }): Promise<void> {
+  private async save(session: UnlockedVaultSession): Promise<void> {
     const activeMaterial =
       await this.materialRepository.getUnlockedVaultSessionMaterial();
     const incomingVaultId = session.unlockedVault.vaultId;
@@ -173,32 +165,14 @@ export class UnlockedVaultSessionService {
   }
 
   private async protect(
-    session: {
-      readonly unlockedVault: UnlockedVault;
-      readonly sourceSnapshotVersionVector: VersionVector;
-    },
-    activeMaterial?: {
-      readonly sessionId: string;
-      readonly payloadKey: UnlockedVaultSessionPayloadKey;
-    },
+    session: UnlockedVaultSession,
+    activeMaterial?: Pick<
+      UnlockedVaultSessionMaterial,
+      "sessionId" | "payloadKey"
+    >,
   ): Promise<{
-    readonly material: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-      readonly deviceId: string;
-      readonly vaultMasterKey: VaultMasterKey;
-      readonly devicePrivateSignKey: DevicePrivateSignKey;
-      readonly payloadKey: UnlockedVaultSessionPayloadKey;
-    };
-    readonly encryptedPayload: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-      readonly content: SerializedEncrypted<{
-        readonly vault: Vault;
-      }>;
-    };
+    readonly material: UnlockedVaultSessionMaterial;
+    readonly encryptedPayload: EncryptedUnlockedVaultSessionPayload;
   }> {
     const sessionId =
       activeMaterial?.sessionId ?? (await this.ids.generateId());
@@ -225,6 +199,8 @@ export class UnlockedVaultSessionService {
         deviceId: unlockedVault.deviceId,
         vaultMasterKey: unlockedVault.vaultMasterKey,
         devicePrivateSignKey: unlockedVault.devicePrivateSignKey,
+        trustedSnapshotContext: unlockedVault.trustedSnapshotContext,
+        vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
         payloadKey,
       },
       encryptedPayload: {
@@ -235,27 +211,9 @@ export class UnlockedVaultSessionService {
   }
 
   private async restore(
-    material: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-      readonly deviceId: string;
-      readonly vaultMasterKey: VaultMasterKey;
-      readonly devicePrivateSignKey: DevicePrivateSignKey;
-      readonly payloadKey: UnlockedVaultSessionPayloadKey;
-    },
-    encryptedPayload: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-      readonly content: SerializedEncrypted<{
-        readonly vault: Vault;
-      }>;
-    },
-  ): Promise<{
-    readonly unlockedVault: UnlockedVault;
-    readonly sourceSnapshotVersionVector: VersionVector;
-  }> {
+    material: UnlockedVaultSessionMaterial,
+    encryptedPayload: EncryptedUnlockedVaultSessionPayload,
+  ): Promise<UnlockedVaultSession> {
     this.requireMatchingSessionRecords(material, encryptedPayload);
 
     const context = {
@@ -288,6 +246,8 @@ export class UnlockedVaultSessionService {
         vault: payload.vault,
         vaultMasterKey: material.vaultMasterKey,
         devicePrivateSignKey: material.devicePrivateSignKey,
+        trustedSnapshotContext: material.trustedSnapshotContext,
+        vaultTrustAnchor: material.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: encryptedPayload.sourceSnapshotVersionVector,
     };
@@ -302,16 +262,14 @@ export class UnlockedVaultSessionService {
   }
 
   private requireMatchingSessionRecords(
-    material: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-    },
-    encryptedPayload: {
-      readonly sessionId: string;
-      readonly vaultId: string;
-      readonly sourceSnapshotVersionVector: VersionVector;
-    },
+    material: Pick<
+      UnlockedVaultSessionMaterial,
+      "sessionId" | "vaultId" | "sourceSnapshotVersionVector"
+    >,
+    encryptedPayload: Pick<
+      EncryptedUnlockedVaultSessionPayload,
+      "sessionId" | "vaultId" | "sourceSnapshotVersionVector"
+    >,
   ): void {
     if (
       material.sessionId !== encryptedPayload.sessionId ||

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -887,6 +887,36 @@ describe("VaultSnapshotService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("fails when the current device is absent from the effective trust state", async () => {
+    const ctx = createContext();
+    const unlockedVault = {
+      ...ctx.unlockedVault,
+      trustedSnapshotContext: {
+        ...ctx.unlockedVault.trustedSnapshotContext,
+        trust: {
+          ...ctx.unlockedVault.trustedSnapshotContext.trust,
+          trustedDevices:
+            ctx.unlockedVault.trustedSnapshotContext.trust.trustedDevices.filter(
+              (device) => device.deviceId !== ctx.values.deviceId,
+            ),
+        },
+      },
+    };
+
+    await expect(
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        unlockedVault,
+        ctx.currentSnapshot.metadata.snapshotVersionVector,
+      ),
+    ).rejects.toThrow(SnapshotSigningDeviceNotTrustedError);
+
+    expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
   it("does not save a snapshot when content encryption fails", async () => {
     const ctx = createContext();
     const error = new Error("encryption failed");

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -33,15 +33,31 @@ describe("VaultSnapshotService", () => {
       ports.clock,
       ports.vaultLocalRepository,
     );
-    const unlockedVault = createUnlockedVaultWithEntries(
+    const baseUnlockedVault = createUnlockedVaultWithEntries(
       values,
       [singlePasswordEntry],
       [workTag],
     );
+    const unlockedVault = {
+      ...baseUnlockedVault,
+      trustedSnapshotContext: {
+        ...baseUnlockedVault.trustedSnapshotContext,
+        trust: {
+          ...baseUnlockedVault.trustedSnapshotContext.trust,
+          trustedDevices: [
+            ...baseUnlockedVault.trustedSnapshotContext.trust.trustedDevices,
+            {
+              deviceId: previousDeviceId,
+              publicSignKey: values.devicePublicSignKey,
+            },
+          ],
+        },
+      },
+    };
     const currentSnapshot: VaultSnapshot = {
       metadata: {
         id: values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: values.timestamp - 1_000,
         revisionTimestamp: values.timestamp - 500,
         snapshotVersionVector: {
@@ -50,6 +66,7 @@ describe("VaultSnapshotService", () => {
         algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
         createdByDeviceId: previousDeviceId,
       },
+      trustChain: values.vaultTrustChain,
       keySlots: {
         deviceSlots: [
           {
@@ -94,6 +111,11 @@ describe("VaultSnapshotService", () => {
         [ctx.values.deviceId]: 4,
       },
       revisionTimestamp: ctx.values.timestamp,
+      trustedSnapshotContext: {
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+        trust: ctx.unlockedVault.trustedSnapshotContext.trust,
+      },
+      snapshot: ctx.saved.vaultSnapshot,
     });
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).toHaveBeenCalledWith(
       ctx.unlockedVault.vault,
@@ -111,6 +133,7 @@ describe("VaultSnapshotService", () => {
         },
         keySlots: ctx.currentSnapshot.keySlots,
         content: ctx.values.encryptedVault,
+        trustChain: ctx.currentSnapshot.trustChain,
       },
       ctx.values.devicePrivateSignKey,
     );
@@ -125,6 +148,7 @@ describe("VaultSnapshotService", () => {
       },
       keySlots: ctx.currentSnapshot.keySlots,
       content: ctx.values.encryptedVault,
+      trustChain: ctx.currentSnapshot.trustChain,
       signature: ctx.values.snapshotSignature,
     });
   });
@@ -143,7 +167,7 @@ describe("VaultSnapshotService", () => {
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -708,7 +732,7 @@ describe("VaultSnapshotService", () => {
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -727,7 +751,7 @@ describe("VaultSnapshotService", () => {
       ctx.ports.vaultLocalRepository.getVaultSnapshot,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -745,7 +769,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -760,7 +784,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -784,7 +808,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -813,7 +837,7 @@ describe("VaultSnapshotService", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -833,7 +857,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -859,7 +883,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -881,7 +905,7 @@ describe("VaultSnapshotService", () => {
 
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -904,7 +928,7 @@ describe("VaultSnapshotService", () => {
       ctx.values.vaultMasterKey,
     );
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/services/snapshot/vault-snapshot.service.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.ts
@@ -84,10 +84,24 @@ export class VaultSnapshotService {
       throw new VaultTrustStateInvalidError(vaultId, "trust chain is missing");
     }
 
+    const trustedSigningDevice = trustState.trustedDevices.find(
+      (device) => device.deviceId === unlockedVault.deviceId,
+    );
+    const signingDeviceSlot = keySlots.deviceSlots.find(
+      (deviceSlot) => deviceSlot.deviceId === unlockedVault.deviceId,
+    );
+
     if (
-      !keySlots.deviceSlots.some(
-        (deviceSlot) => deviceSlot.deviceId === unlockedVault.deviceId,
-      )
+      trustedSigningDevice === undefined ||
+      signingDeviceSlot === undefined ||
+      !(await this.crypto.verifyDeviceSignKeyPair(
+        trustedSigningDevice.publicSignKey,
+        unlockedVault.devicePrivateSignKey,
+      )) ||
+      !(await this.crypto.verifyDeviceSignKeyPair(
+        signingDeviceSlot.publicSignKey,
+        unlockedVault.devicePrivateSignKey,
+      ))
     ) {
       throw new SnapshotSigningDeviceNotTrustedError(
         vaultId,

--- a/packages/core/src/services/snapshot/vault-snapshot.service.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.ts
@@ -24,21 +24,23 @@ import {
   SnapshotSigningDeviceNotTrustedError,
   VaultSnapshotVersionMismatchError,
 } from "../../errors/vault-snapshot.errors";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import {
   compareVersionVectors,
   incrementVersionVector,
 } from "../../domain/versioning/version-vector.utils";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
-
-export type OpenTrustedVaultSnapshotResult = {
-  readonly vault: Vault;
-  readonly completedEnrollmentProof: CompletedDeviceEnrollmentProof | null;
-};
+import type {
+  VaultTrustChain,
+  VerifiedVaultTrustState,
+} from "../../domain/device-trust";
+import { VaultTrustService } from "../trust/vault-trust.service";
 
 export class VaultSnapshotService {
   private readonly crypto: CryptoPort;
   private readonly clock: ClockPort;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     crypto: CryptoPort,
@@ -48,6 +50,7 @@ export class VaultSnapshotService {
     this.crypto = crypto;
     this.clock = clock;
     this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async persistUnlockedVault(
@@ -57,11 +60,12 @@ export class VaultSnapshotService {
     options: {
       readonly baseSnapshotVersionVector?: VersionVector;
       readonly keySlots?: UnsignedVaultSnapshot["keySlots"];
+      readonly nextTrust?: {
+        readonly chain: VaultTrustChain;
+        readonly state: VerifiedVaultTrustState;
+      };
     } = {},
-  ): Promise<{
-    readonly snapshotVersionVector: VersionVector;
-    readonly revisionTimestamp: number;
-  }> {
+  ) {
     const currentVaultSnapshot =
       await this.requireCurrentSnapshotForUnlockedVault(
         vaultId,
@@ -71,6 +75,14 @@ export class VaultSnapshotService {
 
     const revisionTimestamp = this.clock.now();
     const keySlots = options.keySlots ?? currentVaultSnapshot.keySlots;
+    const trustChain =
+      options.nextTrust?.chain ?? currentVaultSnapshot.trustChain;
+    const trustState =
+      options.nextTrust?.state ?? unlockedVault.trustedSnapshotContext.trust;
+
+    if (trustChain === undefined) {
+      throw new VaultTrustStateInvalidError(vaultId, "trust chain is missing");
+    }
 
     if (
       !keySlots.deviceSlots.some(
@@ -94,6 +106,7 @@ export class VaultSnapshotService {
         ),
         createdByDeviceId: unlockedVault.deviceId,
       },
+      trustChain,
       keySlots,
       content: await this.crypto.encryptVaultSnapshotContent(
         unlockedVault.vault,
@@ -109,11 +122,29 @@ export class VaultSnapshotService {
       ),
     };
 
-    await this.vaultLocalRepository.saveVaultSnapshot(vaultSnapshot);
+    const snapshotDigest = await this.crypto.digestVaultSnapshot(vaultSnapshot);
+    const checkpoint = await this.vaultTrust.createCheckpoint(
+      vaultSnapshot,
+      trustState,
+      unlockedVault.deviceId,
+      unlockedVault.devicePrivateSignKey,
+    );
+
+    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest:
+        unlockedVault.trustedSnapshotContext.snapshotDigest,
+      snapshot: vaultSnapshot,
+      checkpoint,
+    });
 
     return {
       snapshotVersionVector: vaultSnapshot.metadata.snapshotVersionVector,
       revisionTimestamp: vaultSnapshot.metadata.revisionTimestamp,
+      trustedSnapshotContext: {
+        snapshotDigest,
+        trust: trustState,
+      },
+      snapshot: vaultSnapshot,
     };
   }
 
@@ -128,8 +159,58 @@ export class VaultSnapshotService {
     return vaultSnapshot;
   }
 
-  async restoreLocalVaultSnapshot(vaultSnapshot: VaultSnapshot): Promise<void> {
-    await this.vaultLocalRepository.saveVaultSnapshot(vaultSnapshot);
+  async verifyCandidateSnapshotTrust(
+    vaultId: string,
+    vaultSnapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
+  ): Promise<{
+    readonly chain: VaultTrustChain;
+    readonly state: VerifiedVaultTrustState;
+  }> {
+    this.requireSupportedSnapshotAlgorithm(vaultId, vaultSnapshot);
+
+    if (vaultSnapshot.metadata.id !== vaultId) {
+      throw new PersistedVaultMismatchError(vaultId, vaultSnapshot.metadata.id);
+    }
+
+    const chain = vaultSnapshot.trustChain;
+
+    if (chain === undefined) {
+      throw new VaultTrustStateInvalidError(vaultId, "trust chain is missing");
+    }
+
+    const state = await this.vaultTrust.verifyTrustChain(
+      vaultId,
+      unlockedVault.vaultTrustAnchor,
+      chain,
+    );
+    await this.vaultTrust.requireTrustDescendsFrom(
+      vaultId,
+      chain,
+      state,
+      unlockedVault.trustedSnapshotContext.trust,
+    );
+    await this.vaultTrust.verifySnapshot(vaultId, vaultSnapshot, state);
+
+    return { chain, state };
+  }
+
+  async restoreLocalVaultSnapshot(
+    vaultSnapshot: VaultSnapshot,
+    replacedSnapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
+  ): Promise<void> {
+    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest:
+        await this.crypto.digestVaultSnapshot(replacedSnapshot),
+      snapshot: vaultSnapshot,
+      checkpoint: await this.vaultTrust.createCheckpoint(
+        vaultSnapshot,
+        unlockedVault.trustedSnapshotContext.trust,
+        unlockedVault.deviceId,
+        unlockedVault.devicePrivateSignKey,
+      ),
+    });
   }
 
   async openTrustedVaultSnapshot(
@@ -153,7 +234,7 @@ export class VaultSnapshotService {
     vaultSnapshot: VaultSnapshot,
     vaultMasterKey: VaultMasterKey,
     trustSourceSnapshot: Pick<VaultSnapshot, "keySlots">,
-  ): Promise<OpenTrustedVaultSnapshotResult> {
+  ) {
     this.requireSupportedSnapshotAlgorithm(vaultId, vaultSnapshot);
 
     if (vaultSnapshot.metadata.id !== vaultId) {
@@ -209,10 +290,24 @@ export class VaultSnapshotService {
     }
 
     this.requireSupportedSnapshotAlgorithm(vaultId, currentVaultSnapshot);
-    await this.requireTrustedSnapshotSignature(
+    const currentSnapshotDigest =
+      await this.crypto.digestVaultSnapshot(currentVaultSnapshot);
+
+    if (
+      currentSnapshotDigest !==
+      unlockedVault.trustedSnapshotContext.snapshotDigest
+    ) {
+      throw new VaultSnapshotVersionMismatchError(
+        vaultId,
+        sourceSnapshotVersionVector,
+        currentVaultSnapshot.metadata.snapshotVersionVector,
+      );
+    }
+
+    await this.vaultTrust.verifySnapshot(
       vaultId,
       currentVaultSnapshot,
-      currentVaultSnapshot,
+      unlockedVault.trustedSnapshotContext.trust,
     );
 
     const trustedDevice = currentVaultSnapshot.keySlots.deviceSlots.find(
@@ -375,6 +470,13 @@ export class VaultSnapshotService {
     vaultId: string,
     vaultSnapshot: VaultSnapshot,
   ): void {
+    if (vaultSnapshot.metadata.schemaVersion !== 2) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "unsupported snapshot schema version",
+      );
+    }
+
     if (
       vaultSnapshot.metadata.algorithmSuiteId !== this.crypto.algorithmSuite.id
     ) {

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -18,12 +18,6 @@ import {
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultSnapshotService } from "../snapshot/vault-snapshot.service";
 
-export type LocalMutationSyncState = {
-  readonly localSnapshot: VaultSnapshot;
-  readonly syncConfig?: SyncConfig;
-  readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
-};
-
 export class VaultSyncGuardService {
   private readonly syncProvider: SyncProviderPort;
   private readonly vaultSnapshot: VaultSnapshotService;
@@ -54,7 +48,11 @@ export class VaultSyncGuardService {
     vaultId: string,
     unlockedVault: UnlockedVault,
     sourceSnapshotVersionVector: VersionVector,
-  ): Promise<LocalMutationSyncState> {
+  ): Promise<{
+    readonly localSnapshot: VaultSnapshot;
+    readonly syncConfig?: SyncConfig;
+    readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
+  }> {
     const localSnapshot =
       await this.vaultSnapshot.requireCurrentSnapshotForUnlockedVault(
         vaultId,
@@ -115,8 +113,13 @@ export class VaultSyncGuardService {
 
   async uploadPersistedLocalMutation(
     vaultId: string,
-    syncState: LocalMutationSyncState,
+    syncState: {
+      readonly localSnapshot: VaultSnapshot;
+      readonly syncConfig?: SyncConfig;
+      readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
+    },
     persistedSnapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
   ): Promise<void> {
     if (
       syncState.syncConfig === undefined ||
@@ -135,6 +138,8 @@ export class VaultSyncGuardService {
       try {
         await this.vaultSnapshot.restoreLocalVaultSnapshot(
           syncState.localSnapshot,
+          persistedSnapshot,
+          unlockedVault,
         );
       } catch {
         // Preserve the upload failure as the root cause.
@@ -153,6 +158,7 @@ export class VaultSyncGuardService {
     syncConfig: SyncConfig,
     localSnapshot: VaultSnapshot,
     persistedSnapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
   ): Promise<void> {
     try {
       await this.syncProvider.uploadVaultSnapshot(
@@ -162,7 +168,11 @@ export class VaultSyncGuardService {
       );
     } catch (error) {
       try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(localSnapshot);
+        await this.vaultSnapshot.restoreLocalVaultSnapshot(
+          localSnapshot,
+          persistedSnapshot,
+          unlockedVault,
+        );
       } catch {
         // Preserve the upload failure as the root cause.
       }

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -16,18 +16,22 @@ import {
   SyncConflictDetectedError,
 } from "../../errors/sync.errors";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
+import type { UnlockedVaultSessionService } from "../session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../snapshot/vault-snapshot.service";
 
 export class VaultSyncGuardService {
   private readonly syncProvider: SyncProviderPort;
   private readonly vaultSnapshot: VaultSnapshotService;
+  private readonly unlockedVaultSession: UnlockedVaultSessionService;
 
   constructor(
     syncProvider: SyncProviderPort,
     vaultSnapshot: VaultSnapshotService,
+    unlockedVaultSession: UnlockedVaultSessionService,
   ) {
     this.syncProvider = syncProvider;
     this.vaultSnapshot = vaultSnapshot;
+    this.unlockedVaultSession = unlockedVaultSession;
   }
 
   async requireReadyForLocalMutation(
@@ -61,7 +65,10 @@ export class VaultSyncGuardService {
       );
     const syncConfig = unlockedVault.vault.syncConfig;
 
-    if (syncConfig === undefined) {
+    if (
+      syncConfig === undefined ||
+      unlockedVault.vault.syncRemovalPending === true
+    ) {
       return {
         localSnapshot,
       };
@@ -142,7 +149,11 @@ export class VaultSyncGuardService {
           unlockedVault,
         );
       } catch {
-        // Preserve the upload failure as the root cause.
+        try {
+          await this.unlockedVaultSession.remove();
+        } catch {
+          // Preserve the upload failure as the root cause.
+        }
       }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
@@ -174,7 +185,11 @@ export class VaultSyncGuardService {
           unlockedVault,
         );
       } catch {
-        // Preserve the upload failure as the root cause.
+        try {
+          await this.unlockedVaultSession.remove();
+        } catch {
+          // Preserve the upload failure as the root cause.
+        }
       }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {

--- a/packages/core/src/services/trust/index.ts
+++ b/packages/core/src/services/trust/index.ts
@@ -1,0 +1,1 @@
+export * from "./vault-trust.service";

--- a/packages/core/src/services/trust/vault-trust.service.test.ts
+++ b/packages/core/src/services/trust/vault-trust.service.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import { bytes, createCoreTestValues } from "../../__tests__/fixtures/values";
+import type { DevicePublicSignKey } from "../../domain/device-trust";
+import type { VaultSnapshot } from "../../domain/snapshot";
+import {
+  VaultSnapshotRollbackDetectedError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
+import { VaultSnapshotSignerNotTrustedError } from "../../errors/unlock-vault.errors";
+import { VaultTrustService } from "./vault-trust.service";
+
+function createContext() {
+  const values = createCoreTestValues();
+  const ports = createCoreTestPorts(values);
+  const service = new VaultTrustService(ports.crypto);
+  const snapshot: VaultSnapshot = {
+    metadata: {
+      id: values.vaultId,
+      schemaVersion: 2,
+      vaultCreationTimestamp: values.timestamp,
+      revisionTimestamp: values.timestamp,
+      snapshotVersionVector: { [values.deviceId]: 1 },
+      algorithmSuiteId: ports.crypto.algorithmSuite.id,
+      createdByDeviceId: values.deviceId,
+    },
+    trustChain: values.vaultTrustChain,
+    keySlots: {
+      deviceSlots: [
+        {
+          deviceId: values.deviceId,
+          publicSignKey: values.devicePublicSignKey,
+          protectedVaultMasterKey: values.protectedDeviceVaultMasterKey,
+        },
+      ],
+    },
+    content: values.encryptedVault,
+    signature: values.snapshotSignature,
+  };
+
+  return { values, ports, service, snapshot };
+}
+
+describe("VaultTrustService", () => {
+  it("verifies a certificate chain rooted in the protected local anchor", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.service.verifyTrustChain(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustAnchor,
+        ctx.values.vaultTrustChain,
+      ),
+    ).resolves.toEqual(ctx.values.verifiedVaultTrustState);
+
+    expect(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).toHaveBeenCalledWith(
+      ctx.values.vaultTrustCertificate,
+      ctx.values.devicePublicSignKey,
+    );
+  });
+
+  it("rejects an attacker signer added only to the candidate snapshot", async () => {
+    const ctx = createContext();
+    const attackerPublicKey = bytes<DevicePublicSignKey>();
+    const attackerSnapshot: VaultSnapshot = {
+      ...ctx.snapshot,
+      metadata: {
+        ...ctx.snapshot.metadata,
+        createdByDeviceId: "attacker-device",
+      },
+      keySlots: {
+        ...ctx.snapshot.keySlots,
+        deviceSlots: [
+          ...ctx.snapshot.keySlots.deviceSlots,
+          {
+            deviceId: "attacker-device",
+            publicSignKey: attackerPublicKey,
+            protectedVaultMasterKey: ctx.values.protectedDeviceVaultMasterKey,
+          },
+        ],
+      },
+    };
+
+    await expect(
+      ctx.service.verifySnapshot(
+        ctx.values.vaultId,
+        attackerSnapshot,
+        ctx.values.verifiedVaultTrustState,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotSignerNotTrustedError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultSnapshotSignature,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a disconnected trust transition", async () => {
+    const ctx = createContext();
+    const disconnectedCertificate = {
+      ...ctx.values.vaultTrustCertificate,
+      payload: {
+        ...ctx.values.vaultTrustCertificate.payload,
+        generation: 1,
+        previousCertificateDigest: "unrelated-certificate",
+      },
+    };
+
+    await expect(
+      ctx.service.verifyTrustChain(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustAnchor,
+        {
+          ...ctx.values.vaultTrustChain,
+          certificates: [
+            ctx.values.vaultTrustCertificate,
+            disconnectedCertificate,
+          ],
+        },
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+  });
+
+  it("rejects a valid old snapshot when the signed checkpoint is newer", async () => {
+    const ctx = createContext();
+    const newerCheckpoint = {
+      ...ctx.values.localVaultTrustCheckpoint,
+      payload: {
+        ...ctx.values.localVaultTrustCheckpoint.payload,
+        snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+      },
+    };
+
+    await expect(
+      ctx.service.requireSnapshotNotRolledBack(
+        ctx.values.vaultId,
+        ctx.snapshot,
+        ctx.values.verifiedVaultTrustState,
+        newerCheckpoint,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+  });
+
+  it("rejects an equal vector whose signed snapshot digest changed", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.crypto.digestVaultSnapshot).mockResolvedValueOnce(
+      "different-snapshot-digest",
+    );
+
+    await expect(
+      ctx.service.requireSnapshotNotRolledBack(
+        ctx.values.vaultId,
+        ctx.snapshot,
+        ctx.values.verifiedVaultTrustState,
+        ctx.values.localVaultTrustCheckpoint,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+  });
+
+  it("rejects a newer trust fork that does not contain the local trust checkpoint", async () => {
+    const ctx = createContext();
+    const forkCertificate = {
+      ...ctx.values.vaultTrustCertificate,
+      payload: {
+        ...ctx.values.vaultTrustCertificate.payload,
+        generation: 1,
+        previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
+      },
+    };
+    vi.mocked(
+      ctx.ports.crypto.digestVaultTrustCertificate,
+    ).mockResolvedValueOnce("fork-certificate-digest");
+
+    await expect(
+      ctx.service.requireTrustDescendsFrom(
+        ctx.values.vaultId,
+        {
+          ...ctx.values.vaultTrustChain,
+          certificates: [ctx.values.vaultTrustCertificate, forkCertificate],
+        },
+        {
+          ...ctx.values.verifiedVaultTrustState,
+          generation: 1,
+          certificateDigest: "fork-certificate-digest",
+        },
+        {
+          generation: 1,
+          certificateDigest: "locally-checkpointed-certificate-digest",
+        },
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+  });
+});

--- a/packages/core/src/services/trust/vault-trust.service.test.ts
+++ b/packages/core/src/services/trust/vault-trust.service.test.ts
@@ -96,6 +96,48 @@ describe("VaultTrustService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("rejects a snapshot that belongs to another vault", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.service.verifySnapshot(
+        ctx.values.vaultId,
+        {
+          ...ctx.snapshot,
+          metadata: {
+            ...ctx.snapshot.metadata,
+            id: "another-vault-id",
+          },
+        },
+        ctx.values.verifiedVaultTrustState,
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultSnapshotSignature,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a trust transition signed by a key other than its authorizer", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.crypto.verifyDeviceSignKeyPair).mockResolvedValueOnce(
+      false,
+    );
+
+    await expect(
+      ctx.service.appendTrustTransition(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustChain,
+        ctx.values.verifiedVaultTrustState,
+        ctx.values.verifiedVaultTrustState.trustedDevices,
+        ctx.values.deviceId,
+        ctx.values.devicePrivateSignKey,
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(ctx.ports.crypto.signVaultTrustCertificate).not.toHaveBeenCalled();
+  });
+
   it("rejects a disconnected trust transition", async () => {
     const ctx = createContext();
     const disconnectedCertificate = {

--- a/packages/core/src/services/trust/vault-trust.service.ts
+++ b/packages/core/src/services/trust/vault-trust.service.ts
@@ -204,6 +204,18 @@ export class VaultTrustService {
       );
     }
 
+    if (
+      !(await this.crypto.verifyDeviceSignKeyPair(
+        authorizer.publicSignKey,
+        privateKey,
+      ))
+    ) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "authorizer private key mismatch",
+      );
+    }
+
     const latestCertificate = chain.certificates.at(-1);
 
     if (
@@ -254,6 +266,10 @@ export class VaultTrustService {
     snapshot: VaultSnapshot,
     trust: VerifiedVaultTrustState,
   ): Promise<void> {
+    if (snapshot.metadata.id !== vaultId) {
+      throw new VaultTrustStateInvalidError(vaultId, "snapshot vault mismatch");
+    }
+
     if (snapshot.metadata.schemaVersion !== 2) {
       throw new VaultTrustStateInvalidError(
         vaultId,

--- a/packages/core/src/services/trust/vault-trust.service.ts
+++ b/packages/core/src/services/trust/vault-trust.service.ts
@@ -1,0 +1,442 @@
+import type {
+  LocalVaultTrustAnchor,
+  LocalVaultTrustCheckpoint,
+  DeviceTrustIdentity,
+  VaultTrustCertificate,
+  VaultTrustChain,
+  VerifiedVaultTrustState,
+} from "../../domain/device-trust";
+import type { DevicePrivateSignKey } from "../../domain/device-trust/brand-keys";
+import type { VaultSnapshot } from "../../domain/snapshot";
+import { compareVersionVectors } from "../../domain/versioning/version-vector.utils";
+import {
+  LocalVaultTrustCheckpointInvalidError,
+  VaultSnapshotRollbackDetectedError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
+import {
+  VaultSnapshotSignatureVerificationFailedError,
+  VaultSnapshotSignerNotTrustedError,
+} from "../../errors/unlock-vault.errors";
+import type { CryptoPort } from "../../ports/crypto/crypto.port";
+
+export class VaultTrustService {
+  private readonly crypto: CryptoPort;
+
+  constructor(crypto: CryptoPort) {
+    this.crypto = crypto;
+  }
+
+  async createGenesis(
+    vaultId: string,
+    device: DeviceTrustIdentity,
+    privateKey: DevicePrivateSignKey,
+  ): Promise<{
+    readonly anchor: LocalVaultTrustAnchor;
+    readonly chain: VaultTrustChain;
+    readonly trust: VerifiedVaultTrustState;
+  }> {
+    const payload = {
+      version: 1,
+      vaultId,
+      generation: 0,
+      previousCertificateDigest: null,
+      authorizedByDeviceId: device.deviceId,
+      trustedDevices: [device],
+    } as const;
+    const certificate: VaultTrustCertificate = {
+      payload,
+      signature: await this.crypto.signVaultTrustCertificate(
+        payload,
+        privateKey,
+      ),
+    };
+    const certificateDigest =
+      await this.crypto.digestVaultTrustCertificate(certificate);
+
+    return {
+      anchor: {
+        version: 1,
+        vaultId,
+        genesisDeviceId: device.deviceId,
+        genesisPublicSignKey: device.publicSignKey,
+        genesisCertificateDigest: certificateDigest,
+      },
+      chain: {
+        certificates: [certificate],
+      },
+      trust: {
+        generation: 0,
+        certificateDigest,
+        trustedDevices: [device],
+      },
+    };
+  }
+
+  async verifyTrustChain(
+    vaultId: string,
+    anchor: LocalVaultTrustAnchor,
+    chain: VaultTrustChain,
+  ): Promise<VerifiedVaultTrustState> {
+    if (anchor.vaultId !== vaultId || anchor.version !== 1) {
+      throw new VaultTrustStateInvalidError(vaultId, "anchor mismatch");
+    }
+
+    if (chain.certificates.length === 0) {
+      throw new VaultTrustStateInvalidError(vaultId, "genesis mismatch");
+    }
+
+    let previous: {
+      readonly certificate: VaultTrustCertificate;
+      readonly digest: string;
+    } | null = null;
+
+    for (const certificate of chain.certificates) {
+      this.requireValidDeviceIdentities(vaultId, certificate);
+      await this.requireUniquePublicKeys(vaultId, certificate);
+
+      if (certificate.payload.vaultId !== vaultId) {
+        throw new VaultTrustStateInvalidError(
+          vaultId,
+          "certificate vault mismatch",
+        );
+      }
+
+      const digest = await this.crypto.digestVaultTrustCertificate(certificate);
+
+      if (previous === null) {
+        if (
+          certificate.payload.generation !== 0 ||
+          certificate.payload.previousCertificateDigest !== null ||
+          certificate.payload.authorizedByDeviceId !== anchor.genesisDeviceId ||
+          digest !== anchor.genesisCertificateDigest
+        ) {
+          throw new VaultTrustStateInvalidError(
+            vaultId,
+            "invalid genesis certificate",
+          );
+        }
+
+        const genesisIdentity = certificate.payload.trustedDevices.find(
+          (device) => device.deviceId === anchor.genesisDeviceId,
+        );
+
+        if (
+          genesisIdentity === undefined ||
+          !(await this.arePublicKeysEqual(
+            genesisIdentity.publicSignKey,
+            anchor.genesisPublicSignKey,
+          )) ||
+          !(await this.crypto.verifyVaultTrustCertificateSignature(
+            certificate,
+            anchor.genesisPublicSignKey,
+          ))
+        ) {
+          throw new VaultTrustStateInvalidError(
+            vaultId,
+            "invalid genesis signature",
+          );
+        }
+      } else {
+        if (
+          certificate.payload.generation !==
+            previous.certificate.payload.generation + 1 ||
+          certificate.payload.previousCertificateDigest !== previous.digest
+        ) {
+          throw new VaultTrustStateInvalidError(
+            vaultId,
+            "disconnected certificate chain",
+          );
+        }
+
+        const authorizer = previous.certificate.payload.trustedDevices.find(
+          (device) =>
+            device.deviceId === certificate.payload.authorizedByDeviceId,
+        );
+
+        if (
+          authorizer === undefined ||
+          !(await this.crypto.verifyVaultTrustCertificateSignature(
+            certificate,
+            authorizer.publicSignKey,
+          ))
+        ) {
+          throw new VaultTrustStateInvalidError(
+            vaultId,
+            "unauthorized trust transition",
+          );
+        }
+      }
+
+      previous = { certificate, digest };
+    }
+
+    if (previous === null) {
+      throw new VaultTrustStateInvalidError(vaultId, "empty certificate chain");
+    }
+
+    return {
+      generation: previous.certificate.payload.generation,
+      certificateDigest: previous.digest,
+      trustedDevices: previous.certificate.payload.trustedDevices,
+    };
+  }
+
+  async appendTrustTransition(
+    vaultId: string,
+    chain: VaultTrustChain,
+    currentTrust: VerifiedVaultTrustState,
+    trustedDevices: readonly DeviceTrustIdentity[],
+    authorizedByDeviceId: string,
+    privateKey: DevicePrivateSignKey,
+  ): Promise<{
+    readonly chain: VaultTrustChain;
+    readonly trust: VerifiedVaultTrustState;
+  }> {
+    const authorizer = currentTrust.trustedDevices.find(
+      (device) => device.deviceId === authorizedByDeviceId,
+    );
+
+    if (authorizer === undefined) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "authorizer is not trusted",
+      );
+    }
+
+    const latestCertificate = chain.certificates.at(-1);
+
+    if (
+      latestCertificate === undefined ||
+      (await this.crypto.digestVaultTrustCertificate(latestCertificate)) !==
+        currentTrust.certificateDigest
+    ) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "current trust chain mismatch",
+      );
+    }
+
+    const payload = {
+      version: 1,
+      vaultId,
+      generation: currentTrust.generation + 1,
+      previousCertificateDigest: currentTrust.certificateDigest,
+      authorizedByDeviceId,
+      trustedDevices,
+    } as const;
+    const certificate: VaultTrustCertificate = {
+      payload,
+      signature: await this.crypto.signVaultTrustCertificate(
+        payload,
+        privateKey,
+      ),
+    };
+    this.requireValidDeviceIdentities(vaultId, certificate);
+    await this.requireUniquePublicKeys(vaultId, certificate);
+    const certificateDigest =
+      await this.crypto.digestVaultTrustCertificate(certificate);
+
+    return {
+      chain: {
+        certificates: [...chain.certificates, certificate],
+      },
+      trust: {
+        generation: payload.generation,
+        certificateDigest,
+        trustedDevices,
+      },
+    };
+  }
+
+  async verifySnapshot(
+    vaultId: string,
+    snapshot: VaultSnapshot,
+    trust: VerifiedVaultTrustState,
+  ): Promise<void> {
+    if (snapshot.metadata.schemaVersion !== 2) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "unsupported snapshot schema version",
+      );
+    }
+
+    const signer = trust.trustedDevices.find(
+      (device) => device.deviceId === snapshot.metadata.createdByDeviceId,
+    );
+
+    if (signer === undefined) {
+      throw new VaultSnapshotSignerNotTrustedError(
+        vaultId,
+        snapshot.metadata.createdByDeviceId,
+      );
+    }
+
+    const matchingSlots = snapshot.keySlots.deviceSlots.filter(
+      (slot) => slot.deviceId === signer.deviceId,
+    );
+
+    if (
+      matchingSlots.length !== 1 ||
+      !(await this.arePublicKeysEqual(
+        matchingSlots[0].publicSignKey,
+        signer.publicSignKey,
+      ))
+    ) {
+      throw new VaultSnapshotSignerNotTrustedError(vaultId, signer.deviceId);
+    }
+
+    if (
+      !(await this.crypto.verifyVaultSnapshotSignature(
+        snapshot,
+        signer.publicSignKey,
+      ))
+    ) {
+      throw new VaultSnapshotSignatureVerificationFailedError(vaultId);
+    }
+  }
+
+  async createCheckpoint(
+    snapshot: VaultSnapshot,
+    trust: VerifiedVaultTrustState,
+    deviceId: string,
+    privateKey: DevicePrivateSignKey,
+  ): Promise<LocalVaultTrustCheckpoint> {
+    const payload = {
+      version: 1,
+      vaultId: snapshot.metadata.id,
+      deviceId,
+      trustGeneration: trust.generation,
+      trustCertificateDigest: trust.certificateDigest,
+      snapshotVersionVector: snapshot.metadata.snapshotVersionVector,
+      snapshotDigest: await this.crypto.digestVaultSnapshot(snapshot),
+    } as const;
+
+    return {
+      payload,
+      signature: await this.crypto.signLocalVaultTrustCheckpoint(
+        payload,
+        privateKey,
+      ),
+    };
+  }
+
+  async verifyCheckpoint(
+    vaultId: string,
+    checkpoint: LocalVaultTrustCheckpoint,
+    device: DeviceTrustIdentity,
+  ): Promise<void> {
+    if (
+      checkpoint.payload.vaultId !== vaultId ||
+      checkpoint.payload.deviceId !== device.deviceId ||
+      checkpoint.payload.version !== 1 ||
+      !(await this.crypto.verifyLocalVaultTrustCheckpointSignature(
+        checkpoint,
+        device.publicSignKey,
+      ))
+    ) {
+      throw new LocalVaultTrustCheckpointInvalidError(
+        vaultId,
+        "identity or signature mismatch",
+      );
+    }
+  }
+
+  async requireSnapshotNotRolledBack(
+    vaultId: string,
+    snapshot: VaultSnapshot,
+    trust: VerifiedVaultTrustState,
+    checkpoint: LocalVaultTrustCheckpoint,
+  ): Promise<"same" | "newer"> {
+    const relation = compareVersionVectors(
+      snapshot.metadata.snapshotVersionVector,
+      checkpoint.payload.snapshotVersionVector,
+    );
+    const snapshotDigest = await this.crypto.digestVaultSnapshot(snapshot);
+
+    await this.requireTrustDescendsFrom(vaultId, snapshot.trustChain, trust, {
+      generation: checkpoint.payload.trustGeneration,
+      certificateDigest: checkpoint.payload.trustCertificateDigest,
+    });
+
+    if (
+      relation === "remote_ahead" ||
+      relation === "broken" ||
+      (relation === "equal" &&
+        snapshotDigest !== checkpoint.payload.snapshotDigest)
+    ) {
+      throw new VaultSnapshotRollbackDetectedError(vaultId);
+    }
+
+    return relation === "equal" ? "same" : "newer";
+  }
+
+  async requireTrustDescendsFrom(
+    vaultId: string,
+    chain: VaultTrustChain,
+    trust: VerifiedVaultTrustState,
+    baseline: Pick<VerifiedVaultTrustState, "generation" | "certificateDigest">,
+  ): Promise<void> {
+    if (trust.generation < baseline.generation) {
+      throw new VaultSnapshotRollbackDetectedError(vaultId);
+    }
+
+    const baselineCertificate = chain.certificates[baseline.generation];
+
+    if (
+      baselineCertificate === undefined ||
+      (await this.crypto.digestVaultTrustCertificate(baselineCertificate)) !==
+        baseline.certificateDigest
+    ) {
+      throw new VaultSnapshotRollbackDetectedError(vaultId);
+    }
+  }
+
+  private requireValidDeviceIdentities(
+    vaultId: string,
+    certificate: VaultTrustCertificate,
+  ): void {
+    if (
+      certificate.payload.version !== 1 ||
+      certificate.payload.generation < 0 ||
+      !Number.isSafeInteger(certificate.payload.generation) ||
+      certificate.payload.trustedDevices.length === 0 ||
+      new Set(
+        certificate.payload.trustedDevices.map((device) => device.deviceId),
+      ).size !== certificate.payload.trustedDevices.length
+    ) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "invalid certificate fields",
+      );
+    }
+  }
+
+  private async arePublicKeysEqual(
+    left: DeviceTrustIdentity["publicSignKey"],
+    right: DeviceTrustIdentity["publicSignKey"],
+  ): Promise<boolean> {
+    return (
+      (await this.crypto.digestDevicePublicSignKey(left)) ===
+      (await this.crypto.digestDevicePublicSignKey(right))
+    );
+  }
+
+  private async requireUniquePublicKeys(
+    vaultId: string,
+    certificate: VaultTrustCertificate,
+  ): Promise<void> {
+    const digests = await Promise.all(
+      certificate.payload.trustedDevices.map((device) =>
+        this.crypto.digestDevicePublicSignKey(device.publicSignKey),
+      ),
+    );
+
+    if (new Set(digests).size !== digests.length) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "duplicate trusted device public key",
+      );
+    }
+  }
+}

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
-import {
-  createUnlockedVaultWithEntries,
-  createVaultSnapshotServiceMock,
-} from "../../__tests__/fixtures/vault-entries";
+import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
+import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
+import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { VaultSnapshotDescriptor } from "../../domain/snapshot/vault-snapshot-descriptor.type";
 import { DeviceEnrollmentVaultNotSynchronizedError } from "../../errors/device-enrollment.errors";
 import {
@@ -16,18 +15,50 @@ import {
 import { VaultSnapshotSignatureVerificationFailedError } from "../../errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
 import { VaultSnapshotVersionMismatchError } from "../../errors/vault-snapshot.errors";
+import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { InitializeDeviceEnrollmentUseCase } from "./initialize-device-enrollment";
 
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
-  const vaultSnapshot = createVaultSnapshotServiceMock(values);
+  const vaultSnapshot = new VaultSnapshotService(
+    ports.crypto,
+    ports.clock,
+    ports.vaultLocalRepository,
+  );
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
   );
+  vi.spyOn(vaultSnapshot, "requireCurrentSnapshotForUnlockedVault");
   const unlockedVault = createUnlockedVaultWithEntries(values, []);
+
+  ports.saved.vaultSnapshot = {
+    metadata: {
+      id: values.vaultId,
+      schemaVersion: 2,
+      vaultCreationTimestamp: values.timestamp - 1_000,
+      revisionTimestamp: values.timestamp,
+      snapshotVersionVector: {
+        [values.deviceId]: 1,
+      },
+      algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
+      createdByDeviceId: values.deviceId,
+    },
+    trustChain: values.vaultTrustChain,
+    keySlots: {
+      deviceSlots: [
+        {
+          deviceId: values.deviceId,
+          protectedVaultMasterKey: values.protectedDeviceVaultMasterKey,
+          publicSignKey: values.devicePublicSignKey,
+        },
+      ],
+    },
+    content: values.encryptedVault,
+    signature: values.snapshotSignature,
+  } satisfies VaultSnapshot;
 
   ports.saved.unlockedVaultSession = {
     unlockedVault: {
@@ -67,13 +98,12 @@ function createContext() {
     remoteSnapshotDescriptor,
     vaultSnapshot,
     useCase: new InitializeDeviceEnrollmentUseCase(
-      ports.clock,
       ports.crypto,
       ports.ids,
       ports.syncProvider,
       ports.sessionServices.unlockedVaultSession,
       vaultSyncGuard,
-      ports.vaultLocalRepository,
+      vaultSnapshot,
     ),
   };
 }
@@ -98,9 +128,9 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
           [ctx.values.deviceId]: 2,
         },
         revisionTimestamp: ctx.values.timestamp,
-        snapshotSignerPublicKey: ctx.values.devicePublicSignKey,
         enrollmentSecret: ctx.values.deviceEnrollmentSecret,
         pendingDevicePrivateSignKey: ctx.values.pendingDevicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       snapshotVersionVector: {
         [ctx.values.deviceId]: 2,
@@ -154,10 +184,10 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       initialUnlockedVault?.vault,
       ctx.values.vaultMasterKey,
     );
-    expect(ctx.ports.saved.vaultSnapshot).toEqual({
+    expect(ctx.ports.saved.vaultSnapshot).toMatchObject({
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -191,6 +221,9 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       content: ctx.values.encryptedVault,
       signature: ctx.values.snapshotSignature,
     });
+    expect(
+      ctx.ports.saved.vaultSnapshot?.trustChain?.certificates,
+    ).toHaveLength(2);
     expect(ctx.ports.saved.unlockedVaultSession).toMatchObject({
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 2,
@@ -290,7 +323,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       ctx.ports.crypto.generateDeviceEnrollmentSecret,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -313,7 +346,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       ctx.ports.crypto.generateDeviceEnrollmentSecret,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -342,7 +375,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       ctx.ports.crypto.generateDeviceEnrollmentSecret,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -364,7 +397,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       ctx.ports.crypto.generateDeviceEnrollmentSecret,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -384,7 +417,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).rejects.toBe(commitError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledTimes(2);
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(ctx.ports.saved.vaultSnapshot).toEqual(
@@ -443,9 +476,9 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
-    vi.mocked(ctx.ports.vaultLocalRepository.saveVaultSnapshot)
-      .mockImplementationOnce(async (vaultSnapshot) => {
-        ctx.ports.saved.vaultSnapshot = vaultSnapshot;
+    vi.mocked(ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint)
+      .mockImplementationOnce(async ({ snapshot }) => {
+        ctx.ports.saved.vaultSnapshot = snapshot;
       })
       .mockRejectedValueOnce(rollbackError);
 
@@ -457,20 +490,22 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledTimes(2);
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        metadata: expect.objectContaining({
-          snapshotVersionVector: {
-            [ctx.values.deviceId]: 1,
-          },
-        }),
-        keySlots: expect.not.objectContaining({
-          enrollmentKeySlot: expect.anything(),
+        snapshot: expect.objectContaining({
+          metadata: expect.objectContaining({
+            snapshotVersionVector: {
+              [ctx.values.deviceId]: 1,
+            },
+          }),
+          keySlots: expect.not.objectContaining({
+            enrollmentKeySlot: expect.anything(),
+          }),
         }),
       }),
     );
@@ -515,7 +550,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledTimes(2);
     expect(ctx.ports.saved.vaultSnapshot).toEqual(
       expect.objectContaining({

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -11,6 +11,7 @@ import {
   RemoteVaultSnapshotAheadError,
   SyncConflictDetectedError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import { VaultSnapshotSignatureVerificationFailedError } from "../../errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
@@ -30,6 +31,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
+    ports.sessionServices.unlockedVaultSession,
   );
   vi.spyOn(vaultSnapshot, "requireCurrentSnapshotForUnlockedVault");
   const unlockedVault = createUnlockedVaultWithEntries(values, []);
@@ -281,6 +283,32 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("does not start enrollment while remote cleanup is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.ports.saved.unlockedVaultSession!;
+    ctx.ports.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncRemovalPending: true,
+        },
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        remoteSnapshotDescriptor: ctx.remoteSnapshotDescriptor,
+      }),
+    ).rejects.toBeInstanceOf(SyncRemovalPendingError);
+
+    expect(
+      ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault,
+    ).not.toHaveBeenCalled();
+  });
+
   it("fails when the target vault is not unlocked", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSession = undefined;
@@ -521,11 +549,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
         }),
       }),
     );
-    expect(ctx.ports.saved.unlockedVaultSession).toMatchObject({
-      sourceSnapshotVersionVector: {
-        [ctx.values.deviceId]: 1,
-      },
-    });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
 
   it("preserves sync conflict when session rollback fails", async () => {

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -4,31 +4,22 @@ import {
   toVaultSnapshotDescriptor,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 import type { VaultSnapshotDescriptor } from "../../domain/snapshot/vault-snapshot-descriptor.type";
-import type {
-  UnsignedVaultSnapshot,
-  VaultSnapshot,
-} from "../../domain/snapshot/vault-snapshot";
 import { DeviceEnrollmentVaultNotSynchronizedError } from "../../errors/device-enrollment.errors";
 import {
   RemoteVaultSnapshotChangedError,
   SyncConflictDetectedError,
   SyncNotConfiguredError,
 } from "../../errors/sync.errors";
-import {
-  VaultSnapshotSignatureVerificationFailedError,
-  VaultSnapshotSignerNotTrustedError,
-} from "../../errors/unlock-vault.errors";
-import { SnapshotSigningDeviceNotTrustedError } from "../../errors/vault-snapshot.errors";
-import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { IdPort } from "../../ports/system/id.port";
-import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSyncGuardService } from "../../services/sync";
-import { incrementVersionVector } from "../../domain/versioning/version-vector.utils";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { DeviceEnrollmentAuthorizationPayload } from "../../domain/device-trust";
+import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 
 export type InitializeDeviceEnrollmentCommandParams = {
   readonly vaultId: string;
@@ -42,30 +33,29 @@ export type InitializeDeviceEnrollmentResult = {
 };
 
 export class InitializeDeviceEnrollmentUseCase {
-  private readonly clock: ClockPort;
   private readonly crypto: CryptoPort;
   private readonly ids: IdPort;
   private readonly syncProvider: SyncProviderPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultSyncGuard: VaultSyncGuardService;
-  private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultSnapshot: VaultSnapshotService;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
-    clock: ClockPort,
     crypto: CryptoPort,
     ids: IdPort,
     syncProvider: SyncProviderPort,
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultSyncGuard: VaultSyncGuardService,
-    vaultLocalRepository: VaultLocalRepositoryPort,
+    vaultSnapshot: VaultSnapshotService,
   ) {
-    this.clock = clock;
     this.crypto = crypto;
     this.ids = ids;
     this.syncProvider = syncProvider;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultSyncGuard = vaultSyncGuard;
-    this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultSnapshot = vaultSnapshot;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(
@@ -105,44 +95,34 @@ export class InitializeDeviceEnrollmentUseCase {
       throw new DeviceEnrollmentVaultNotSynchronizedError(params.vaultId);
     }
 
-    const signerDevice = currentVaultSnapshot.keySlots.deviceSlots.find(
-      (deviceSlot) =>
-        deviceSlot.deviceId === currentVaultSnapshot.metadata.createdByDeviceId,
-    );
-
-    if (signerDevice === undefined) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        params.vaultId,
-        currentVaultSnapshot.metadata.createdByDeviceId,
-      );
-    }
-
-    const isSnapshotAuthentic = await this.crypto.verifyVaultSnapshotSignature(
-      currentVaultSnapshot,
-      signerDevice.publicSignKey,
-    );
-
-    if (!isSnapshotAuthentic) {
-      throw new VaultSnapshotSignatureVerificationFailedError(params.vaultId);
-    }
-
-    const currentTrustedDevice = currentVaultSnapshot.keySlots.deviceSlots.find(
-      (deviceSlot) => deviceSlot.deviceId === unlockedVault.deviceId,
-    );
-
-    if (currentTrustedDevice === undefined) {
-      throw new SnapshotSigningDeviceNotTrustedError(
-        params.vaultId,
-        unlockedVault.deviceId,
-      );
-    }
-
-    const revisionTimestamp = this.clock.now();
     const enrollmentSecret = await this.crypto.generateDeviceEnrollmentSecret();
     const enrollmentId = await this.ids.generateId();
     const pendingDeviceId = await this.ids.generateId();
     const pendingDeviceSignKeyPair =
       await this.crypto.generateDeviceSignKeyPair();
+    const currentTrustChain = currentVaultSnapshot.trustChain;
+
+    if (currentTrustChain === undefined) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "trust chain is missing",
+      );
+    }
+
+    const nextTrust = await this.vaultTrust.appendTrustTransition(
+      params.vaultId,
+      currentTrustChain,
+      unlockedVault.trustedSnapshotContext.trust,
+      [
+        ...unlockedVault.trustedSnapshotContext.trust.trustedDevices,
+        {
+          deviceId: pendingDeviceId,
+          publicSignKey: pendingDeviceSignKeyPair.publicKey,
+        },
+      ],
+      unlockedVault.deviceId,
+      unlockedVault.devicePrivateSignKey,
+    );
     const pendingDevicePublicSignKeyDigest =
       await this.crypto.digestDevicePublicSignKey(
         pendingDeviceSignKeyPair.publicKey,
@@ -173,53 +153,53 @@ export class InitializeDeviceEnrollmentUseCase {
         enrollmentAuthorization,
         unlockedVault.devicePrivateSignKey,
       );
-    const unsignedVaultSnapshot: UnsignedVaultSnapshot = {
-      metadata: {
-        ...currentVaultSnapshot.metadata,
-        id: params.vaultId,
-        revisionTimestamp,
-        snapshotVersionVector: incrementVersionVector(
-          currentVaultSnapshot.metadata.snapshotVersionVector,
-          unlockedVault.deviceId,
-        ),
-        createdByDeviceId: unlockedVault.deviceId,
-      },
-      keySlots: {
-        deviceSlots: currentVaultSnapshot.keySlots.deviceSlots,
-        completedEnrollments:
-          currentVaultSnapshot.keySlots.completedEnrollments,
-        enrollmentKeySlot: {
-          enrollmentId,
-          pendingDeviceId,
-          pendingDevicePublicSignKey: pendingDeviceSignKeyPair.publicKey,
-          pendingDevicePublicSignKeyDigest,
-          protectedVaultMasterKeyDigest,
-          protectedVaultMasterKey: protectedEnrollmentVaultMasterKey,
-          authorizedByDeviceId: unlockedVault.deviceId,
-          authorizerSignature,
+    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
+      params.vaultId,
+      unlockedVault,
+      sourceSnapshotVersionVector,
+      {
+        keySlots: {
+          deviceSlots: currentVaultSnapshot.keySlots.deviceSlots,
+          ...(currentVaultSnapshot.keySlots.completedEnrollments === undefined
+            ? {}
+            : {
+                completedEnrollments:
+                  currentVaultSnapshot.keySlots.completedEnrollments,
+              }),
+          enrollmentKeySlot: {
+            enrollmentId,
+            pendingDeviceId,
+            pendingDevicePublicSignKey: pendingDeviceSignKeyPair.publicKey,
+            pendingDevicePublicSignKeyDigest,
+            protectedVaultMasterKeyDigest,
+            protectedVaultMasterKey: protectedEnrollmentVaultMasterKey,
+            authorizedByDeviceId: unlockedVault.deviceId,
+            authorizerSignature,
+          },
+        },
+        nextTrust: {
+          chain: nextTrust.chain,
+          state: nextTrust.trust,
         },
       },
-      content: await this.crypto.encryptVaultSnapshotContent(
-        unlockedVault.vault,
-        unlockedVault.vaultMasterKey,
-      ),
+    );
+    const nextUnlockedVault = {
+      ...unlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
     };
-    const enrollmentVaultSnapshot: VaultSnapshot = {
-      ...unsignedVaultSnapshot,
-      signature: await this.crypto.signVaultSnapshot(
-        unsignedVaultSnapshot,
-        unlockedVault.devicePrivateSignKey,
-      ),
-    };
-    await this.vaultLocalRepository.saveVaultSnapshot(enrollmentVaultSnapshot);
+
     try {
       await this.unlockedVaultSession.commitPersistedSnapshot(
-        unlockedVault,
-        enrollmentVaultSnapshot.metadata.snapshotVersionVector,
+        nextUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
       );
     } catch (error) {
       try {
-        await this.vaultLocalRepository.saveVaultSnapshot(currentVaultSnapshot);
+        await this.vaultSnapshot.restoreLocalVaultSnapshot(
+          currentVaultSnapshot,
+          persistedSnapshot.snapshot,
+          unlockedVault,
+        );
       } catch {
         // Preserve the session commit failure as the root cause.
       }
@@ -230,7 +210,7 @@ export class InitializeDeviceEnrollmentUseCase {
     try {
       await this.syncProvider.uploadVaultSnapshot(
         syncConfig,
-        enrollmentVaultSnapshot,
+        persistedSnapshot.snapshot,
         params.remoteSnapshotDescriptor,
       );
     } catch (error) {
@@ -240,7 +220,11 @@ export class InitializeDeviceEnrollmentUseCase {
           : error;
 
       try {
-        await this.vaultLocalRepository.saveVaultSnapshot(currentVaultSnapshot);
+        await this.vaultSnapshot.restoreLocalVaultSnapshot(
+          currentVaultSnapshot,
+          persistedSnapshot.snapshot,
+          unlockedVault,
+        );
       } catch {
         // Preserve the upload failure as the root cause.
       }
@@ -262,16 +246,14 @@ export class InitializeDeviceEnrollmentUseCase {
         version: 1,
         vaultId: params.vaultId,
         syncConfig,
-        snapshotVersionVector:
-          enrollmentVaultSnapshot.metadata.snapshotVersionVector,
-        revisionTimestamp: enrollmentVaultSnapshot.metadata.revisionTimestamp,
-        snapshotSignerPublicKey: currentTrustedDevice.publicSignKey,
+        snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+        revisionTimestamp: persistedSnapshot.revisionTimestamp,
         enrollmentSecret,
         pendingDevicePrivateSignKey: pendingDeviceSignKeyPair.privateKey,
+        vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
       },
-      snapshotVersionVector:
-        enrollmentVaultSnapshot.metadata.snapshotVersionVector,
-      revisionTimestamp: enrollmentVaultSnapshot.metadata.revisionTimestamp,
+      snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+      revisionTimestamp: persistedSnapshot.revisionTimestamp,
     };
   }
 }

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -9,6 +9,7 @@ import {
   RemoteVaultSnapshotChangedError,
   SyncConflictDetectedError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { IdPort } from "../../ports/system/id.port";
@@ -70,6 +71,13 @@ export class InitializeDeviceEnrollmentUseCase {
 
     if (syncConfig === undefined) {
       throw new SyncNotConfiguredError(
+        params.vaultId,
+        "initialize device enrollment",
+      );
+    }
+
+    if (unlockedVault.vault.syncRemovalPending === true) {
+      throw new SyncRemovalPendingError(
         params.vaultId,
         "initialize device enrollment",
       );
@@ -218,6 +226,7 @@ export class InitializeDeviceEnrollmentUseCase {
         error instanceof RemoteVaultSnapshotChangedError
           ? new SyncConflictDetectedError(params.vaultId)
           : error;
+      let restored = false;
 
       try {
         await this.vaultSnapshot.restoreLocalVaultSnapshot(
@@ -225,17 +234,24 @@ export class InitializeDeviceEnrollmentUseCase {
           persistedSnapshot.snapshot,
           unlockedVault,
         );
+        restored = true;
       } catch {
-        // Preserve the upload failure as the root cause.
+        try {
+          await this.unlockedVaultSession.remove();
+        } catch {
+          // Preserve the upload failure as the root cause.
+        }
       }
 
-      try {
-        await this.unlockedVaultSession.commitPersistedSnapshot(
-          unlockedVault,
-          sourceSnapshotVersionVector,
-        );
-      } catch {
-        // Preserve the upload failure as the root cause.
+      if (restored) {
+        try {
+          await this.unlockedVaultSession.commitPersistedSnapshot(
+            unlockedVault,
+            sourceSnapshotVersionVector,
+          );
+        } catch {
+          // Preserve the upload failure as the root cause.
+        }
       }
 
       throw mappedError;

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -47,7 +47,7 @@ function createRemoteSnapshot(
   return {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp - 1,
       snapshotVersionVector: {
@@ -55,6 +55,24 @@ function createRemoteSnapshot(
       },
       algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
       createdByDeviceId: values.deviceId,
+    },
+    trustChain: {
+      ...values.vaultTrustChain,
+      certificates: [
+        {
+          ...values.vaultTrustCertificate,
+          payload: {
+            ...values.vaultTrustCertificate.payload,
+            trustedDevices: [
+              ...values.vaultTrustCertificate.payload.trustedDevices,
+              {
+                deviceId: values.pendingDeviceId,
+                publicSignKey: values.pendingDevicePublicSignKey,
+              },
+            ],
+          },
+        },
+      ],
     },
     keySlots: {
       deviceSlots: [
@@ -116,9 +134,9 @@ function createContext() {
     syncConfig: values.syncConfig,
     snapshotVersionVector: remoteSnapshotDescriptor.snapshotVersionVector,
     revisionTimestamp: remoteSnapshotDescriptor.revisionTimestamp,
-    snapshotSignerPublicKey: values.devicePublicSignKey,
     enrollmentSecret: values.deviceEnrollmentSecret,
     pendingDevicePrivateSignKey: values.pendingDevicePrivateSignKey,
+    vaultTrustAnchor: values.vaultTrustAnchor,
   };
 
   vi.mocked(
@@ -238,6 +256,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       {
         deviceSlotKey: ctx.values.deviceSlotKey,
         devicePrivateSignKey: ctx.values.pendingDevicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       ctx.values.localKeysProtectionKey,
     );
@@ -254,6 +273,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       {
         deviceSlotKey: ctx.values.deviceSlotKey,
         devicePrivateSignKey: ctx.values.pendingDevicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       ctx.values.recoveryLocalKeysProtectionKey,
     );
@@ -284,7 +304,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       devicePublicSignKey: ctx.values.pendingDevicePublicSignKey,
       protectedLocalKeys: ctx.values.recoveryProtectedLocalKeys,
     });
-    expect(ctx.ports.saved.vaultSnapshot).toEqual({
+    expect(ctx.ports.saved.vaultSnapshot).toMatchObject({
       metadata: {
         ...ctx.remoteSnapshot.metadata,
         snapshotVersionVector: {
@@ -322,6 +342,9 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       content: ctx.values.encryptedVault,
       signature: ctx.values.snapshotSignature,
     });
+    expect(ctx.ports.saved.vaultSnapshot?.trustChain).toEqual(
+      ctx.remoteSnapshot.trustChain,
+    );
     expect(ctx.ports.crypto.signVaultSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -35,7 +35,6 @@ import {
   RemoteVaultSnapshotNotFoundError,
   SyncConflictDetectedError,
 } from "../../errors/sync.errors";
-import { VaultSnapshotSignatureVerificationFailedError } from "../../errors/unlock-vault.errors";
 import type { Bip39Port } from "../../ports/crypto/bip39.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
@@ -43,6 +42,8 @@ import type { ClockPort } from "../../ports/system/clock.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 
 export type PerformDeviceEnrollmentCommandParams = {
   readonly enrollmentBundle: DeviceEnrollmentBundle;
@@ -66,6 +67,7 @@ export class PerformDeviceEnrollmentUseCase {
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultDisplayName: VaultDisplayNamePort;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     clock: ClockPort,
@@ -83,6 +85,7 @@ export class PerformDeviceEnrollmentUseCase {
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultDisplayName = vaultDisplayName;
     this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(
@@ -144,16 +147,23 @@ export class PerformDeviceEnrollmentUseCase {
       });
     }
 
-    const isSnapshotAuthentic = await this.crypto.verifyVaultSnapshotSignature(
-      remoteSnapshot,
-      enrollmentBundle.snapshotSignerPublicKey,
-    );
-
-    if (!isSnapshotAuthentic) {
-      throw new VaultSnapshotSignatureVerificationFailedError(
+    if (remoteSnapshot.trustChain === undefined) {
+      throw new VaultTrustStateInvalidError(
         enrollmentBundle.vaultId,
+        "trust chain is missing",
       );
     }
+
+    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
+      enrollmentBundle.vaultId,
+      enrollmentBundle.vaultTrustAnchor,
+      remoteSnapshot.trustChain,
+    );
+    await this.vaultTrust.verifySnapshot(
+      enrollmentBundle.vaultId,
+      remoteSnapshot,
+      verifiedTrust,
+    );
 
     const enrollmentKeySlot = remoteSnapshot.keySlots.enrollmentKeySlot;
 
@@ -213,9 +223,8 @@ export class PerformDeviceEnrollmentUseCase {
       );
     }
 
-    const authorizerDevice = remoteSnapshot.keySlots.deviceSlots.find(
-      (deviceSlot) =>
-        deviceSlot.deviceId === enrollmentKeySlot.authorizedByDeviceId,
+    const authorizerDevice = verifiedTrust.trustedDevices.find(
+      (device) => device.deviceId === enrollmentKeySlot.authorizedByDeviceId,
     );
 
     if (authorizerDevice === undefined) {
@@ -296,6 +305,7 @@ export class PerformDeviceEnrollmentUseCase {
     const localKeysPayload: LocalKeysPayload = {
       deviceSlotKey,
       devicePrivateSignKey,
+      vaultTrustAnchor: enrollmentBundle.vaultTrustAnchor,
     };
     const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
       localKeysPayload,
@@ -345,6 +355,7 @@ export class PerformDeviceEnrollmentUseCase {
         ),
         createdByDeviceId: deviceId,
       },
+      trustChain: remoteSnapshot.trustChain,
       keySlots: {
         deviceSlots: [
           ...remoteSnapshot.keySlots.deviceSlots,
@@ -371,16 +382,17 @@ export class PerformDeviceEnrollmentUseCase {
         devicePrivateSignKey,
       ),
     };
-    const isRegisteredSnapshotAuthentic =
-      await this.crypto.verifyVaultSnapshotSignature(
+    try {
+      await this.vaultTrust.verifySnapshot(
+        enrollmentBundle.vaultId,
         registeredVaultSnapshot,
-        devicePublicSignKey,
+        verifiedTrust,
       );
-
-    if (!isRegisteredSnapshotAuthentic) {
+    } catch (error) {
       throw new DeviceEnrollmentIntegrityError(
         enrollmentBundle.vaultId,
-        "pending device private key does not match the enrolled public key",
+        "pending device cannot authenticate the completed snapshot",
+        { cause: error },
       );
     }
 
@@ -412,14 +424,28 @@ export class PerformDeviceEnrollmentUseCase {
       vault: registeredVault,
       vaultMasterKey,
       devicePrivateSignKey,
+      trustedSnapshotContext: {
+        snapshotDigest: await this.crypto.digestVaultSnapshot(
+          registeredVaultSnapshot,
+        ),
+        trust: verifiedTrust,
+      },
+      vaultTrustAnchor: enrollmentBundle.vaultTrustAnchor,
     };
+    const checkpoint = await this.vaultTrust.createCheckpoint(
+      registeredVaultSnapshot,
+      verifiedTrust,
+      deviceId,
+      devicePrivateSignKey,
+    );
 
-    await this.vaultLocalRepository.saveInitializedLocalVault(
-      localVaultDescriptor,
+    await this.vaultLocalRepository.saveInitializedLocalVault({
+      descriptor: localVaultDescriptor,
       deviceAccessMaterial,
       deviceAccessRecoveryBackup,
-      registeredVaultSnapshot,
-    );
+      snapshot: registeredVaultSnapshot,
+      checkpoint,
+    });
 
     try {
       await this.unlockedVaultSession.commit(

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -407,7 +407,7 @@ describe("RecoverDeviceAccessUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("rejects an unsupported snapshot schema before trust-chain verification", async () => {
+  it("rejects an unsupported snapshot schema before recovery-key operations", async () => {
     const ctx = createContext();
     ctx.ports.saved.vaultSnapshot = {
       ...ctx.vaultSnapshot,
@@ -425,9 +425,12 @@ describe("RecoverDeviceAccessUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
 
+    expect(ctx.ports.bip39.mnemonicToRecoveryKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+      ctx.ports.crypto.deriveRecoveryLocalKeysProtectionKey,
     ).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.unwrapLocalKeysPayload).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.verifyDeviceSignKeyPair).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -26,7 +26,7 @@ function createContext() {
   const vaultSnapshot: VaultSnapshot = {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -35,6 +35,7 @@ function createContext() {
       algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
       createdByDeviceId: values.deviceId,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {
@@ -57,6 +58,7 @@ function createContext() {
   };
 
   ports.saved.vaultSnapshot = vaultSnapshot;
+  ports.saved.localVaultTrustCheckpoint = values.localVaultTrustCheckpoint;
   ports.saved.deviceAccessRecoveryBackup = deviceAccessRecoveryBackup;
   vi.mocked(ports.crypto.generateMasterPasswordSalt)
     .mockReset()
@@ -144,6 +146,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       {
         deviceSlotKey: ctx.values.deviceSlotKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       ctx.values.newLocalKeysProtectionKey,
     );
@@ -162,6 +165,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       {
         deviceSlotKey: ctx.values.deviceSlotKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       ctx.values.rotatedRecoveryLocalKeysProtectionKey,
     );
@@ -212,7 +216,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       ctx.ports.vaultLocalRepository.saveDeviceAccessRecoveryBackup,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
@@ -235,6 +239,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       ctx.ports.vaultLocalRepository.getVaultSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.bip39.mnemonicToRecoveryKey).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(
       ctx.ports.vaultLocalRepository.saveRecoveredDeviceAccess,
     ).not.toHaveBeenCalled();
@@ -249,6 +254,11 @@ describe("RecoverDeviceAccessUseCase", () => {
         vault: ctx.values.decryptedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: ctx.values.verifiedVaultTrustState,
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 1,
@@ -323,6 +333,7 @@ describe("RecoverDeviceAccessUseCase", () => {
     ).rejects.toBeInstanceOf(VaultSnapshotNotFoundError);
 
     expect(ctx.ports.bip39.mnemonicToRecoveryKey).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(
       ctx.ports.vaultLocalRepository.saveRecoveredDeviceAccess,
     ).not.toHaveBeenCalled();
@@ -372,7 +383,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(VaultSnapshotSignerNotTrustedError);
 
-    expect(ctx.ports.bip39.mnemonicToRecoveryKey).not.toHaveBeenCalled();
+    expect(ctx.ports.bip39.mnemonicToRecoveryKey).toHaveBeenCalled();
   });
 
   it("fails when the snapshot signature is invalid", async () => {
@@ -389,7 +400,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(VaultSnapshotSignatureVerificationFailedError);
 
-    expect(ctx.ports.bip39.mnemonicToRecoveryKey).not.toHaveBeenCalled();
+    expect(ctx.ports.bip39.mnemonicToRecoveryKey).toHaveBeenCalled();
     expect(
       ctx.ports.vaultLocalRepository.saveRecoveredDeviceAccess,
     ).not.toHaveBeenCalled();

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -407,6 +407,30 @@ describe("RecoverDeviceAccessUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("rejects an unsupported snapshot schema before trust-chain verification", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        schemaVersion: 3,
+      },
+    } as unknown as VaultSnapshot;
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        recoveryMnemonicKey: ctx.values.recoveryMnemonicKey,
+        newMasterPassword: ctx.values.newMasterPassword,
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
+  });
+
   it("rejects a recovered device revoked by the verified trust chain", async () => {
     const ctx = createContext();
     const remainingDeviceId = "remaining-device-id";

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../errors/unlock-vault.errors";
 import { ActiveUnlockedVaultMismatchError } from "../../errors/vault-session.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import {
   DeviceAccessRecoveryBackupMismatchError,
   DeviceAccessRecoveryBackupNotFoundError,
@@ -404,6 +405,77 @@ describe("RecoverDeviceAccessUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveRecoveredDeviceAccess,
     ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a recovered device revoked by the verified trust chain", async () => {
+    const ctx = createContext();
+    const remainingDeviceId = "remaining-device-id";
+    ctx.ports.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      trustChain: {
+        certificates: [
+          ctx.values.vaultTrustCertificate,
+          {
+            ...ctx.values.vaultTrustCertificate,
+            payload: {
+              ...ctx.values.vaultTrustCertificate.payload,
+              generation: 1,
+              previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
+              trustedDevices: [
+                {
+                  deviceId: remainingDeviceId,
+                  publicSignKey: ctx.values.pendingDevicePublicSignKey,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        recoveryMnemonicKey: ctx.values.recoveryMnemonicKey,
+        newMasterPassword: ctx.values.newMasterPassword,
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveRecoveredDeviceAccess,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("updates a newer checkpoint with the snapshot-and-checkpoint compare-and-set", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        snapshotVersionVector: {
+          [ctx.values.deviceId]: 2,
+        },
+      },
+    };
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      recoveryMnemonicKey: ctx.values.recoveryMnemonicKey,
+      newMasterPassword: ctx.values.newMasterPassword,
+    });
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenCalledWith({
+      expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+      snapshot: ctx.ports.saved.vaultSnapshot,
+      checkpoint: expect.objectContaining({
+        payload: expect.objectContaining({
+          snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+        }),
+      }),
+    });
   });
 
   it("fails when the recovered device is no longer trusted by the snapshot", async () => {

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -9,8 +9,6 @@ import {
   DeviceKeySlotNotFoundError,
   DeviceKeySlotVerificationFailedError,
   VaultSnapshotNotFoundError,
-  VaultSnapshotSignatureVerificationFailedError,
-  VaultSnapshotSignerNotTrustedError,
 } from "../../errors/unlock-vault.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
 import type { Bip39Port } from "../../ports/crypto/bip39.port";
@@ -21,6 +19,11 @@ import {
   DeviceAccessRecoveryBackupMismatchError,
   DeviceAccessRecoveryBackupNotFoundError,
 } from "./recover-device-access.errors";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import {
+  LocalVaultTrustCheckpointNotFoundError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
 
 export type RecoverDeviceAccessCommandParams = {
   readonly vaultId: string;
@@ -38,6 +41,7 @@ export class RecoverDeviceAccessUseCase {
   private readonly crypto: CryptoPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     bip39: Bip39Port,
@@ -49,6 +53,7 @@ export class RecoverDeviceAccessUseCase {
     this.crypto = crypto;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(
@@ -104,18 +109,6 @@ export class RecoverDeviceAccessUseCase {
       });
     }
 
-    const signerDeviceKeySlot = vaultSnapshot.keySlots.deviceSlots.find(
-      (slot: DeviceKeySlot) =>
-        slot.deviceId === vaultSnapshot.metadata.createdByDeviceId,
-    );
-
-    if (signerDeviceKeySlot === undefined) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        params.vaultId,
-        vaultSnapshot.metadata.createdByDeviceId,
-      );
-    }
-
     const deviceKeySlot = vaultSnapshot.keySlots.deviceSlots.find(
       (slot: DeviceKeySlot) => slot.deviceId === recoveryBackup.deviceId,
     );
@@ -125,15 +118,6 @@ export class RecoverDeviceAccessUseCase {
         params.vaultId,
         recoveryBackup.deviceId,
       );
-    }
-
-    const isSnapshotAuthentic = await this.crypto.verifyVaultSnapshotSignature(
-      vaultSnapshot,
-      signerDeviceKeySlot.publicSignKey,
-    );
-
-    if (!isSnapshotAuthentic) {
-      throw new VaultSnapshotSignatureVerificationFailedError(params.vaultId);
     }
 
     const recoverySecretKey = await this.bip39.mnemonicToRecoveryKey(
@@ -175,6 +159,49 @@ export class RecoverDeviceAccessUseCase {
       );
     }
 
+    if (vaultSnapshot.trustChain === undefined) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "trust chain is missing",
+      );
+    }
+
+    const checkpoint =
+      await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+        params.vaultId,
+      );
+
+    if (checkpoint === null) {
+      throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
+    }
+
+    const localDeviceIdentity = {
+      deviceId: recoveryBackup.deviceId,
+      publicSignKey: recoveryBackup.devicePublicSignKey,
+    };
+    await this.vaultTrust.verifyCheckpoint(
+      params.vaultId,
+      checkpoint,
+      localDeviceIdentity,
+    );
+    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
+      params.vaultId,
+      localKeysPayload.vaultTrustAnchor,
+      vaultSnapshot.trustChain,
+    );
+    await this.vaultTrust.verifySnapshot(
+      params.vaultId,
+      vaultSnapshot,
+      verifiedTrust,
+    );
+    const checkpointRelation =
+      await this.vaultTrust.requireSnapshotNotRolledBack(
+        params.vaultId,
+        vaultSnapshot,
+        verifiedTrust,
+        checkpoint,
+      );
+
     const vaultMasterKeyProtectionKey =
       await this.crypto.deriveDeviceSlotVaultMasterKeyProtectionKey(
         localKeysPayload.deviceSlotKey,
@@ -189,6 +216,17 @@ export class RecoverDeviceAccessUseCase {
       vaultSnapshot.content,
       vaultMasterKey,
     );
+
+    if (checkpointRelation === "newer") {
+      await this.vaultLocalRepository.saveLocalVaultTrustCheckpoint(
+        await this.vaultTrust.createCheckpoint(
+          vaultSnapshot,
+          verifiedTrust,
+          recoveryBackup.deviceId,
+          localKeysPayload.devicePrivateSignKey,
+        ),
+      );
+    }
 
     const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
     const localRootKey = await this.crypto.deriveLocalRootKey(

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -109,6 +109,13 @@ export class RecoverDeviceAccessUseCase {
       });
     }
 
+    if (vaultSnapshot.metadata.schemaVersion !== 2) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "unsupported snapshot schema version",
+      );
+    }
+
     const deviceKeySlot = vaultSnapshot.keySlots.deviceSlots.find(
       (slot: DeviceKeySlot) => slot.deviceId === recoveryBackup.deviceId,
     );
@@ -156,13 +163,6 @@ export class RecoverDeviceAccessUseCase {
       throw new DeviceKeySlotVerificationFailedError(
         params.vaultId,
         recoveryBackup.deviceId,
-      );
-    }
-
-    if (vaultSnapshot.metadata.schemaVersion !== 2) {
-      throw new VaultTrustStateInvalidError(
-        params.vaultId,
-        "unsupported snapshot schema version",
       );
     }
 

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -159,6 +159,13 @@ export class RecoverDeviceAccessUseCase {
       );
     }
 
+    if (vaultSnapshot.metadata.schemaVersion !== 2) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "unsupported snapshot schema version",
+      );
+    }
+
     if (vaultSnapshot.trustChain === undefined) {
       throw new VaultTrustStateInvalidError(
         params.vaultId,

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -189,6 +189,23 @@ export class RecoverDeviceAccessUseCase {
       localKeysPayload.vaultTrustAnchor,
       vaultSnapshot.trustChain,
     );
+    const trustedRecoveredDevice = verifiedTrust.trustedDevices.find(
+      (device) => device.deviceId === recoveryBackup.deviceId,
+    );
+
+    if (
+      trustedRecoveredDevice === undefined ||
+      !(await this.crypto.verifyDeviceSignKeyPair(
+        trustedRecoveredDevice.publicSignKey,
+        localKeysPayload.devicePrivateSignKey,
+      ))
+    ) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "recovered device is not trusted",
+      );
+    }
+
     await this.vaultTrust.verifySnapshot(
       params.vaultId,
       vaultSnapshot,
@@ -218,14 +235,17 @@ export class RecoverDeviceAccessUseCase {
     );
 
     if (checkpointRelation === "newer") {
-      await this.vaultLocalRepository.saveLocalVaultTrustCheckpoint(
-        await this.vaultTrust.createCheckpoint(
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest:
+          await this.crypto.digestVaultSnapshot(vaultSnapshot),
+        snapshot: vaultSnapshot,
+        checkpoint: await this.vaultTrust.createCheckpoint(
           vaultSnapshot,
           verifiedTrust,
           recoveryBackup.deviceId,
           localKeysPayload.devicePrivateSignKey,
         ),
-      );
+      });
     }
 
     const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -102,6 +102,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     snapshotService,
+    ports.sessionServices.unlockedVaultSession,
   );
   const vault = createVault(values);
   const vaultSnapshot = createVaultSnapshot(values);

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -13,10 +13,7 @@ import {
 } from "../../errors/unlock-vault.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
 import { RemoteVaultSnapshotAheadError } from "../../errors/sync.errors";
-import {
-  SnapshotSigningDeviceNotTrustedError,
-  VaultSnapshotVersionMismatchError,
-} from "../../errors/vault-snapshot.errors";
+import { VaultSnapshotVersionMismatchError } from "../../errors/vault-snapshot.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
@@ -65,7 +62,7 @@ function createVaultSnapshot(values: CoreTestValues): VaultSnapshot {
   return {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 10,
       revisionTimestamp: values.timestamp - 1,
       snapshotVersionVector: {
@@ -74,6 +71,7 @@ function createVaultSnapshot(values: CoreTestValues): VaultSnapshot {
       algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
       createdByDeviceId: values.deviceId,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {
@@ -109,6 +107,7 @@ function createContext() {
   const vaultSnapshot = createVaultSnapshot(values);
 
   ports.saved.vaultSnapshot = vaultSnapshot;
+  ports.saved.localVaultTrustCheckpoint = values.localVaultTrustCheckpoint;
   ports.saved.unlockedVaultSession = {
     unlockedVault: {
       vaultId: values.vaultId,
@@ -116,6 +115,11 @@ function createContext() {
       vault,
       vaultMasterKey: values.vaultMasterKey,
       devicePrivateSignKey: values.devicePrivateSignKey,
+      trustedSnapshotContext: {
+        snapshotDigest: values.vaultSnapshotDigest,
+        trust: values.verifiedVaultTrustState,
+      },
+      vaultTrustAnchor: values.vaultTrustAnchor,
     },
     sourceSnapshotVersionVector: vaultSnapshot.metadata.snapshotVersionVector,
   };
@@ -132,7 +136,7 @@ function createContext() {
       ports.crypto,
       ports.sessionServices.unlockedVaultSession,
       vaultSyncGuard,
-      ports.vaultLocalRepository,
+      snapshotService,
     ),
   };
 }
@@ -189,30 +193,42 @@ describe("RevokeDeviceUseCase", () => {
       expectedVault,
       ctx.values.vaultMasterKey,
     );
-    expect(ctx.saved.vaultSnapshot).toEqual({
-      metadata: {
-        ...ctx.vaultSnapshot.metadata,
-        snapshotVersionVector: {
-          [ctx.values.deviceId]: 2,
-        },
-        revisionTimestamp: ctx.values.timestamp,
-        createdByDeviceId: ctx.values.deviceId,
-      },
-      keySlots: {
-        deviceSlots: [
-          {
-            deviceId: ctx.values.deviceId,
-            protectedVaultMasterKey: ctx.values.protectedDeviceVaultMasterKey,
-            publicSignKey: ctx.values.devicePublicSignKey,
+    expect(ctx.saved.vaultSnapshot).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          snapshotVersionVector: {
+            [ctx.values.deviceId]: 2,
           },
-        ],
+          revisionTimestamp: ctx.values.timestamp,
+          createdByDeviceId: ctx.values.deviceId,
+        }),
+        keySlots: expect.objectContaining({
+          deviceSlots: [
+            {
+              deviceId: ctx.values.deviceId,
+              protectedVaultMasterKey: ctx.values.protectedDeviceVaultMasterKey,
+              publicSignKey: ctx.values.devicePublicSignKey,
+            },
+          ],
+        }),
+        content: ctx.values.encryptedVault,
+        signature: ctx.values.snapshotSignature,
+      }),
+    );
+    expect(ctx.saved.vaultSnapshot?.trustChain?.certificates).toHaveLength(2);
+    expect(
+      ctx.saved.vaultSnapshot?.trustChain?.certificates.at(-1)?.payload
+        .trustedDevices,
+    ).toEqual([
+      {
+        deviceId: ctx.values.deviceId,
+        publicSignKey: ctx.values.devicePublicSignKey,
       },
-      content: ctx.values.encryptedVault,
-      signature: ctx.values.snapshotSignature,
-    });
+    ]);
     expect(ctx.ports.crypto.signVaultSnapshot).toHaveBeenCalledWith(
       {
         metadata: ctx.saved.vaultSnapshot?.metadata,
+        trustChain: ctx.saved.vaultSnapshot?.trustChain,
         keySlots: ctx.saved.vaultSnapshot?.keySlots,
         content: ctx.saved.vaultSnapshot?.content,
       },
@@ -225,14 +241,28 @@ describe("RevokeDeviceUseCase", () => {
         vault: expectedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: {
+            generation: 1,
+            certificateDigest: ctx.values.vaultTrustCertificateDigest,
+            trustedDevices: [
+              {
+                deviceId: ctx.values.deviceId,
+                publicSignKey: ctx.values.devicePublicSignKey,
+              },
+            ],
+          },
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 2,
       },
     });
     expect(
-      vi.mocked(ctx.ports.vaultLocalRepository.saveVaultSnapshot).mock
-        .invocationCallOrder[0],
+      vi.mocked(ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint)
+        .mock.invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
         .invocationCallOrder[0],
@@ -379,6 +409,11 @@ describe("RevokeDeviceUseCase", () => {
         vault: ctx.vault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: ctx.values.verifiedVaultTrustState,
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector:
         ctx.vaultSnapshot.metadata.snapshotVersionVector,
@@ -426,7 +461,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -453,7 +488,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -492,7 +527,7 @@ describe("RevokeDeviceUseCase", () => {
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.signVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
@@ -520,7 +555,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -545,7 +580,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -564,11 +599,11 @@ describe("RevokeDeviceUseCase", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
-  it("fails when the current device is no longer trusted", async () => {
+  it("rejects a signer trusted only by a manipulated snapshot roster", async () => {
     const ctx = createContext();
     ctx.saved.vaultSnapshot = {
       ...ctx.vaultSnapshot,
@@ -593,11 +628,11 @@ describe("RevokeDeviceUseCase", () => {
         vaultId: ctx.values.vaultId,
         deviceId: revokedDeviceId,
       }),
-    ).rejects.toBeInstanceOf(SnapshotSigningDeviceNotTrustedError);
+    ).rejects.toBeInstanceOf(VaultSnapshotSignerNotTrustedError);
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -622,7 +657,7 @@ describe("RevokeDeviceUseCase", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -647,7 +682,7 @@ describe("RevokeDeviceUseCase", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -665,6 +700,11 @@ describe("RevokeDeviceUseCase", () => {
         },
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: ctx.values.verifiedVaultTrustState,
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector:
         ctx.vaultSnapshot.metadata.snapshotVersionVector,
@@ -679,14 +719,14 @@ describe("RevokeDeviceUseCase", () => {
 
     expect(ctx.ports.crypto.encryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
   it("does not commit the session when snapshot persistence fails", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).mockRejectedValueOnce(new Error("snapshot save failed"));
 
     await expect(
@@ -719,7 +759,7 @@ describe("RevokeDeviceUseCase", () => {
     ).rejects.toThrow("session save failed");
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledTimes(1);
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.remove,

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -1,25 +1,18 @@
-import type {
-  UnsignedVaultSnapshot,
-  VaultSnapshot,
-} from "../../domain/snapshot/vault-snapshot";
 import type { Vault } from "../../domain/vault/vault";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device.mutations";
-import {
-  VaultSnapshotSignatureVerificationFailedError,
-  VaultSnapshotSignerNotTrustedError,
-} from "../../errors/unlock-vault.errors";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
-import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import {
   CannotRevokeCurrentDeviceError,
   DeviceProfileNotFoundForRevocationError,
   DeviceToRevokeNotTrustedError,
 } from "./revoke-device.errors";
-import { incrementVersionVector } from "../../domain/versioning/version-vector.utils";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { VaultSyncGuardService } from "../../services/sync";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
+import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 
 export type RevokeDeviceCommandParams = {
   readonly vaultId: string;
@@ -34,23 +27,23 @@ export type RevokeDeviceResult = {
 
 export class RevokeDeviceUseCase {
   private readonly clock: ClockPort;
-  private readonly crypto: CryptoPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultSyncGuard: VaultSyncGuardService;
-  private readonly vaultLocalRepository: VaultLocalRepositoryPort;
+  private readonly vaultSnapshot: VaultSnapshotService;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     clock: ClockPort,
     crypto: CryptoPort,
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultSyncGuard: VaultSyncGuardService,
-    vaultLocalRepository: VaultLocalRepositoryPort,
+    vaultSnapshot: VaultSnapshotService,
   ) {
     this.clock = clock;
-    this.crypto = crypto;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultSyncGuard = vaultSyncGuard;
-    this.vaultLocalRepository = vaultLocalRepository;
+    this.vaultSnapshot = vaultSnapshot;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(
@@ -76,27 +69,6 @@ export class RevokeDeviceUseCase {
       sourceSnapshotVersionVector,
     );
     const currentVaultSnapshot = syncState.localSnapshot;
-
-    const signerDevice = currentVaultSnapshot.keySlots.deviceSlots.find(
-      (deviceSlot) =>
-        deviceSlot.deviceId === currentVaultSnapshot.metadata.createdByDeviceId,
-    );
-
-    if (signerDevice === undefined) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        params.vaultId,
-        currentVaultSnapshot.metadata.createdByDeviceId,
-      );
-    }
-
-    const isSnapshotAuthentic = await this.crypto.verifyVaultSnapshotSignature(
-      currentVaultSnapshot,
-      signerDevice.publicSignKey,
-    );
-
-    if (!isSnapshotAuthentic) {
-      throw new VaultSnapshotSignatureVerificationFailedError(params.vaultId);
-    }
 
     // The target must exist in the device access surface we are about to remove it from.
     const isRevokedDeviceTrusted =
@@ -134,69 +106,72 @@ export class RevokeDeviceUseCase {
       enrollmentKeySlot?.authorizedByDeviceId === params.deviceId
         ? undefined
         : enrollmentKeySlot;
+    const currentTrustChain = currentVaultSnapshot.trustChain;
 
-    // Rebuild the snapshot device access state without the revoked device and sign the
-    // result as the still-trusted local device.
-    const unsignedVaultSnapshot: UnsignedVaultSnapshot = {
-      metadata: {
-        ...currentVaultSnapshot.metadata,
-        id: params.vaultId,
-        revisionTimestamp,
-        snapshotVersionVector: incrementVersionVector(
-          currentVaultSnapshot.metadata.snapshotVersionVector,
-          unlockedVault.deviceId,
-        ),
-        createdByDeviceId: unlockedVault.deviceId,
-      },
-      keySlots: {
-        deviceSlots: currentVaultSnapshot.keySlots.deviceSlots.filter(
-          (deviceSlot) => deviceSlot.deviceId !== params.deviceId,
-        ),
-        ...(retainedEnrollmentKeySlot === undefined
-          ? {}
-          : { enrollmentKeySlot: retainedEnrollmentKeySlot }),
-        completedEnrollments:
-          currentVaultSnapshot.keySlots.completedEnrollments,
-      },
-      content: await this.crypto.encryptVaultSnapshotContent(
-        revokedVault,
-        unlockedVault.vaultMasterKey,
+    if (currentTrustChain === undefined) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "trust chain is missing",
+      );
+    }
+
+    const nextTrust = await this.vaultTrust.appendTrustTransition(
+      params.vaultId,
+      currentTrustChain,
+      unlockedVault.trustedSnapshotContext.trust,
+      unlockedVault.trustedSnapshotContext.trust.trustedDevices.filter(
+        (device) => device.deviceId !== params.deviceId,
       ),
-    };
-
-    const revokedVaultSnapshot: VaultSnapshot = {
-      ...unsignedVaultSnapshot,
-      signature: await this.crypto.signVaultSnapshot(
-        unsignedVaultSnapshot,
-        unlockedVault.devicePrivateSignKey,
-      ),
-    };
-
-    // Persist the revoked snapshot before advancing the unlocked session to
-    // the matching snapshot version vector.
-    await this.vaultLocalRepository.saveVaultSnapshot(revokedVaultSnapshot);
+      unlockedVault.deviceId,
+      unlockedVault.devicePrivateSignKey,
+    );
 
     const updatedUnlockedVault = {
       ...unlockedVault,
       vault: revokedVault,
     };
+    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
+      params.vaultId,
+      updatedUnlockedVault,
+      sourceSnapshotVersionVector,
+      {
+        keySlots: {
+          deviceSlots: currentVaultSnapshot.keySlots.deviceSlots.filter(
+            (deviceSlot) => deviceSlot.deviceId !== params.deviceId,
+          ),
+          ...(retainedEnrollmentKeySlot === undefined
+            ? {}
+            : { enrollmentKeySlot: retainedEnrollmentKeySlot }),
+          completedEnrollments:
+            currentVaultSnapshot.keySlots.completedEnrollments,
+        },
+        nextTrust: {
+          chain: nextTrust.chain,
+          state: nextTrust.trust,
+        },
+      },
+    );
+    const persistedUnlockedVault = {
+      ...updatedUnlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    };
 
     await this.vaultSyncGuard.uploadPersistedLocalMutation(
       params.vaultId,
       syncState,
-      revokedVaultSnapshot,
+      persistedSnapshot.snapshot,
+      unlockedVault,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
-      revokedVaultSnapshot.metadata.snapshotVersionVector,
+      persistedUnlockedVault,
+      persistedSnapshot.snapshotVersionVector,
     );
 
     return {
       vault: revokedVault,
-      snapshotVersionVector:
-        revokedVaultSnapshot.metadata.snapshotVersionVector,
-      revisionTimestamp: revokedVaultSnapshot.metadata.revisionTimestamp,
+      snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+      revisionTimestamp: persistedSnapshot.revisionTimestamp,
     };
   }
 }

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -19,6 +19,7 @@ import {
   SyncAlreadyResolvedError,
   SyncConflictDetectedError,
   SyncResolutionIncompleteError,
+  SyncRemovalPendingError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
 import { VaultSnapshotSignerNotTrustedError } from "../../errors/unlock-vault.errors";
@@ -206,6 +207,37 @@ function createContext() {
 }
 
 describe("ApplySyncResolutionUseCase", () => {
+  it("does not read remote state while remote cleanup is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncRemovalPending: true,
+        },
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        remoteSnapshotDescriptor: createRemoteSnapshotDescriptor(ctx.values),
+        resolution: {
+          entryResolutions: [],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncRemovalPendingError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+  });
+
   it("applies explicit resolutions, persists locally, commits session, and uploads", async () => {
     const ctx = createContext();
     const remoteEntry = createEntry("remote-entry", {
@@ -579,7 +611,7 @@ describe("ApplySyncResolutionUseCase", () => {
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
 
-  it("restores the local snapshot and does not commit when resolved upload races", async () => {
+  it("invalidates the session when resolved upload restoration fails", async () => {
     const ctx = createContext();
     const remoteEntry = createEntry("remote-entry", {
       "remote-device-id": 1,
@@ -629,6 +661,9 @@ describe("ApplySyncResolutionUseCase", () => {
     vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
+    ctx.restoreLocalVaultSnapshot.mockRejectedValueOnce(
+      new Error("restore failed"),
+    );
 
     await expect(
       ctx.useCase.execute({
@@ -659,7 +694,10 @@ describe("ApplySyncResolutionUseCase", () => {
       }),
       expect.objectContaining({ vaultId: ctx.values.vaultId }),
     );
-    expect(ctx.saved.vaultSnapshot).toBe(ctx.localSnapshot);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.remove,
+    ).toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -5,6 +5,7 @@ import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-e
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { CURRENT_ALGORITHM_SUITE } from "../../domain/crypto/algorithm-suite.const";
 import type { CompletedDeviceEnrollmentProof } from "../../domain/device-trust";
+import type { VaultTrustChain } from "../../domain/device-trust";
 import type { PasswordEntry } from "../../domain/entry/password-entry.type";
 import type { EnrollmentKeySlot } from "../../domain/snapshot";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
@@ -26,12 +27,15 @@ import { ApplySyncResolutionUseCase } from "./apply-sync-resolution";
 
 function createSnapshot(
   values: ReturnType<typeof createCoreTestValues>,
-  overrides: Partial<VaultSnapshot> = {},
+  overrides: Partial<Omit<VaultSnapshot, "metadata">> & {
+    readonly metadata?: Partial<VaultSnapshot["metadata"]>;
+  } = {},
 ): VaultSnapshot {
   return {
+    ...overrides,
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -41,7 +45,8 @@ function createSnapshot(
       createdByDeviceId: values.deviceId,
       ...overrides.metadata,
     },
-    keySlots: {
+    trustChain: overrides.trustChain ?? values.vaultTrustChain,
+    keySlots: overrides.keySlots ?? {
       deviceSlots: [
         {
           deviceId: values.deviceId,
@@ -50,9 +55,8 @@ function createSnapshot(
         },
       ],
     },
-    content: values.encryptedVault,
-    signature: values.snapshotSignature,
-    ...overrides,
+    content: overrides.content ?? values.encryptedVault,
+    signature: overrides.signature ?? values.snapshotSignature,
   };
 }
 
@@ -116,6 +120,32 @@ function createCompletedEnrollmentProof(
   };
 }
 
+function createEnrollmentTrustChain(
+  values: ReturnType<typeof createCoreTestValues>,
+): VaultTrustChain {
+  return {
+    ...values.vaultTrustChain,
+    certificates: [
+      ...values.vaultTrustChain.certificates,
+      {
+        ...values.vaultTrustCertificate,
+        payload: {
+          ...values.vaultTrustCertificate.payload,
+          generation: 1,
+          previousCertificateDigest: values.vaultTrustCertificateDigest,
+          trustedDevices: [
+            ...values.verifiedVaultTrustState.trustedDevices,
+            {
+              deviceId: values.pendingDeviceId,
+              publicSignKey: values.pendingDevicePublicSignKey,
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
@@ -129,7 +159,7 @@ function createContext() {
   const localSnapshot = createSnapshot(values, {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -202,7 +232,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -277,12 +307,12 @@ describe("ApplySyncResolutionUseCase", () => {
       {
         [ctx.values.deviceId]: 3,
       },
-      {
+      expect.objectContaining({
         baseSnapshotVersionVector: {
           [ctx.values.deviceId]: 3,
           "remote-device-id": 1,
         },
-      },
+      }),
     );
     expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
       [ctx.values.deviceId]: 4,
@@ -346,7 +376,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -367,6 +397,7 @@ describe("ApplySyncResolutionUseCase", () => {
         ],
         completedEnrollments: [createCompletedEnrollmentProof(ctx.values)],
       },
+      trustChain: createEnrollmentTrustChain(ctx.values),
     });
 
     ctx.saved.vaultSnapshot = localSnapshotWithEnrollment;
@@ -421,15 +452,26 @@ describe("ApplySyncResolutionUseCase", () => {
       {
         [ctx.values.deviceId]: 3,
       },
-      {
+      expect.objectContaining({
         baseSnapshotVersionVector: {
           [ctx.values.deviceId]: 3,
           [ctx.values.pendingDeviceId]: 1,
         },
         keySlots: remoteSnapshot.keySlots,
-      },
+      }),
     );
     expect(ctx.saved.vaultSnapshot?.keySlots).toEqual(remoteSnapshot.keySlots);
+    expect(ctx.saved.vaultSnapshot?.trustChain).toEqual(
+      remoteSnapshot.trustChain,
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.trustedSnapshotContext.trust
+        .trustedDevices,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ deviceId: ctx.values.pendingDeviceId }),
+      ]),
+    );
     expect(ctx.saved.vaultSnapshot?.metadata.createdByDeviceId).toBe(
       ctx.values.deviceId,
     );
@@ -479,7 +521,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -500,6 +542,7 @@ describe("ApplySyncResolutionUseCase", () => {
         ],
         completedEnrollments: [createCompletedEnrollmentProof(ctx.values)],
       },
+      trustChain: createEnrollmentTrustChain(ctx.values),
     });
 
     ctx.saved.vaultSnapshot = localSnapshotWithEnrollment;
@@ -531,7 +574,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ).rejects.toBeInstanceOf(InvalidSyncResolutionError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -562,7 +605,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -606,6 +649,15 @@ describe("ApplySyncResolutionUseCase", () => {
 
     expect(ctx.restoreLocalVaultSnapshot).toHaveBeenCalledWith(
       ctx.localSnapshot,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          snapshotVersionVector: {
+            [ctx.values.deviceId]: 4,
+            "remote-device-id": 1,
+          },
+        }),
+      }),
+      expect.objectContaining({ vaultId: ctx.values.vaultId }),
     );
     expect(ctx.saved.vaultSnapshot).toBe(ctx.localSnapshot);
     expect(
@@ -646,7 +698,7 @@ describe("ApplySyncResolutionUseCase", () => {
 
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -681,7 +733,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -716,7 +768,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ).rejects.toBeInstanceOf(SyncResolutionIncompleteError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -735,7 +787,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -769,7 +821,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ).rejects.toBeInstanceOf(SyncAlreadyResolvedError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -788,7 +840,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -842,7 +894,7 @@ describe("ApplySyncResolutionUseCase", () => {
       ctx.values.devicePublicSignKey,
     );
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -852,7 +904,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ctx.saved.vaultSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -892,7 +944,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ctx.saved.vaultSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -935,7 +987,7 @@ describe("ApplySyncResolutionUseCase", () => {
 
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -945,7 +997,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ctx.saved.vaultSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp + 1,
         snapshotVersionVector: {
@@ -991,7 +1043,7 @@ describe("ApplySyncResolutionUseCase", () => {
 
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -1026,7 +1078,7 @@ describe("ApplySyncResolutionUseCase", () => {
     const remoteSnapshot = createSnapshot(ctx.values, {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -1077,7 +1129,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ).rejects.toBeInstanceOf(SyncTrustChangeRequiresDeviceTrustFlowError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -16,6 +16,7 @@ import {
   SyncConflictDetectedError,
   SyncAlreadyResolvedError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
   SyncResolutionIncompleteError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
@@ -80,6 +81,13 @@ export class ApplySyncResolutionUseCase {
 
     if (syncConfig === undefined) {
       throw new SyncNotConfiguredError(params.vaultId, "apply sync resolution");
+    }
+
+    if (unlockedVault.vault.syncRemovalPending === true) {
+      throw new SyncRemovalPendingError(
+        params.vaultId,
+        "apply sync resolution",
+      );
     }
 
     if (params.remoteSnapshotDescriptor.vaultId !== params.vaultId) {
@@ -346,7 +354,11 @@ export class ApplySyncResolutionUseCase {
           unlockedVault,
         );
       } catch {
-        // Preserve the upload failure as the root cause.
+        try {
+          await this.unlockedVaultSession.remove();
+        } catch {
+          // Preserve the upload failure as the root cause.
+        }
       }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -148,6 +148,11 @@ export class ApplySyncResolutionUseCase {
       syncConfig,
       params.remoteSnapshotDescriptor,
     );
+    const remoteTrust = await this.vaultSnapshot.verifyCandidateSnapshotTrust(
+      params.vaultId,
+      remoteSnapshot,
+      unlockedVault,
+    );
     const { vault: remoteVault, completedEnrollmentProof } =
       await this.vaultSnapshot.openTrustedVaultSnapshotWithTrustResult(
         params.vaultId,
@@ -311,10 +316,12 @@ export class ApplySyncResolutionUseCase {
       acceptedCompletedEnrollmentTrustState === null
         ? {
             baseSnapshotVersionVector,
+            nextTrust: remoteTrust,
           }
         : {
             baseSnapshotVersionVector,
             keySlots: acceptedCompletedEnrollmentTrustState.keySlots,
+            nextTrust: remoteTrust,
           };
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
@@ -323,9 +330,7 @@ export class ApplySyncResolutionUseCase {
       persistOptions,
     );
 
-    const resolvedSnapshot = await this.vaultSnapshot.requireLocalVaultSnapshot(
-      params.vaultId,
-    );
+    const resolvedSnapshot = persistedSnapshot.snapshot;
 
     try {
       await this.syncProvider.uploadVaultSnapshot(
@@ -335,7 +340,11 @@ export class ApplySyncResolutionUseCase {
       );
     } catch (error) {
       try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(localSnapshot);
+        await this.vaultSnapshot.restoreLocalVaultSnapshot(
+          localSnapshot,
+          resolvedSnapshot,
+          unlockedVault,
+        );
       } catch {
         // Preserve the upload failure as the root cause.
       }
@@ -348,7 +357,10 @@ export class ApplySyncResolutionUseCase {
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
 

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -227,19 +227,36 @@ describe("DisableSyncUseCase", () => {
         .invocationCallOrder[0],
     );
     expect(
-      vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
+      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
+      vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
         .invocationCallOrder[0],
     );
     expect(
-      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
+      vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
         .invocationCallOrder[0],
     );
+  });
+
+  it("keeps remote snapshots when local persistence fails", async () => {
+    const ctx = createContext();
+    const error = new Error("local persistence failed");
+    vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mockRejectedValueOnce(
+      error,
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toThrow(error);
+
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commit,
+    ).not.toHaveBeenCalled();
   });
 
   it("fails when the target vault is not unlocked", async () => {
@@ -386,7 +403,7 @@ describe("DisableSyncUseCase", () => {
     );
   });
 
-  it("does not remove local sync config when remote removal fails", async () => {
+  it("does not update the session when remote removal fails", async () => {
     const ctx = createContext();
     vi.mocked(
       ctx.ports.syncProvider.removeVaultSnapshots,
@@ -398,7 +415,10 @@ describe("DisableSyncUseCase", () => {
       }),
     ).rejects.toThrow("remove failed");
 
-    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commit,
+    ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
     );
@@ -416,7 +436,7 @@ describe("DisableSyncUseCase", () => {
       }),
     ).rejects.toThrow("persist failed");
 
-    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -49,6 +49,7 @@ function createContext(syncConfigured = true) {
     vaultSnapshot,
     useCase: new DisableSyncUseCase(
       ports.clock,
+      ports.crypto,
       ports.syncProvider,
       ports.sessionServices.unlockedVaultSession,
       vaultSnapshot,
@@ -189,12 +190,35 @@ describe("DisableSyncUseCase", () => {
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock.calls[0]?.[3],
-    ).toEqual({
+    ).toMatchObject({
       keySlots: {
         deviceSlots: [currentDeviceSlot],
-        completedEnrollments: undefined,
+      },
+      nextTrust: {
+        state: {
+          generation: 1,
+          trustedDevices: [
+            {
+              deviceId: ctx.values.deviceId,
+              publicSignKey: ctx.values.devicePublicSignKey,
+            },
+          ],
+        },
       },
     });
+    expect(ctx.ports.crypto.signVaultTrustCertificate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: 1,
+        authorizedByDeviceId: ctx.values.deviceId,
+        trustedDevices: [
+          {
+            deviceId: ctx.values.deviceId,
+            publicSignKey: ctx.values.devicePublicSignKey,
+          },
+        ],
+      }),
+      ctx.values.devicePrivateSignKey,
+    );
     expect(
       vi.mocked(ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault).mock
         .invocationCallOrder[0],

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -74,7 +74,7 @@ describe("DisableSyncUseCase", () => {
     const localSnapshot = {
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1 as const,
+        schemaVersion: 2 as const,
         vaultCreationTimestamp: ctx.values.timestamp - 1_000,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -83,6 +83,7 @@ describe("DisableSyncUseCase", () => {
         algorithmSuiteId: ctx.ports.crypto.algorithmSuite.id,
         createdByDeviceId: ctx.values.deviceId,
       },
+      trustChain: ctx.values.vaultTrustChain,
       keySlots: {
         deviceSlots: [currentDeviceSlot, otherDeviceSlot],
         enrollmentKeySlot: {

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -58,7 +58,7 @@ function createContext(syncConfigured = true) {
 }
 
 describe("DisableSyncUseCase", () => {
-  it("removes remote snapshots and then removes local sync config", async () => {
+  it("marks cleanup pending, removes remote snapshots, then removes local sync config", async () => {
     const ctx = createContext();
     const otherDeviceId = "other-device-id";
     const currentDeviceSlot = {
@@ -125,6 +125,7 @@ describe("DisableSyncUseCase", () => {
         },
       },
     };
+    const initialUnlockedVault = ctx.saved.unlockedVaultSession.unlockedVault;
     vi.mocked(
       ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault,
     ).mockResolvedValueOnce(localSnapshot);
@@ -142,16 +143,16 @@ describe("DisableSyncUseCase", () => {
     ).toBeUndefined();
     expect(ctx.saved.unlockedVaultSession?.sourceSnapshotVersionVector).toEqual(
       {
-        [ctx.values.deviceId]: 2,
+        [ctx.values.deviceId]: 3,
       },
     );
 
     const persistedUnlockedVault = vi.mocked(
       ctx.vaultSnapshot.persistUnlockedVault,
-    ).mock.calls[0]?.[1];
+    ).mock.calls[1]?.[1];
     const sourceSnapshotVersionVector = vi.mocked(
       ctx.vaultSnapshot.persistUnlockedVault,
-    ).mock.calls[0]?.[2];
+    ).mock.calls[1]?.[2];
 
     expect(persistedUnlockedVault).toBeDefined();
     expect("syncConfig" in persistedUnlockedVault!.vault).toBe(false);
@@ -179,17 +180,15 @@ describe("DisableSyncUseCase", () => {
       },
     ]);
     expect(sourceSnapshotVersionVector).toEqual({
-      [ctx.values.deviceId]: 1,
+      [ctx.values.deviceId]: 2,
     });
     expect(
       ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault,
-    ).toHaveBeenCalledWith(
-      ctx.values.vaultId,
-      persistedUnlockedVault,
-      sourceSnapshotVersionVector,
-    );
+    ).toHaveBeenCalledWith(ctx.values.vaultId, initialUnlockedVault, {
+      [ctx.values.deviceId]: 1,
+    });
     expect(
-      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock.calls[0]?.[3],
+      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock.calls[1]?.[3],
     ).toMatchObject({
       keySlots: {
         deviceSlots: [currentDeviceSlot],
@@ -234,29 +233,19 @@ describe("DisableSyncUseCase", () => {
         .invocationCallOrder[0],
     );
     expect(
+      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
+        .invocationCallOrder[0],
+    );
+    expect(
       vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
+        .invocationCallOrder[1],
     );
-  });
-
-  it("keeps remote snapshots when local persistence fails", async () => {
-    const ctx = createContext();
-    const error = new Error("local persistence failed");
-    vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mockRejectedValueOnce(
-      error,
-    );
-
-    await expect(
-      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
-    ).rejects.toThrow(error);
-
-    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
-    ).not.toHaveBeenCalled();
   });
 
   it("fails when the target vault is not unlocked", async () => {
@@ -403,7 +392,7 @@ describe("DisableSyncUseCase", () => {
     );
   });
 
-  it("does not update the session when remote removal fails", async () => {
+  it("keeps encrypted sync config while remote cleanup is pending", async () => {
     const ctx = createContext();
     vi.mocked(
       ctx.ports.syncProvider.removeVaultSnapshots,
@@ -418,10 +407,66 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.vaultSnapshot.persistUnlockedVault).toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
-    ).not.toHaveBeenCalled();
-    expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
-      ctx.values.syncConfig,
+    ).toHaveBeenCalled();
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
+    ).toEqual(ctx.values.syncConfig);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toBe(true);
+    expect(ctx.saved.unlockedVaultSession?.sourceSnapshotVersionVector).toEqual(
+      {
+        [ctx.values.deviceId]: 2,
+      },
     );
+  });
+
+  it("retries pending remote cleanup without re-enabling sync", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.removeVaultSnapshots,
+    ).mockRejectedValueOnce(new Error("remove failed"));
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toThrow("remove failed");
+
+    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).toHaveBeenCalledTimes(1);
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
+    ).toBeUndefined();
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toBeUndefined();
+  });
+
+  it("keeps cleanup pending when final local cleanup persistence fails", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.removeVaultSnapshots,
+    ).mockImplementationOnce(async () => {
+      vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mockRejectedValueOnce(
+        new Error("final persist failed"),
+      );
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toThrow("final persist failed");
+
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
+    ).toEqual(ctx.values.syncConfig);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toBe(true);
   });
 
   it("does not update the session when local snapshot persistence fails", async () => {

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -1,5 +1,6 @@
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
 import {
   areVaultSnapshotDescriptorsEqual,
   compareVaultSnapshotDescriptors,
@@ -12,7 +13,9 @@ import {
   RemoteVaultSnapshotIntegrityError,
   SyncNotConfiguredError,
 } from "../../errors/sync.errors";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import type { ClockPort } from "../../ports/system/clock.port";
+import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 
 export type DisableSyncCommandParams = {
@@ -24,9 +27,11 @@ export class DisableSyncUseCase {
   private readonly syncProvider: SyncProviderPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultSnapshot: VaultSnapshotService;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     clock: ClockPort,
+    crypto: CryptoPort,
     syncProvider: SyncProviderPort,
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultSnapshot: VaultSnapshotService,
@@ -35,6 +40,7 @@ export class DisableSyncUseCase {
     this.syncProvider = syncProvider;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultSnapshot = vaultSnapshot;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(params: DisableSyncCommandParams): Promise<void> {
@@ -99,11 +105,31 @@ export class DisableSyncUseCase {
       }
     }
 
-    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
-
     const currentDeviceSlots = localSnapshot.keySlots.deviceSlots.filter(
       (deviceSlot) => deviceSlot.deviceId === unlockedVault.deviceId,
     );
+    const trustChain = localSnapshot.trustChain;
+
+    if (trustChain === undefined) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "trust chain is missing",
+      );
+    }
+
+    const nextTrust = await this.vaultTrust.appendTrustTransition(
+      params.vaultId,
+      trustChain,
+      unlockedVault.trustedSnapshotContext.trust,
+      unlockedVault.trustedSnapshotContext.trust.trustedDevices.filter(
+        (device) => device.deviceId === unlockedVault.deviceId,
+      ),
+      unlockedVault.deviceId,
+      unlockedVault.devicePrivateSignKey,
+    );
+
+    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
+
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
@@ -112,6 +138,10 @@ export class DisableSyncUseCase {
         keySlots: {
           deviceSlots: currentDeviceSlots,
           completedEnrollments: localSnapshot.keySlots.completedEnrollments,
+        },
+        nextTrust: {
+          chain: nextTrust.chain,
+          state: nextTrust.trust,
         },
       },
     );

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -117,7 +117,10 @@ export class DisableSyncUseCase {
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
   }

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -128,8 +128,6 @@ export class DisableSyncUseCase {
       unlockedVault.devicePrivateSignKey,
     );
 
-    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
-
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
@@ -145,6 +143,8 @@ export class DisableSyncUseCase {
         },
       },
     );
+
+    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
       {

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -6,7 +6,10 @@ import {
   compareVaultSnapshotDescriptors,
   toVaultSnapshotDescriptor,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
-import { removeVaultSyncConfig } from "../../domain/vault/vault-sync-config.mutations";
+import {
+  markVaultSyncRemovalPending,
+  removeVaultSyncConfig,
+} from "../../domain/vault/vault-sync-config.mutations";
 import { removeOtherDeviceProfilesFromVault } from "../../domain/vault/vault-device.mutations";
 import {
   RemoteVaultSnapshotAheadError,
@@ -55,60 +58,88 @@ export class DisableSyncUseCase {
       throw new SyncNotConfiguredError(params.vaultId, "disable sync");
     }
 
+    let currentUnlockedVault = unlockedVault;
+    let currentSnapshotVersionVector = sourceSnapshotVersionVector;
+    let currentSnapshot =
+      await this.vaultSnapshot.requireCurrentSnapshotForUnlockedVault(
+        params.vaultId,
+        currentUnlockedVault,
+        currentSnapshotVersionVector,
+      );
+
+    if (currentUnlockedVault.vault.syncRemovalPending !== true) {
+      const remoteSnapshotDescriptor =
+        await this.syncProvider.getLatestVaultSnapshotDescriptor(
+          syncConfig,
+          params.vaultId,
+        );
+
+      if (remoteSnapshotDescriptor !== null) {
+        const localSnapshotDescriptor = toVaultSnapshotDescriptor(
+          params.vaultId,
+          currentSnapshot,
+        );
+        const relation = compareVaultSnapshotDescriptors(
+          localSnapshotDescriptor,
+          remoteSnapshotDescriptor,
+        );
+
+        if (relation === "remote_ahead") {
+          throw new RemoteVaultSnapshotAheadError(params.vaultId);
+        }
+
+        if (
+          relation === "broken" ||
+          (relation === "equal" &&
+            !areVaultSnapshotDescriptorsEqual(
+              remoteSnapshotDescriptor,
+              localSnapshotDescriptor,
+            ))
+        ) {
+          throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+        }
+      }
+
+      const pendingUnlockedVault = {
+        ...unlockedVault,
+        vault: markVaultSyncRemovalPending(unlockedVault.vault),
+      };
+      const pendingSnapshot = await this.vaultSnapshot.persistUnlockedVault(
+        params.vaultId,
+        pendingUnlockedVault,
+        sourceSnapshotVersionVector,
+      );
+
+      currentUnlockedVault = {
+        ...pendingUnlockedVault,
+        trustedSnapshotContext: pendingSnapshot.trustedSnapshotContext,
+      };
+      currentSnapshotVersionVector = pendingSnapshot.snapshotVersionVector;
+      currentSnapshot = pendingSnapshot.snapshot;
+
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        currentUnlockedVault,
+        currentSnapshotVersionVector,
+      );
+    }
+
+    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
+
     const revisionTimestamp = this.clock.now();
     const updatedUnlockedVault = {
-      ...unlockedVault,
+      ...currentUnlockedVault,
       vault: removeVaultSyncConfig(
         removeOtherDeviceProfilesFromVault(
-          unlockedVault.vault,
-          unlockedVault.deviceId,
+          currentUnlockedVault.vault,
+          currentUnlockedVault.deviceId,
           revisionTimestamp,
         ),
       ),
     };
-
-    const localSnapshot =
-      await this.vaultSnapshot.requireCurrentSnapshotForUnlockedVault(
-        params.vaultId,
-        updatedUnlockedVault,
-        sourceSnapshotVersionVector,
-      );
-    const remoteSnapshotDescriptor =
-      await this.syncProvider.getLatestVaultSnapshotDescriptor(
-        syncConfig,
-        params.vaultId,
-      );
-
-    if (remoteSnapshotDescriptor !== null) {
-      const localSnapshotDescriptor = toVaultSnapshotDescriptor(
-        params.vaultId,
-        localSnapshot,
-      );
-      const relation = compareVaultSnapshotDescriptors(
-        localSnapshotDescriptor,
-        remoteSnapshotDescriptor,
-      );
-
-      if (relation === "remote_ahead") {
-        throw new RemoteVaultSnapshotAheadError(params.vaultId);
-      }
-
-      if (
-        relation === "broken" ||
-        (relation === "equal" &&
-          !areVaultSnapshotDescriptorsEqual(
-            remoteSnapshotDescriptor,
-            localSnapshotDescriptor,
-          ))
-      ) {
-        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
-      }
-    }
-
-    const currentDeviceSlots = localSnapshot.keySlots.deviceSlots.filter(
-      (deviceSlot) => deviceSlot.deviceId === unlockedVault.deviceId,
+    const currentDeviceSlots = currentSnapshot.keySlots.deviceSlots.filter(
+      (deviceSlot) => deviceSlot.deviceId === currentUnlockedVault.deviceId,
     );
-    const trustChain = localSnapshot.trustChain;
+    const trustChain = currentSnapshot.trustChain;
 
     if (trustChain === undefined) {
       throw new VaultTrustStateInvalidError(
@@ -120,22 +151,22 @@ export class DisableSyncUseCase {
     const nextTrust = await this.vaultTrust.appendTrustTransition(
       params.vaultId,
       trustChain,
-      unlockedVault.trustedSnapshotContext.trust,
-      unlockedVault.trustedSnapshotContext.trust.trustedDevices.filter(
-        (device) => device.deviceId === unlockedVault.deviceId,
+      currentUnlockedVault.trustedSnapshotContext.trust,
+      currentUnlockedVault.trustedSnapshotContext.trust.trustedDevices.filter(
+        (device) => device.deviceId === currentUnlockedVault.deviceId,
       ),
-      unlockedVault.deviceId,
-      unlockedVault.devicePrivateSignKey,
+      currentUnlockedVault.deviceId,
+      currentUnlockedVault.devicePrivateSignKey,
     );
 
     const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
       params.vaultId,
       updatedUnlockedVault,
-      sourceSnapshotVersionVector,
+      currentSnapshotVersionVector,
       {
         keySlots: {
           deviceSlots: currentDeviceSlots,
-          completedEnrollments: localSnapshot.keySlots.completedEnrollments,
+          completedEnrollments: currentSnapshot.keySlots.completedEnrollments,
         },
         nextTrust: {
           chain: nextTrust.chain,
@@ -143,8 +174,6 @@ export class DisableSyncUseCase {
         },
       },
     );
-
-    await this.syncProvider.removeVaultSnapshots(syncConfig, params.vaultId);
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
       {

--- a/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
@@ -9,6 +9,7 @@ import {
   RemoteVaultSnapshotIntegrityError,
   RemoteVaultSnapshotNotFoundError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
@@ -500,6 +501,29 @@ describe("PrepareSyncReviewUseCase", () => {
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).rejects.toBeInstanceOf(SyncNotConfiguredError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not read remote state while remote cleanup is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncRemovalPending: true,
+        },
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncRemovalPendingError);
 
     expect(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,

--- a/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
@@ -27,7 +27,7 @@ function createSnapshot(
   return {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -37,6 +37,7 @@ function createSnapshot(
       createdByDeviceId: values.deviceId,
       ...overrides,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {
@@ -203,7 +204,7 @@ describe("PrepareSyncReviewUseCase", () => {
     });
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(ctx.saved.vaultSnapshot).toBe(ctx.localSnapshot);
@@ -248,7 +249,7 @@ describe("PrepareSyncReviewUseCase", () => {
     ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(ctx.saved.vaultSnapshot).toBe(ctx.localSnapshot);
@@ -345,7 +346,7 @@ describe("PrepareSyncReviewUseCase", () => {
 
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
@@ -414,7 +415,7 @@ describe("PrepareSyncReviewUseCase", () => {
     ).rejects.toBeInstanceOf(InvalidVaultSyncReviewError);
 
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });

--- a/packages/core/src/use-cases/sync/prepare-sync-review.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.ts
@@ -129,6 +129,11 @@ export class PrepareSyncReviewUseCase {
       syncConfig,
       remoteSnapshotDescriptor,
     );
+    await this.vaultSnapshot.verifyCandidateSnapshotTrust(
+      params.vaultId,
+      remoteSnapshot,
+      unlockedVault,
+    );
     const remoteVault = await this.vaultSnapshot.openTrustedVaultSnapshot(
       params.vaultId,
       remoteSnapshot,

--- a/packages/core/src/use-cases/sync/prepare-sync-review.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.ts
@@ -12,6 +12,7 @@ import {
   RemoteVaultSnapshotIntegrityError,
   RemoteVaultSnapshotNotFoundError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
@@ -73,6 +74,10 @@ export class PrepareSyncReviewUseCase {
 
     if (syncConfig === undefined) {
       throw new SyncNotConfiguredError(params.vaultId, "prepare sync review");
+    }
+
+    if (unlockedVault.vault.syncRemovalPending === true) {
+      throw new SyncRemovalPendingError(params.vaultId, "prepare sync review");
     }
 
     const localSnapshot =

--- a/packages/core/src/use-cases/sync/setup-sync.test.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.test.ts
@@ -21,6 +21,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
+    ports.sessionServices.unlockedVaultSession,
   );
   const unlockedVault = createUnlockedVaultWithEntries(values, []);
 
@@ -234,6 +235,31 @@ describe("SetupSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
     ).toBeUndefined();
+  });
+
+  it("invalidates the session when first sync upload restoration fails", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+      new Error("upload failed"),
+    );
+    vi.mocked(
+      ctx.vaultSnapshot.restoreLocalVaultSnapshot,
+    ).mockRejectedValueOnce(new Error("restore failed"));
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).rejects.toThrow("upload failed");
+
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.remove,
+    ).toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commit,
+    ).not.toHaveBeenCalled();
   });
 
   it("bubbles the session commit failure after snapshot persistence", async () => {

--- a/packages/core/src/use-cases/sync/setup-sync.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.ts
@@ -85,11 +85,15 @@ export class SetupSyncUseCase {
       params.vaultId,
       syncConfig,
       syncState.localSnapshot,
-      await this.vaultSnapshot.requireLocalVaultSnapshot(params.vaultId),
+      persistedSnapshot.snapshot,
+      unlockedVault,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
   }

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -25,7 +25,7 @@ function createSnapshot(
   return {
     metadata: {
       id: values.vaultId,
-      schemaVersion: 1,
+      schemaVersion: 2,
       vaultCreationTimestamp: values.timestamp - 1_000,
       revisionTimestamp: values.timestamp,
       snapshotVersionVector: {
@@ -35,6 +35,7 @@ function createSnapshot(
       createdByDeviceId: values.deviceId,
       ...overrides,
     },
+    trustChain: values.vaultTrustChain,
     keySlots: {
       deviceSlots: [
         {

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -156,7 +156,6 @@ describe("SyncUploadUseCase", () => {
   it("skips upload when the remote descriptor already matches the vault", async () => {
     const ctx = createContext();
     const localSnapshot = createSnapshot(ctx.values, {
-      id: "snapshot-id",
       snapshotVersionVector: {
         [ctx.values.deviceId]: 3,
       },

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -11,6 +11,7 @@ import {
   RemoteVaultSnapshotIntegrityError,
   SyncConflictDetectedError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSnapshotNotFoundError } from "../../errors/unlock-vault.errors";
@@ -363,6 +364,30 @@ describe("SyncUploadUseCase", () => {
     expect(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).not.toHaveBeenCalled();
+  });
+
+  it("does not read or upload while remote cleanup is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncRemovalPending: true,
+        },
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncRemovalPendingError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
 
   it("fails when the local snapshot is missing", async () => {

--- a/packages/core/src/use-cases/sync/sync-upload.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.ts
@@ -9,6 +9,7 @@ import {
   RemoteVaultSnapshotIntegrityError,
   SyncConflictDetectedError,
   SyncNotConfiguredError,
+  SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
@@ -43,6 +44,10 @@ export class SyncUploadUseCase {
 
     if (syncConfig === undefined) {
       throw new SyncNotConfiguredError(params.vaultId, "sync upload");
+    }
+
+    if (unlockedVault.vault.syncRemovalPending === true) {
+      throw new SyncRemovalPendingError(params.vaultId, "sync upload");
     }
 
     const localSnapshot =

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -22,6 +22,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
+    ports.sessionServices.unlockedVaultSession,
   );
   vi.mocked(ports.ids.generateId).mockReset().mockResolvedValue("entry-id");
 
@@ -152,6 +153,40 @@ describe("AddEntryUseCase", () => {
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("persists local changes without reading remote state while cleanup is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncConfig: ctx.values.syncConfig,
+          syncRemovalPending: true,
+        },
+      },
+    };
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entry: {
+        password: "secret-password",
+        login: "user@example.com",
+        tags: [],
+        url: "https://example.com/login",
+      },
+    });
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toBe(true);
   });
 
   it("does not add an entry when synced remote changes must be downloaded first", async () => {
@@ -323,6 +358,55 @@ describe("AddEntryUseCase", () => {
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the session when synced upload restoration fails", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: {
+        [ctx.values.deviceId]: 1,
+      },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const session = ctx.saved.unlockedVaultSession!;
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncConfig: ctx.values.syncConfig,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    );
+    vi.mocked(
+      ctx.vaultSnapshot.restoreLocalVaultSnapshot,
+    ).mockRejectedValueOnce(new Error("restore failed"));
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: "secret-password",
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.remove,
+    ).toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 
   it("does not save the session vault when snapshot persistence fails", async () => {

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -311,6 +311,14 @@ describe("AddEntryUseCase", () => {
           },
         }),
       }),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          snapshotVersionVector: {
+            [ctx.values.deviceId]: 2,
+          },
+        }),
+      }),
+      expect.objectContaining({ vaultId: ctx.values.vaultId }),
     );
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,

--- a/packages/core/src/use-cases/vault-entries/add-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.ts
@@ -96,18 +96,23 @@ export class AddEntryUseCase {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
-        await this.vaultSnapshot.requireLocalVaultSnapshot(params.vaultId),
+        persistedSnapshot.snapshot,
+        updatedUnlockedVault,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
 
     return {
       entryId,
-      ...persistedSnapshot,
+      snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+      revisionTimestamp: persistedSnapshot.revisionTimestamp,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
@@ -20,6 +20,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
+    ports.sessionServices.unlockedVaultSession,
   );
   saveUnlockedVaultWithEntries(ports, values, standardPasswordEntries);
 

--- a/packages/core/src/use-cases/vault-entries/remove-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.ts
@@ -76,18 +76,23 @@ export class RemoveEntryUseCase {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
-        await this.vaultSnapshot.requireLocalVaultSnapshot(params.vaultId),
+        persistedSnapshot.snapshot,
+        updatedUnlockedVault,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
 
     return {
       entryId: params.entryId,
-      ...persistedSnapshot,
+      snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+      revisionTimestamp: persistedSnapshot.revisionTimestamp,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -23,6 +23,7 @@ function createContext() {
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
+    ports.sessionServices.unlockedVaultSession,
   );
   saveUnlockedVaultWithEntries(ports, values, standardPasswordEntries);
 

--- a/packages/core/src/use-cases/vault-entries/update-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.ts
@@ -102,18 +102,23 @@ export class UpdateEntryUseCase {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
-        await this.vaultSnapshot.requireLocalVaultSnapshot(params.vaultId),
+        persistedSnapshot.snapshot,
+        updatedUnlockedVault,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
-      updatedUnlockedVault,
+      {
+        ...updatedUnlockedVault,
+        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+      },
       persistedSnapshot.snapshotVersionVector,
     );
 
     return {
       entryId: params.entryId,
-      ...persistedSnapshot,
+      snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
+      revisionTimestamp: persistedSnapshot.revisionTimestamp,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
@@ -62,6 +62,7 @@ describe("ChangeMasterPasswordUseCase", () => {
       {
         deviceSlotKey: ctx.values.deviceSlotKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       ctx.values.newLocalKeysProtectionKey,
     );

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -19,6 +19,11 @@ function createContext() {
       vault: values.decryptedVault,
       vaultMasterKey: values.vaultMasterKey,
       devicePrivateSignKey: values.devicePrivateSignKey,
+      trustedSnapshotContext: {
+        snapshotDigest: values.vaultSnapshotDigest,
+        trust: values.verifiedVaultTrustState,
+      },
+      vaultTrustAnchor: values.vaultTrustAnchor,
     },
     sourceSnapshotVersionVector: {
       [values.deviceId]: 1,

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -39,6 +39,7 @@ describe("InitializeVaultUseCase", () => {
     const expectedLocalKeysPayload: LocalKeysPayload = {
       deviceSlotKey: ctx.values.deviceSlotKey,
       devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+      vaultTrustAnchor: ctx.values.vaultTrustAnchor,
     };
 
     expect(ctx.ports.crypto.wrapLocalKeysPayload).toHaveBeenCalledWith(
@@ -117,7 +118,7 @@ describe("InitializeVaultUseCase", () => {
     expect(ctx.saved.vaultSnapshot).toEqual({
       metadata: {
         id: ctx.values.vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: ctx.values.timestamp,
         revisionTimestamp: ctx.values.timestamp,
         snapshotVersionVector: {
@@ -126,6 +127,7 @@ describe("InitializeVaultUseCase", () => {
         algorithmSuiteId: CURRENT_ALGORITHM_SUITE.id,
         createdByDeviceId: ctx.values.deviceId,
       },
+      trustChain: ctx.values.vaultTrustChain,
       keySlots: {
         deviceSlots: [
           {
@@ -142,6 +144,7 @@ describe("InitializeVaultUseCase", () => {
     expect(ctx.ports.crypto.signVaultSnapshot).toHaveBeenCalledWith(
       {
         metadata: ctx.saved.vaultSnapshot?.metadata,
+        trustChain: ctx.saved.vaultSnapshot?.trustChain,
         keySlots: ctx.saved.vaultSnapshot?.keySlots,
         content: ctx.saved.vaultSnapshot?.content,
       },
@@ -155,11 +158,19 @@ describe("InitializeVaultUseCase", () => {
         vault: expectedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: ctx.values.verifiedVaultTrustState,
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 1,
       },
     });
+    expect(ctx.saved.localVaultTrustCheckpoint).toEqual(
+      ctx.values.localVaultTrustCheckpoint,
+    );
   });
 
   it("bubbles local initialization errors and does not save unlocked state", async () => {
@@ -190,7 +201,7 @@ describe("InitializeVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.saveDeviceAccessMaterial,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.saveVaultSnapshot,
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
   });
 
@@ -257,6 +268,11 @@ describe("InitializeVaultUseCase", () => {
       vaultMasterKey: ctx.values.vaultMasterKey,
       devicePrivateSignKey: ctx.values.devicePrivateSignKey,
       payloadKey: ctx.values.unlockedVaultSessionPayloadKey,
+      trustedSnapshotContext: {
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+        trust: ctx.values.verifiedVaultTrustState,
+      },
+      vaultTrustAnchor: ctx.values.vaultTrustAnchor,
     };
 
     await expect(

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -18,6 +18,7 @@ import type { IdPort } from "../../ports/system/id.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
 
 export type InitializeVaultCommandParams = {
   masterPassword: RawMasterPassword;
@@ -37,6 +38,7 @@ export class InitializeVaultUseCase {
   private readonly ids: IdPort;
   private readonly clock: ClockPort;
   private readonly vaultDisplayName: VaultDisplayNamePort;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     crypto: CryptoPort,
@@ -54,6 +56,7 @@ export class InitializeVaultUseCase {
     this.ids = ids;
     this.clock = clock;
     this.vaultDisplayName = vaultDisplayName;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(
@@ -70,6 +73,14 @@ export class InitializeVaultUseCase {
     const vaultMasterKey = await this.crypto.generateVaultMasterKey();
     const deviceSlotKey = await this.crypto.generateDeviceSlotKey();
     const deviceSignKeyPair = await this.crypto.generateDeviceSignKeyPair();
+    const genesisTrust = await this.vaultTrust.createGenesis(
+      vaultId,
+      {
+        deviceId,
+        publicSignKey: deviceSignKeyPair.publicKey,
+      },
+      deviceSignKeyPair.privateKey,
+    );
     const recoverySecretKey = await this.crypto.generateRecoveryKey();
     const recoveryMnemonicKey =
       await this.bip39.recoveryKeyToMnemonic(recoverySecretKey);
@@ -92,6 +103,7 @@ export class InitializeVaultUseCase {
     const localKeysPayload: LocalKeysPayload = {
       deviceSlotKey: deviceSlotKey,
       devicePrivateSignKey: deviceSignKeyPair.privateKey,
+      vaultTrustAnchor: genesisTrust.anchor,
     };
 
     const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
@@ -144,7 +156,7 @@ export class InitializeVaultUseCase {
     const unsignedVaultSnapshot: UnsignedVaultSnapshot = {
       metadata: {
         id: vaultId,
-        schemaVersion: 1,
+        schemaVersion: 2,
         vaultCreationTimestamp: timestamp,
         revisionTimestamp: timestamp,
         snapshotVersionVector: {
@@ -153,6 +165,7 @@ export class InitializeVaultUseCase {
         algorithmSuiteId: this.crypto.algorithmSuite.id,
         createdByDeviceId: deviceId,
       },
+      trustChain: genesisTrust.chain,
       keySlots: {
         deviceSlots: [
           {
@@ -206,14 +219,26 @@ export class InitializeVaultUseCase {
       vault,
       vaultMasterKey,
       devicePrivateSignKey: deviceSignKeyPair.privateKey,
+      trustedSnapshotContext: {
+        snapshotDigest: await this.crypto.digestVaultSnapshot(vaultSnapshot),
+        trust: genesisTrust.trust,
+      },
+      vaultTrustAnchor: genesisTrust.anchor,
     };
+    const checkpoint = await this.vaultTrust.createCheckpoint(
+      vaultSnapshot,
+      genesisTrust.trust,
+      deviceId,
+      deviceSignKeyPair.privateKey,
+    );
 
-    await this.vaultLocalRepository.saveInitializedLocalVault(
-      localVaultDescriptor,
+    await this.vaultLocalRepository.saveInitializedLocalVault({
+      descriptor: localVaultDescriptor,
       deviceAccessMaterial,
       deviceAccessRecoveryBackup,
-      vaultSnapshot,
-    );
+      snapshot: vaultSnapshot,
+      checkpoint,
+    });
     try {
       await this.unlockedVaultSession.commit(
         unlockedVault,

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -74,6 +74,11 @@ describe("UnlockVaultUseCase", () => {
         vault: ctx.values.decryptedVault,
         vaultMasterKey: ctx.values.vaultMasterKey,
         devicePrivateSignKey: ctx.values.devicePrivateSignKey,
+        trustedSnapshotContext: {
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+          trust: ctx.values.verifiedVaultTrustState,
+        },
+        vaultTrustAnchor: ctx.values.vaultTrustAnchor,
       },
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 1,
@@ -101,6 +106,24 @@ describe("UnlockVaultUseCase", () => {
       metadata: {
         ...ctx.vaultSnapshot.metadata,
         createdByDeviceId: "other-device-id",
+      },
+      trustChain: {
+        ...ctx.values.vaultTrustChain,
+        certificates: [
+          {
+            ...ctx.values.vaultTrustCertificate,
+            payload: {
+              ...ctx.values.vaultTrustCertificate.payload,
+              trustedDevices: [
+                ...ctx.values.vaultTrustCertificate.payload.trustedDevices,
+                {
+                  deviceId: "other-device-id",
+                  publicSignKey: ctx.values.pendingDevicePublicSignKey,
+                },
+              ],
+            },
+          },
+        ],
       },
       keySlots: {
         ...ctx.vaultSnapshot.keySlots,
@@ -193,7 +216,9 @@ describe("UnlockVaultUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(VaultSnapshotSignatureVerificationFailedError);
 
-    expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.deriveLocalRootKey).toHaveBeenCalled();
+    expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();
@@ -305,7 +330,7 @@ describe("UnlockVaultUseCase", () => {
     expect(
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
-    expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.deriveLocalRootKey).toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commit,
     ).not.toHaveBeenCalled();
@@ -507,6 +532,11 @@ describe("UnlockVaultUseCase", () => {
       vaultMasterKey: ctx.values.vaultMasterKey,
       devicePrivateSignKey: ctx.values.devicePrivateSignKey,
       payloadKey: ctx.values.unlockedVaultSessionPayloadKey,
+      trustedSnapshotContext: {
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+        trust: ctx.values.verifiedVaultTrustState,
+      },
+      vaultTrustAnchor: ctx.values.vaultTrustAnchor,
     };
 
     await expect(

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -13,6 +13,7 @@ import {
   InvalidVaultLockDelayError,
 } from "../../errors/vault-session.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 
 describe("UnlockVaultUseCase", () => {
@@ -159,6 +160,100 @@ describe("UnlockVaultUseCase", () => {
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.deviceId).toBe(
       ctx.values.deviceId,
     );
+  });
+
+  it("rejects a local device revoked by the verified trust chain", async () => {
+    const ctx = createUnlockVaultTestContext();
+    const remainingDeviceId = "remaining-device-id";
+    ctx.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      trustChain: {
+        certificates: [
+          ctx.values.vaultTrustCertificate,
+          {
+            ...ctx.values.vaultTrustCertificate,
+            payload: {
+              ...ctx.values.vaultTrustCertificate.payload,
+              generation: 1,
+              previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
+              trustedDevices: [
+                {
+                  deviceId: remainingDeviceId,
+                  publicSignKey: ctx.values.pendingDevicePublicSignKey,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        masterPassword: ctx.values.masterPassword,
+        lockAfterMs: 600_000,
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commit,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported snapshot schema before trust-chain verification", async () => {
+    const ctx = createUnlockVaultTestContext();
+    ctx.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        schemaVersion: 1,
+      },
+    } as unknown as typeof ctx.vaultSnapshot;
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        masterPassword: ctx.values.masterPassword,
+        lockAfterMs: 600_000,
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("updates a newer checkpoint with the snapshot-and-checkpoint compare-and-set", async () => {
+    const ctx = createUnlockVaultTestContext();
+    ctx.saved.vaultSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        snapshotVersionVector: {
+          [ctx.values.deviceId]: 2,
+        },
+      },
+    };
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      masterPassword: ctx.values.masterPassword,
+      lockAfterMs: 600_000,
+    });
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenCalledWith({
+      expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+      snapshot: ctx.saved.vaultSnapshot,
+      checkpoint: expect.objectContaining({
+        payload: expect.objectContaining({
+          snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+        }),
+      }),
+    });
   });
 
   it("fails when device access material is missing", async () => {

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
@@ -196,6 +196,23 @@ export class UnlockVaultUseCase {
       localKeysPayload.vaultTrustAnchor,
       this.requireTrustChain(params.vaultId, vaultSnapshot),
     );
+    const trustedLocalDevice = verifiedTrust.trustedDevices.find(
+      (device) => device.deviceId === deviceAccessMaterial.deviceId,
+    );
+
+    if (
+      trustedLocalDevice === undefined ||
+      !(await this.crypto.verifyDeviceSignKeyPair(
+        trustedLocalDevice.publicSignKey,
+        localKeysPayload.devicePrivateSignKey,
+      ))
+    ) {
+      throw new VaultTrustStateInvalidError(
+        params.vaultId,
+        "local device is not trusted",
+      );
+    }
+
     await this.vaultTrust.verifySnapshot(
       params.vaultId,
       vaultSnapshot,
@@ -227,14 +244,16 @@ export class UnlockVaultUseCase {
     const snapshotDigest = await this.crypto.digestVaultSnapshot(vaultSnapshot);
 
     if (checkpointRelation === "newer") {
-      await this.vaultLocalRepository.saveLocalVaultTrustCheckpoint(
-        await this.vaultTrust.createCheckpoint(
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: snapshotDigest,
+        snapshot: vaultSnapshot,
+        checkpoint: await this.vaultTrust.createCheckpoint(
           vaultSnapshot,
           verifiedTrust,
           deviceAccessMaterial.deviceId,
           localKeysPayload.devicePrivateSignKey,
         ),
-      );
+      });
     }
 
     const unlockedVault: UnlockedVault = {
@@ -306,6 +325,13 @@ export class UnlockVaultUseCase {
     vaultId: string,
     snapshot: VaultSnapshot,
   ): NonNullable<VaultSnapshot["trustChain"]> {
+    if (snapshot.metadata.schemaVersion !== 2) {
+      throw new VaultTrustStateInvalidError(
+        vaultId,
+        "unsupported snapshot schema version",
+      );
+    }
+
     if (snapshot.trustChain === undefined) {
       throw new VaultTrustStateInvalidError(vaultId, "trust chain is missing");
     }

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
@@ -17,12 +17,14 @@ import {
   DeviceKeySlotNotFoundError,
   DeviceKeySlotVerificationFailedError,
   VaultSnapshotNotFoundError,
-  VaultSnapshotSignatureVerificationFailedError,
-  VaultSnapshotSignerNotTrustedError,
 } from "../../errors/unlock-vault.errors";
 import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { LocalVaultTrustCheckpointNotFoundError } from "../../errors/vault-trust.errors";
+import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
+import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 
 export type UnlockVaultCommandParams = {
   vaultId: string;
@@ -42,6 +44,7 @@ export class UnlockVaultUseCase {
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
   private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
+  private readonly vaultTrust: VaultTrustService;
 
   constructor(
     clock: ClockPort,
@@ -59,6 +62,7 @@ export class UnlockVaultUseCase {
     this.vaultLocalRepository = vaultLocalRepository;
     this.vaultLockTasks = vaultLockTasks;
     this.unlockedVaultSession = unlockedVaultSession;
+    this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(params: UnlockVaultCommandParams): Promise<UnlockVaultResult> {
@@ -116,18 +120,6 @@ export class UnlockVaultUseCase {
       );
     }
 
-    const signerDeviceKeySlot = vaultSnapshot.keySlots.deviceSlots.find(
-      (slot: DeviceKeySlot) =>
-        slot.deviceId === vaultSnapshot.metadata.createdByDeviceId,
-    );
-
-    if (signerDeviceKeySlot === undefined) {
-      throw new VaultSnapshotSignerNotTrustedError(
-        params.vaultId,
-        vaultSnapshot.metadata.createdByDeviceId,
-      );
-    }
-
     const deviceKeySlot = vaultSnapshot.keySlots.deviceSlots.find(
       (slot: DeviceKeySlot) => slot.deviceId === deviceAccessMaterial.deviceId,
     );
@@ -137,15 +129,6 @@ export class UnlockVaultUseCase {
         params.vaultId,
         deviceAccessMaterial.deviceId,
       );
-    }
-
-    const isSnapshotAuthentic = await this.crypto.verifyVaultSnapshotSignature(
-      vaultSnapshot,
-      signerDeviceKeySlot.publicSignKey,
-    );
-
-    if (!isSnapshotAuthentic) {
-      throw new VaultSnapshotSignatureVerificationFailedError(params.vaultId);
     }
 
     const localRootKey = await this.crypto.deriveLocalRootKey(
@@ -190,6 +173,42 @@ export class UnlockVaultUseCase {
       );
     }
 
+    const localDeviceIdentity = {
+      deviceId: deviceAccessMaterial.deviceId,
+      publicSignKey: deviceAccessMaterial.devicePublicSignKey,
+    };
+    const checkpoint =
+      await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+        params.vaultId,
+      );
+
+    if (checkpoint === null) {
+      throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
+    }
+
+    await this.vaultTrust.verifyCheckpoint(
+      params.vaultId,
+      checkpoint,
+      localDeviceIdentity,
+    );
+    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
+      params.vaultId,
+      localKeysPayload.vaultTrustAnchor,
+      this.requireTrustChain(params.vaultId, vaultSnapshot),
+    );
+    await this.vaultTrust.verifySnapshot(
+      params.vaultId,
+      vaultSnapshot,
+      verifiedTrust,
+    );
+    const checkpointRelation =
+      await this.vaultTrust.requireSnapshotNotRolledBack(
+        params.vaultId,
+        vaultSnapshot,
+        verifiedTrust,
+        checkpoint,
+      );
+
     const vaultMasterKeyProtectionKey =
       await this.crypto.deriveDeviceSlotVaultMasterKeyProtectionKey(
         localKeysPayload.deviceSlotKey,
@@ -205,12 +224,30 @@ export class UnlockVaultUseCase {
       vaultMasterKey,
     );
 
+    const snapshotDigest = await this.crypto.digestVaultSnapshot(vaultSnapshot);
+
+    if (checkpointRelation === "newer") {
+      await this.vaultLocalRepository.saveLocalVaultTrustCheckpoint(
+        await this.vaultTrust.createCheckpoint(
+          vaultSnapshot,
+          verifiedTrust,
+          deviceAccessMaterial.deviceId,
+          localKeysPayload.devicePrivateSignKey,
+        ),
+      );
+    }
+
     const unlockedVault: UnlockedVault = {
       vaultId: params.vaultId,
       deviceId: deviceAccessMaterial.deviceId,
       vault,
       vaultMasterKey,
       devicePrivateSignKey: localKeysPayload.devicePrivateSignKey,
+      trustedSnapshotContext: {
+        snapshotDigest,
+        trust: verifiedTrust,
+      },
+      vaultTrustAnchor: localKeysPayload.vaultTrustAnchor,
     };
 
     const lockVaultActionId = await this.ids.generateId();
@@ -263,5 +300,16 @@ export class UnlockVaultUseCase {
     return {
       vault,
     };
+  }
+
+  private requireTrustChain(
+    vaultId: string,
+    snapshot: VaultSnapshot,
+  ): NonNullable<VaultSnapshot["trustChain"]> {
+    if (snapshot.trustChain === undefined) {
+      throw new VaultTrustStateInvalidError(vaultId, "trust chain is missing");
+    }
+
+    return snapshot.trustChain;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vault-trust verification with signed trust chains/certificates and signed local trust checkpoints; vault snapshots now use schema version 2 with trust metadata.
  * Unlocking, enrollment, recovery, revocation, and sync now validate trust/rollback protection and persist the verified trusted context across restarts.
  * Added behavior to prevent sync actions while remote cleanup is pending.
* **Bug Fixes**
  * Strengthened rollback/fork detection and invalid-trust handling, including more robust persistence/rehydration of session trust material.
* **Documentation**
  * Added a security design report covering snapshot trust and local rollback protection.
* **Tests**
  * Expanded trust-chain and checkpoint-based save/restore test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->