### PR TITLE
fix(core): prevent stale vault session resurrection

### DIFF
--- a/packages/core/src/__tests__/fixtures/change-master-password.ts
+++ b/packages/core/src/__tests__/fixtures/change-master-password.ts
@@ -20,6 +20,7 @@ export function createChangeMasterPasswordTestContext() {
 
   ports.saved.deviceAccessMaterial = deviceAccessMaterial;
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       vaultId: values.vaultId,
       deviceId: values.deviceId,

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -53,7 +53,7 @@ export function createCoreTestPorts(
     session: UnlockedVaultSession,
   ): void {
     const context = {
-      sessionId: values.sessionId,
+      sessionId: session.sessionId,
       vaultId: session.unlockedVault.vaultId,
       sourceSnapshotVersionVector: session.sourceSnapshotVersionVector,
     };
@@ -339,6 +339,7 @@ export function createCoreTestPorts(
       ),
       removeUnlockedVaultSessionMaterial: vi.fn(async () => {
         saved.unlockedVaultSessionMaterial = undefined;
+        unlockedVaultSessionMirror = undefined;
       }),
     };
 
@@ -376,22 +377,54 @@ export function createCoreTestPorts(
     unlockedVaultSession,
   };
 
-  const commitSessionOriginal =
-    sessionServices.unlockedVaultSession.commit.bind(
+  const activateSessionOriginal =
+    sessionServices.unlockedVaultSession.activate.bind(
       sessionServices.unlockedVaultSession,
     );
   const getSessionOriginal = sessionServices.unlockedVaultSession.get.bind(
     sessionServices.unlockedVaultSession,
   );
+  const commitPersistedSnapshotOriginal =
+    sessionServices.unlockedVaultSession.commitPersistedSnapshot.bind(
+      sessionServices.unlockedVaultSession,
+    );
   const removeSessionOriginal =
     sessionServices.unlockedVaultSession.remove.bind(
       sessionServices.unlockedVaultSession,
     );
 
-  vi.spyOn(sessionServices.unlockedVaultSession, "commit").mockImplementation(
-    async (unlockedVault, sourceSnapshotVersionVector) => {
-      await commitSessionOriginal(unlockedVault, sourceSnapshotVersionVector);
+  vi.spyOn(sessionServices.unlockedVaultSession, "activate").mockImplementation(
+    async (
+      activationGeneration,
+      unlockedVault,
+      sourceSnapshotVersionVector,
+    ) => {
+      const sessionId = await activateSessionOriginal(
+        activationGeneration,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      );
       unlockedVaultSessionMirror = {
+        sessionId,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      };
+
+      return sessionId;
+    },
+  );
+  vi.spyOn(
+    sessionServices.unlockedVaultSession,
+    "commitPersistedSnapshot",
+  ).mockImplementation(
+    async (sessionId, unlockedVault, sourceSnapshotVersionVector) => {
+      await commitPersistedSnapshotOriginal(
+        sessionId,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      );
+      unlockedVaultSessionMirror = {
+        sessionId,
         unlockedVault,
         sourceSnapshotVersionVector,
       };

--- a/packages/core/src/__tests__/fixtures/unlock-vault.ts
+++ b/packages/core/src/__tests__/fixtures/unlock-vault.ts
@@ -9,7 +9,9 @@ export function createUnlockVaultTestContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
   vi.mocked(ports.ids.generateId).mockReset();
-  vi.mocked(ports.ids.generateId).mockResolvedValue(values.vaultLockActionId);
+  vi.mocked(ports.ids.generateId)
+    .mockResolvedValueOnce(values.vaultLockActionId)
+    .mockResolvedValue(values.sessionId);
 
   const deviceAccessMaterial: DeviceAccessMaterial = {
     vaultId: values.vaultId,

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -96,6 +96,7 @@ export function createUnlockedVaultSessionWithEntries(
   sourceSnapshotVersionVector: VersionVector = { [values.deviceId]: 1 },
 ) {
   return {
+    sessionId: values.sessionId,
     unlockedVault: createUnlockedVaultWithEntries(values, entries, tags),
     sourceSnapshotVersionVector,
   };

--- a/packages/core/src/domain/session/unlocked-vault-session.type.ts
+++ b/packages/core/src/domain/session/unlocked-vault-session.type.ts
@@ -5,6 +5,7 @@ import type { UnlockedVault } from "./unlocked-vault";
 import type { UnlockedVaultSessionPayloadKey } from "./unlocked-vault-session-payload-key";
 
 export type UnlockedVaultSession = {
+  readonly sessionId: string;
   readonly unlockedVault: UnlockedVault;
   readonly sourceSnapshotVersionVector: VersionVector;
 };

--- a/packages/core/src/errors/vault-session.errors.ts
+++ b/packages/core/src/errors/vault-session.errors.ts
@@ -19,6 +19,13 @@ export class UnlockedVaultSessionInvalidError extends Error {
   }
 }
 
+export class UnlockedVaultSessionExpiredError extends Error {
+  constructor(vaultId: string) {
+    super(`Unlocked vault session for vault "${vaultId}" is no longer active.`);
+    this.name = "UnlockedVaultSessionExpiredError";
+  }
+}
+
 export class ActiveUnlockedVaultMismatchError extends Error {
   constructor(activeVaultId: string, incomingVaultId: string) {
     super(

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../__tests__/fixtures/vault-entries";
 import {
   ActiveUnlockedVaultMismatchError,
+  UnlockedVaultSessionExpiredError,
   UnlockedVaultSessionInvalidError,
   VaultMustBeUnlockedError,
 } from "../../errors/vault-session.errors";
@@ -96,7 +97,7 @@ describe("UnlockedVaultSessionService", () => {
 
     await expect(
       ctx.service.requireVaultCanBeActivated(ctx.values.vaultId),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(0);
   });
 
   it("allows activation for the active vault", async () => {
@@ -105,7 +106,7 @@ describe("UnlockedVaultSessionService", () => {
 
     await expect(
       ctx.service.requireVaultCanBeActivated(ctx.values.vaultId),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(0);
   });
 
   it("rejects activation when another vault is active", async () => {
@@ -115,6 +116,46 @@ describe("UnlockedVaultSessionService", () => {
     await expect(
       ctx.service.requireVaultCanBeActivated("other-vault-id"),
     ).rejects.toBeInstanceOf(ActiveUnlockedVaultMismatchError);
+  });
+
+  it("rejects activation after lock invalidates its lease", async () => {
+    const ctx = createContext();
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+
+    await ctx.service.remove();
+
+    await expect(
+      ctx.service.activate(
+        activationGeneration,
+        ctx.session.unlockedVault,
+        ctx.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeUndefined();
+  });
+
+  it("consumes an activation lease", async () => {
+    const ctx = createContext();
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+
+    await ctx.service.activate(
+      activationGeneration,
+      ctx.session.unlockedVault,
+      ctx.sourceSnapshotVersionVector,
+    );
+
+    await expect(
+      ctx.service.activate(
+        activationGeneration,
+        ctx.session.unlockedVault,
+        ctx.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
   });
 
   it("returns null when no session material exists", async () => {
@@ -135,6 +176,7 @@ describe("UnlockedVaultSessionService", () => {
       createEncryptedPayload(ctx);
 
     await expect(ctx.service.get()).resolves.toEqual({
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -172,6 +214,7 @@ describe("UnlockedVaultSessionService", () => {
         "test operation",
       ),
     ).resolves.toEqual({
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -307,7 +350,8 @@ describe("UnlockedVaultSessionService", () => {
   it("commits a new unlocked vault session as encrypted payload then material", async () => {
     const ctx = createContext();
 
-    await ctx.service.commit(
+    await ctx.service.activate(
+      0,
       ctx.session.unlockedVault,
       ctx.sourceSnapshotVersionVector,
     );
@@ -363,7 +407,8 @@ describe("UnlockedVaultSessionService", () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSessionMaterial = createActiveMaterial(ctx);
 
-    await ctx.service.commit(
+    await ctx.service.activate(
+      0,
       ctx.session.unlockedVault,
       ctx.sourceSnapshotVersionVector,
     );
@@ -399,7 +444,8 @@ describe("UnlockedVaultSessionService", () => {
     );
 
     await expect(
-      ctx.service.commit(
+      ctx.service.activate(
+        0,
         ctx.session.unlockedVault,
         ctx.sourceSnapshotVersionVector,
       ),
@@ -424,7 +470,8 @@ describe("UnlockedVaultSessionService", () => {
     ).mockRejectedValueOnce(error);
 
     await expect(
-      ctx.service.commit(
+      ctx.service.activate(
+        0,
         ctx.session.unlockedVault,
         ctx.sourceSnapshotVersionVector,
       ),
@@ -453,7 +500,8 @@ describe("UnlockedVaultSessionService", () => {
     ).mockRejectedValueOnce(error);
 
     await expect(
-      ctx.service.commit(
+      ctx.service.activate(
+        0,
         ctx.session.unlockedVault,
         ctx.sourceSnapshotVersionVector,
       ),
@@ -472,6 +520,9 @@ describe("UnlockedVaultSessionService", () => {
   it("invalidates the session when persisted snapshot commit fails", async () => {
     const ctx = createContext();
     const error = new Error("encrypt failed");
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
 
     vi.mocked(
       ctx.ports.crypto.encryptUnlockedVaultSessionPayload,
@@ -479,6 +530,7 @@ describe("UnlockedVaultSessionService", () => {
 
     await expect(
       ctx.service.commitPersistedSnapshot(
+        ctx.values.sessionId,
         ctx.session.unlockedVault,
         ctx.sourceSnapshotVersionVector,
       ),
@@ -494,6 +546,168 @@ describe("UnlockedVaultSessionService", () => {
     ).toHaveBeenCalled();
   });
 
+  it("rejects a persisted snapshot commit after the session was removed", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    const context = await ctx.service.requireUnlockedVaultContext(
+      ctx.values.vaultId,
+      "test operation",
+    );
+    await ctx.service.remove();
+
+    await expect(
+      ctx.service.commitPersistedSnapshot(
+        context.sessionId,
+        context.unlockedVault,
+        context.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .saveEncryptedUnlockedVaultSessionPayload,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not replace a newer session with a stale persisted snapshot commit", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    const context = await ctx.service.requireUnlockedVaultContext(
+      ctx.values.vaultId,
+      "test operation",
+    );
+    await ctx.service.remove();
+    vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce("new-session-id");
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+    await ctx.service.activate(
+      activationGeneration,
+      ctx.session.unlockedVault,
+      ctx.sourceSnapshotVersionVector,
+    );
+
+    await expect(
+      ctx.service.commitPersistedSnapshot(
+        context.sessionId,
+        context.unlockedVault,
+        context.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.sessionId).toBe(
+      "new-session-id",
+    );
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload?.sessionId,
+    ).toBe("new-session-id");
+  });
+
+  it("does not restore state for a stale session", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    await ctx.service.remove();
+    vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce("new-session-id");
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+    await ctx.service.activate(
+      activationGeneration,
+      ctx.session.unlockedVault,
+      ctx.sourceSnapshotVersionVector,
+    );
+
+    const restored = await ctx.service.restoreIfSessionIsActive(
+      ctx.values.sessionId,
+      ctx.values.vaultId,
+      async () => undefined,
+    );
+
+    expect(restored).toBe(false);
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.sessionId).toBe(
+      "new-session-id",
+    );
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload?.sessionId,
+    ).toBe("new-session-id");
+  });
+
+  it("does not allow lock to interleave with active session work", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    let continueOperation!: () => void;
+    let markOperationStarted!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      markOperationStarted = resolve;
+    });
+    const operationCanContinue = new Promise<void>((resolve) => {
+      continueOperation = resolve;
+    });
+    const activeOperation = ctx.service.persistForActiveSession(
+      ctx.values.sessionId,
+      ctx.values.vaultId,
+      async () => {
+        markOperationStarted();
+        await operationCanContinue;
+      },
+    );
+
+    await operationStarted;
+    const lock = ctx.service.remove();
+    await Promise.resolve();
+
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeDefined();
+
+    continueOperation();
+    await activeOperation;
+    await lock;
+
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeUndefined();
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
+    ).toBeUndefined();
+  });
+
+  it("keeps local enrollment state when session removal fails during discard", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const removeError = new Error("material removal failed");
+    const discard = vi.fn(async () => undefined);
+
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(removeError);
+
+    await expect(
+      ctx.service.discardIfSessionIsActive(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        discard,
+      ),
+    ).resolves.toBe(false);
+
+    expect(discard).not.toHaveBeenCalled();
+  });
+
   it("does not invalidate another active vault after persisted snapshot commit mismatch", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSessionMaterial = createActiveMaterial(
@@ -503,10 +717,11 @@ describe("UnlockedVaultSessionService", () => {
 
     await expect(
       ctx.service.commitPersistedSnapshot(
+        ctx.values.sessionId,
         ctx.session.unlockedVault,
         ctx.sourceSnapshotVersionVector,
       ),
-    ).rejects.toBeInstanceOf(ActiveUnlockedVaultMismatchError);
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
 
     expect(
       ctx.ports.unlockedVaultSessionMaterialRepository
@@ -554,6 +769,47 @@ describe("UnlockedVaultSessionService", () => {
     expect(
       ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
     ).toBeUndefined();
+  });
+
+  it("does not resurrect a session after material removal fails", async () => {
+    const ctx = createContext();
+    const removeError = new Error("material remove failed");
+    const persist = vi.fn(async () => undefined);
+
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(removeError);
+
+    await expect(ctx.service.remove()).rejects.toBe(removeError);
+
+    await expect(
+      ctx.service.persistForActiveSession(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        persist,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+    await expect(
+      ctx.service.commitPersistedSnapshot(
+        ctx.values.sessionId,
+        ctx.session.unlockedVault,
+        ctx.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .saveEncryptedUnlockedVaultSessionPayload,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
   });
 
   it("bubbles encrypted payload removal failure", async () => {

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -706,6 +706,12 @@ describe("UnlockedVaultSessionService", () => {
     ).resolves.toBe(false);
 
     expect(discard).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toEqual(
+      createMaterial(ctx),
+    );
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
+    ).toBeUndefined();
   });
 
   it("does not invalidate another active vault after persisted snapshot commit mismatch", async () => {

--- a/packages/core/src/services/session/unlocked-vault-session.service.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.ts
@@ -13,6 +13,7 @@ import type { EncryptedUnlockedVaultSessionPayloadRepositoryPort } from "../../p
 import type { UnlockedVaultSessionMaterialRepositoryPort } from "../../ports/session/unlocked-vault-session-material-repository.port";
 import {
   ActiveUnlockedVaultMismatchError,
+  UnlockedVaultSessionExpiredError,
   UnlockedVaultSessionInvalidError,
   VaultMustBeUnlockedError,
 } from "../../errors/vault-session.errors";
@@ -22,6 +23,9 @@ export class UnlockedVaultSessionService {
   private readonly encryptedPayloadRepository: EncryptedUnlockedVaultSessionPayloadRepositoryPort;
   private readonly crypto: CryptoPort;
   private readonly ids: IdPort;
+  private pendingSessionOperation: Promise<void> = Promise.resolve();
+  private activationGeneration = 0;
+  private sessionIsInvalidated = false;
 
   constructor(
     materialRepository: UnlockedVaultSessionMaterialRepositoryPort,
@@ -35,21 +39,196 @@ export class UnlockedVaultSessionService {
     this.ids = ids;
   }
 
-  async requireVaultCanBeActivated(vaultId: string): Promise<void> {
-    const activeMaterial =
-      await this.materialRepository.getUnlockedVaultSessionMaterial();
+  async requireVaultCanBeActivated(vaultId: string): Promise<number> {
+    return this.serializeSessionOperation(async () => {
+      const storedMaterial =
+        await this.materialRepository.getUnlockedVaultSessionMaterial();
+      const activeMaterial = this.getActiveMaterial(storedMaterial);
 
-    if (activeMaterial !== null && activeMaterial.vaultId !== vaultId) {
-      throw new ActiveUnlockedVaultMismatchError(
-        activeMaterial.vaultId,
-        vaultId,
-      );
-    }
+      if (activeMaterial !== null && activeMaterial.vaultId !== vaultId) {
+        throw new ActiveUnlockedVaultMismatchError(
+          activeMaterial.vaultId,
+          vaultId,
+        );
+      }
+
+      return this.activationGeneration;
+    });
   }
 
   async get(): Promise<UnlockedVaultSession | null> {
-    const material =
+    return this.serializeSessionOperation(async () => this.restoreSession());
+  }
+
+  async requireUnlockedVaultContext(
+    vaultId: string,
+    operation: string,
+  ): Promise<UnlockedVaultSession> {
+    return this.serializeSessionOperation(async () => {
+      const unlockedVaultSession = await this.restoreSession();
+
+      if (
+        unlockedVaultSession === null ||
+        unlockedVaultSession.unlockedVault.vaultId !== vaultId
+      ) {
+        throw new VaultMustBeUnlockedError(vaultId, operation);
+      }
+
+      return unlockedVaultSession;
+    });
+  }
+
+  async persistForActiveSession<T>(
+    sessionId: string,
+    vaultId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.serializeSessionOperation(async () => {
+      this.requireActiveSession(
+        await this.materialRepository.getUnlockedVaultSessionMaterial(),
+        sessionId,
+        vaultId,
+      );
+
+      return operation();
+    });
+  }
+
+  async restoreIfSessionIsActive(
+    sessionId: string,
+    vaultId: string,
+    restore: () => Promise<void>,
+  ): Promise<boolean> {
+    return this.serializeSessionOperation(async () => {
+      const storedMaterial =
+        await this.materialRepository.getUnlockedVaultSessionMaterial();
+      const activeMaterial = this.getActiveMaterial(storedMaterial);
+
+      if (!this.isActiveSession(activeMaterial, sessionId, vaultId)) {
+        return false;
+      }
+
+      try {
+        await restore();
+        return true;
+      } catch {
+        await this.removeSessionRecordsPreservingRootCause();
+        return false;
+      }
+    });
+  }
+
+  async discardIfSessionIsActive(
+    sessionId: string,
+    vaultId: string,
+    discard: () => Promise<void>,
+  ): Promise<boolean> {
+    return this.serializeSessionOperation(async () => {
+      const activeMaterial =
+        await this.materialRepository.getUnlockedVaultSessionMaterial();
+
+      if (!this.isActiveSession(activeMaterial, sessionId, vaultId)) {
+        return false;
+      }
+
+      try {
+        await this.removeSessionRecords();
+      } catch {
+        return false;
+      }
+
+      try {
+        await discard();
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  async activate(
+    activationGeneration: number,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotVersionVector: VersionVector,
+  ): Promise<string> {
+    return this.serializeSessionOperation(async () => {
+      if (activationGeneration !== this.activationGeneration) {
+        throw new UnlockedVaultSessionExpiredError(unlockedVault.vaultId);
+      }
+
+      const storedMaterial =
+        await this.materialRepository.getUnlockedVaultSessionMaterial();
+      const activeMaterial = this.getActiveMaterial(storedMaterial);
+
+      if (
+        activeMaterial !== null &&
+        activeMaterial.vaultId !== unlockedVault.vaultId
+      ) {
+        throw new ActiveUnlockedVaultMismatchError(
+          activeMaterial.vaultId,
+          unlockedVault.vaultId,
+        );
+      }
+
+      const protectedSession = await this.protect(
+        {
+          unlockedVault,
+          sourceSnapshotVersionVector,
+        },
+        activeMaterial ?? undefined,
+      );
+
+      try {
+        await this.persistProtectedSession(protectedSession);
+      } catch (error) {
+        await this.removeSessionRecordsPreservingRootCause();
+        throw error;
+      }
+
+      this.sessionIsInvalidated = false;
+      this.activationGeneration += 1;
+      return protectedSession.material.sessionId;
+    });
+  }
+
+  async commitPersistedSnapshot(
+    sessionId: string,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotVersionVector: VersionVector,
+  ): Promise<void> {
+    await this.serializeSessionOperation(async () => {
+      const activeMaterial = this.requireActiveSession(
+        await this.materialRepository.getUnlockedVaultSessionMaterial(),
+        sessionId,
+        unlockedVault.vaultId,
+      );
+
+      try {
+        const protectedSession = await this.protect(
+          {
+            unlockedVault,
+            sourceSnapshotVersionVector,
+          },
+          activeMaterial,
+        );
+        await this.persistProtectedSession(protectedSession);
+      } catch (error) {
+        await this.removeSessionRecordsPreservingRootCause();
+        throw error;
+      }
+    });
+  }
+
+  async remove(): Promise<void> {
+    await this.serializeSessionOperation(async () => {
+      await this.removeSessionRecords();
+    });
+  }
+
+  private async restoreSession(): Promise<UnlockedVaultSession | null> {
+    const storedMaterial =
       await this.materialRepository.getUnlockedVaultSessionMaterial();
+    const material = this.getActiveMaterial(storedMaterial);
 
     if (material === null) {
       return null;
@@ -67,52 +246,10 @@ export class UnlockedVaultSessionService {
     return this.restore(material, encryptedPayload);
   }
 
-  async requireUnlockedVaultContext(
-    vaultId: string,
-    operation: string,
-  ): Promise<UnlockedVaultSession> {
-    const unlockedVaultSession = await this.get();
+  private async removeSessionRecords(): Promise<void> {
+    this.activationGeneration += 1;
+    this.sessionIsInvalidated = true;
 
-    if (
-      unlockedVaultSession === null ||
-      unlockedVaultSession.unlockedVault.vaultId !== vaultId
-    ) {
-      throw new VaultMustBeUnlockedError(vaultId, operation);
-    }
-
-    return {
-      unlockedVault: unlockedVaultSession.unlockedVault,
-      sourceSnapshotVersionVector:
-        unlockedVaultSession.sourceSnapshotVersionVector,
-    };
-  }
-
-  async commit(
-    unlockedVault: UnlockedVault,
-    sourceSnapshotVersionVector: VersionVector,
-  ): Promise<void> {
-    await this.save({
-      unlockedVault,
-      sourceSnapshotVersionVector,
-    });
-  }
-
-  async commitPersistedSnapshot(
-    unlockedVault: UnlockedVault,
-    sourceSnapshotVersionVector: VersionVector,
-  ): Promise<void> {
-    try {
-      await this.commit(unlockedVault, sourceSnapshotVersionVector);
-    } catch (error) {
-      if (!(error instanceof ActiveUnlockedVaultMismatchError)) {
-        await this.removePreservingRootCause();
-      }
-
-      throw error;
-    }
-  }
-
-  async remove(): Promise<void> {
     let removalError: unknown;
 
     try {
@@ -134,38 +271,23 @@ export class UnlockedVaultSessionService {
     }
   }
 
-  private async save(session: UnlockedVaultSession): Promise<void> {
-    const activeMaterial =
-      await this.materialRepository.getUnlockedVaultSessionMaterial();
-    const incomingVaultId = session.unlockedVault.vaultId;
-
-    if (activeMaterial !== null && activeMaterial.vaultId !== incomingVaultId) {
-      throw new ActiveUnlockedVaultMismatchError(
-        activeMaterial.vaultId,
-        incomingVaultId,
-      );
-    }
-
-    const protectedSession = await this.protect(
-      session,
-      activeMaterial ?? undefined,
+  private async persistProtectedSession(protectedSession: {
+    readonly material: UnlockedVaultSessionMaterial;
+    readonly encryptedPayload: EncryptedUnlockedVaultSessionPayload;
+  }): Promise<void> {
+    await this.encryptedPayloadRepository.saveEncryptedUnlockedVaultSessionPayload(
+      protectedSession.encryptedPayload,
     );
-
-    try {
-      await this.encryptedPayloadRepository.saveEncryptedUnlockedVaultSessionPayload(
-        protectedSession.encryptedPayload,
-      );
-      await this.materialRepository.saveUnlockedVaultSessionMaterial(
-        protectedSession.material,
-      );
-    } catch (error) {
-      await this.removePreservingRootCause();
-      throw error;
-    }
+    await this.materialRepository.saveUnlockedVaultSessionMaterial(
+      protectedSession.material,
+    );
   }
 
   private async protect(
-    session: UnlockedVaultSession,
+    session: Pick<
+      UnlockedVaultSession,
+      "unlockedVault" | "sourceSnapshotVersionVector"
+    >,
     activeMaterial?: Pick<
       UnlockedVaultSessionMaterial,
       "sessionId" | "payloadKey"
@@ -240,6 +362,7 @@ export class UnlockedVaultSessionService {
     }
 
     return {
+      sessionId: material.sessionId,
       unlockedVault: {
         vaultId: material.vaultId,
         deviceId: material.deviceId,
@@ -253,12 +376,64 @@ export class UnlockedVaultSessionService {
     };
   }
 
-  private async removePreservingRootCause(): Promise<void> {
+  private async removeSessionRecordsPreservingRootCause(): Promise<void> {
     try {
-      await this.remove();
+      await this.removeSessionRecords();
     } catch {
       // Preserve the original failure as the root cause.
     }
+  }
+
+  private async serializeSessionOperation<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previousOperation = this.pendingSessionOperation;
+    let completeOperation!: () => void;
+    this.pendingSessionOperation = new Promise<void>((resolve) => {
+      completeOperation = resolve;
+    });
+
+    await previousOperation;
+
+    try {
+      return await operation();
+    } finally {
+      completeOperation();
+    }
+  }
+
+  private requireActiveSession(
+    activeMaterial: UnlockedVaultSessionMaterial | null,
+    sessionId: string,
+    vaultId: string,
+  ): UnlockedVaultSessionMaterial {
+    if (
+      activeMaterial === null ||
+      !this.isActiveSession(activeMaterial, sessionId, vaultId)
+    ) {
+      throw new UnlockedVaultSessionExpiredError(vaultId);
+    }
+
+    return activeMaterial;
+  }
+
+  private isActiveSession(
+    activeMaterial: UnlockedVaultSessionMaterial | null,
+    sessionId: string,
+    vaultId: string,
+  ): boolean {
+    return (
+      activeMaterial !== null &&
+      !this.sessionIsInvalidated &&
+      activeMaterial.sessionId === sessionId &&
+      activeMaterial.vaultId === vaultId
+    );
+  }
+
+  private getActiveMaterial(
+    material: UnlockedVaultSessionMaterial | null,
+  ): UnlockedVaultSessionMaterial | null {
+    return this.sessionIsInvalidated ? null : material;
   }
 
   private requireMatchingSessionRecords(

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -127,6 +127,7 @@ export class VaultSyncGuardService {
     },
     persistedSnapshot: VaultSnapshot,
     unlockedVault: UnlockedVault,
+    sessionId: string,
   ): Promise<void> {
     if (
       syncState.syncConfig === undefined ||
@@ -142,19 +143,17 @@ export class VaultSyncGuardService {
         syncState.remoteSnapshotDescriptor,
       );
     } catch (error) {
-      try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(
-          syncState.localSnapshot,
-          persistedSnapshot,
-          unlockedVault,
-        );
-      } catch {
-        try {
-          await this.unlockedVaultSession.remove();
-        } catch {
-          // Preserve the upload failure as the root cause.
-        }
-      }
+      await this.unlockedVaultSession.restoreIfSessionIsActive(
+        sessionId,
+        vaultId,
+        async () => {
+          await this.vaultSnapshot.restoreLocalVaultSnapshot(
+            syncState.localSnapshot,
+            persistedSnapshot,
+            unlockedVault,
+          );
+        },
+      );
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(vaultId);
@@ -170,6 +169,7 @@ export class VaultSyncGuardService {
     localSnapshot: VaultSnapshot,
     persistedSnapshot: VaultSnapshot,
     unlockedVault: UnlockedVault,
+    sessionId: string,
   ): Promise<void> {
     try {
       await this.syncProvider.uploadVaultSnapshot(
@@ -178,19 +178,17 @@ export class VaultSyncGuardService {
         null,
       );
     } catch (error) {
-      try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(
-          localSnapshot,
-          persistedSnapshot,
-          unlockedVault,
-        );
-      } catch {
-        try {
-          await this.unlockedVaultSession.remove();
-        } catch {
-          // Preserve the upload failure as the root cause.
-        }
-      }
+      await this.unlockedVaultSession.restoreIfSessionIsActive(
+        sessionId,
+        vaultId,
+        async () => {
+          await this.vaultSnapshot.restoreLocalVaultSnapshot(
+            localSnapshot,
+            persistedSnapshot,
+            unlockedVault,
+          );
+        },
+      );
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(vaultId);

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -63,6 +63,7 @@ function createContext() {
   } satisfies VaultSnapshot;
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       ...unlockedVault,
       vault: {
@@ -429,12 +430,12 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("restores the local snapshot when session commit fails", async () => {
+  it("keeps the persisted snapshot when session commit fails", async () => {
     const ctx = createContext();
     const commitError = new Error("commit failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.crypto.encryptUnlockedVaultSessionPayload,
     ).mockRejectedValueOnce(commitError);
 
     await expect(
@@ -446,16 +447,16 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
 
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(1);
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(ctx.ports.saved.vaultSnapshot).toEqual(
       expect.objectContaining({
         metadata: expect.objectContaining({
           snapshotVersionVector: {
-            [ctx.values.deviceId]: 1,
+            [ctx.values.deviceId]: 2,
           },
         }),
-        keySlots: expect.not.objectContaining({
+        keySlots: expect.objectContaining({
           enrollmentKeySlot: expect.anything(),
         }),
       }),
@@ -556,14 +557,12 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     const ctx = createContext();
     const rollbackError = new Error("session rollback failed");
     const unlockedVaultSession = ctx.ports.sessionServices.unlockedVaultSession;
-    const commitPersistedSnapshotOriginal =
-      unlockedVaultSession.commitPersistedSnapshot.bind(unlockedVaultSession);
 
     vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
-    vi.spyOn(unlockedVaultSession, "commitPersistedSnapshot")
-      .mockImplementationOnce(commitPersistedSnapshotOriginal)
+    vi.mocked(ctx.ports.crypto.encryptUnlockedVaultSessionPayload)
+      .mockResolvedValueOnce(ctx.values.encryptedUnlockedVaultSessionPayload)
       .mockRejectedValueOnce(rollbackError);
 
     await expect(
@@ -591,10 +590,6 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     expect(unlockedVaultSession.commitPersistedSnapshot).toHaveBeenCalledTimes(
       2,
     );
-    expect(ctx.ports.saved.unlockedVaultSession).toMatchObject({
-      sourceSnapshotVersionVector: {
-        [ctx.values.deviceId]: 2,
-      },
-    });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
 });

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -62,7 +62,7 @@ export class InitializeDeviceEnrollmentUseCase {
   async execute(
     params: InitializeDeviceEnrollmentCommandParams,
   ): Promise<InitializeDeviceEnrollmentResult> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "initialize device enrollment",
@@ -161,59 +161,54 @@ export class InitializeDeviceEnrollmentUseCase {
         enrollmentAuthorization,
         unlockedVault.devicePrivateSignKey,
       );
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      unlockedVault,
-      sourceSnapshotVersionVector,
-      {
-        keySlots: {
-          deviceSlots: currentVaultSnapshot.keySlots.deviceSlots,
-          ...(currentVaultSnapshot.keySlots.completedEnrollments === undefined
-            ? {}
-            : {
-                completedEnrollments:
-                  currentVaultSnapshot.keySlots.completedEnrollments,
-              }),
-          enrollmentKeySlot: {
-            enrollmentId,
-            pendingDeviceId,
-            pendingDevicePublicSignKey: pendingDeviceSignKeyPair.publicKey,
-            pendingDevicePublicSignKeyDigest,
-            protectedVaultMasterKeyDigest,
-            protectedVaultMasterKey: protectedEnrollmentVaultMasterKey,
-            authorizedByDeviceId: unlockedVault.deviceId,
-            authorizerSignature,
-          },
-        },
-        nextTrust: {
-          chain: nextTrust.chain,
-          state: nextTrust.trust,
-        },
-      },
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            unlockedVault,
+            sourceSnapshotVersionVector,
+            {
+              keySlots: {
+                deviceSlots: currentVaultSnapshot.keySlots.deviceSlots,
+                ...(currentVaultSnapshot.keySlots.completedEnrollments ===
+                undefined
+                  ? {}
+                  : {
+                      completedEnrollments:
+                        currentVaultSnapshot.keySlots.completedEnrollments,
+                    }),
+                enrollmentKeySlot: {
+                  enrollmentId,
+                  pendingDeviceId,
+                  pendingDevicePublicSignKey:
+                    pendingDeviceSignKeyPair.publicKey,
+                  pendingDevicePublicSignKeyDigest,
+                  protectedVaultMasterKeyDigest,
+                  protectedVaultMasterKey: protectedEnrollmentVaultMasterKey,
+                  authorizedByDeviceId: unlockedVault.deviceId,
+                  authorizerSignature,
+                },
+              },
+              nextTrust: {
+                chain: nextTrust.chain,
+                state: nextTrust.trust,
+              },
+            },
+          ),
+      );
     const nextUnlockedVault = {
       ...unlockedVault,
       trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
     };
 
-    try {
-      await this.unlockedVaultSession.commitPersistedSnapshot(
-        nextUnlockedVault,
-        persistedSnapshot.snapshotVersionVector,
-      );
-    } catch (error) {
-      try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(
-          currentVaultSnapshot,
-          persistedSnapshot.snapshot,
-          unlockedVault,
-        );
-      } catch {
-        // Preserve the session commit failure as the root cause.
-      }
-
-      throw error;
-    }
+    await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
+      nextUnlockedVault,
+      persistedSnapshot.snapshotVersionVector,
+    );
 
     try {
       await this.syncProvider.uploadVaultSnapshot(
@@ -226,26 +221,22 @@ export class InitializeDeviceEnrollmentUseCase {
         error instanceof RemoteVaultSnapshotChangedError
           ? new SyncConflictDetectedError(params.vaultId)
           : error;
-      let restored = false;
-
-      try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(
-          currentVaultSnapshot,
-          persistedSnapshot.snapshot,
-          unlockedVault,
-        );
-        restored = true;
-      } catch {
-        try {
-          await this.unlockedVaultSession.remove();
-        } catch {
-          // Preserve the upload failure as the root cause.
-        }
-      }
+      const restored = await this.unlockedVaultSession.restoreIfSessionIsActive(
+        sessionId,
+        params.vaultId,
+        async () => {
+          await this.vaultSnapshot.restoreLocalVaultSnapshot(
+            currentVaultSnapshot,
+            persistedSnapshot.snapshot,
+            unlockedVault,
+          );
+        },
+      );
 
       if (restored) {
         try {
           await this.unlockedVaultSession.commitPersistedSnapshot(
+            sessionId,
             unlockedVault,
             sourceSnapshotVersionVector,
           );

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -776,7 +776,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     const error = new Error("commit failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).mockRejectedValueOnce(error);
 
     await expect(
@@ -817,9 +817,6 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
-    expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).toHaveBeenCalledWith(ctx.values.vaultId);
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
@@ -827,5 +824,49 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(ctx.ports.saved.deviceAccessMaterial).toBeUndefined();
     expect(ctx.ports.saved.deviceAccessRecoveryBackup).toBeUndefined();
     expect(ctx.ports.saved.vaultSnapshot).toBeUndefined();
+  });
+
+  it("does not remove a newer enrollment session after a stale upload fails", async () => {
+    const ctx = createContext();
+    let originalSessionId = "";
+
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(async () => {
+      const activeSession = ctx.ports.saved.unlockedVaultSession!;
+      originalSessionId = activeSession.sessionId;
+
+      await ctx.ports.sessionServices.unlockedVaultSession.remove();
+      vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce(
+        "new-session-id",
+      );
+      const activationGeneration =
+        await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+          ctx.values.vaultId,
+        );
+      await ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        activeSession.unlockedVault,
+        activeSession.sourceSnapshotVersionVector,
+      );
+
+      throw new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        enrollmentBundle: ctx.enrollmentBundle,
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "New laptop",
+      }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession?.sessionId).not.toBe(
+      originalSessionId,
+    );
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
   });
 });

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -93,9 +93,10 @@ export class PerformDeviceEnrollmentUseCase {
   ): Promise<PerformDeviceEnrollmentResult> {
     const { enrollmentBundle } = params;
 
-    await this.unlockedVaultSession.requireVaultCanBeActivated(
-      enrollmentBundle.vaultId,
-    );
+    const activationGeneration =
+      await this.unlockedVaultSession.requireVaultCanBeActivated(
+        enrollmentBundle.vaultId,
+      );
 
     const remoteSnapshotDescriptor =
       await this.syncProvider.getLatestVaultSnapshotDescriptor(
@@ -447,8 +448,11 @@ export class PerformDeviceEnrollmentUseCase {
       checkpoint,
     });
 
+    let sessionId: string;
+
     try {
-      await this.unlockedVaultSession.commit(
+      sessionId = await this.unlockedVaultSession.activate(
+        activationGeneration,
         unlockedVault,
         registeredVaultSnapshot.metadata.snapshotVersionVector,
       );
@@ -476,19 +480,15 @@ export class PerformDeviceEnrollmentUseCase {
           ? new SyncConflictDetectedError(enrollmentBundle.vaultId)
           : error;
 
-      try {
-        await this.unlockedVaultSession.remove();
-      } catch {
-        // Preserve the upload failure as the root cause.
-      }
-
-      try {
-        await this.vaultLocalRepository.removePersistedLocalVault(
-          enrollmentBundle.vaultId,
-        );
-      } catch {
-        // Preserve the upload failure as the root cause.
-      }
+      await this.unlockedVaultSession.discardIfSessionIsActive(
+        sessionId,
+        enrollmentBundle.vaultId,
+        async () => {
+          await this.vaultLocalRepository.removePersistedLocalVault(
+            enrollmentBundle.vaultId,
+          );
+        },
+      );
 
       throw mappedError;
     }

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -220,7 +220,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -249,6 +249,7 @@ describe("RecoverDeviceAccessUseCase", () => {
   it("fails when another vault is active", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSession = {
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: "another-vault-id",
         deviceId: ctx.values.deviceId,

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -110,6 +110,7 @@ function createContext() {
   ports.saved.vaultSnapshot = vaultSnapshot;
   ports.saved.localVaultTrustCheckpoint = values.localVaultTrustCheckpoint;
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       vaultId: values.vaultId,
       deviceId: values.deviceId,
@@ -236,6 +237,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.values.devicePrivateSignKey,
     );
     expect(ctx.saved.unlockedVaultSession).toEqual({
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -265,8 +267,9 @@ describe("RevokeDeviceUseCase", () => {
       vi.mocked(ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint)
         .mock.invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -314,8 +317,9 @@ describe("RevokeDeviceUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -404,6 +408,7 @@ describe("RevokeDeviceUseCase", () => {
   it("fails when another vault is unlocked", async () => {
     const ctx = createContext();
     ctx.saved.unlockedVaultSession = {
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: "another-vault-id",
         deviceId: ctx.values.deviceId,
@@ -531,7 +536,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
   });
 
@@ -690,6 +695,7 @@ describe("RevokeDeviceUseCase", () => {
   it("fails when the target device profile is missing", async () => {
     const ctx = createContext();
     ctx.saved.unlockedVaultSession = {
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -738,7 +744,7 @@ describe("RevokeDeviceUseCase", () => {
     ).rejects.toThrow("snapshot save failed");
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault).toEqual(
@@ -749,7 +755,7 @@ describe("RevokeDeviceUseCase", () => {
   it("invalidates the session when session commit fails after snapshot persistence", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.crypto.encryptUnlockedVaultSessionPayload,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(
@@ -762,9 +768,6 @@ describe("RevokeDeviceUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledTimes(1);
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 });

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -51,7 +51,7 @@ export class RevokeDeviceUseCase {
   ): Promise<RevokeDeviceResult> {
     // Revoke can only be performed by the currently unlocked vault, and a
     // device cannot revoke the local identity it is actively using.
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "revoke device",
@@ -130,27 +130,33 @@ export class RevokeDeviceUseCase {
       ...unlockedVault,
       vault: revokedVault,
     };
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-      {
-        keySlots: {
-          deviceSlots: currentVaultSnapshot.keySlots.deviceSlots.filter(
-            (deviceSlot) => deviceSlot.deviceId !== params.deviceId,
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+            {
+              keySlots: {
+                deviceSlots: currentVaultSnapshot.keySlots.deviceSlots.filter(
+                  (deviceSlot) => deviceSlot.deviceId !== params.deviceId,
+                ),
+                ...(retainedEnrollmentKeySlot === undefined
+                  ? {}
+                  : { enrollmentKeySlot: retainedEnrollmentKeySlot }),
+                completedEnrollments:
+                  currentVaultSnapshot.keySlots.completedEnrollments,
+              },
+              nextTrust: {
+                chain: nextTrust.chain,
+                state: nextTrust.trust,
+              },
+            },
           ),
-          ...(retainedEnrollmentKeySlot === undefined
-            ? {}
-            : { enrollmentKeySlot: retainedEnrollmentKeySlot }),
-          completedEnrollments:
-            currentVaultSnapshot.keySlots.completedEnrollments,
-        },
-        nextTrust: {
-          chain: nextTrust.chain,
-          state: nextTrust.trust,
-        },
-      },
-    );
+      );
     const persistedUnlockedVault = {
       ...updatedUnlockedVault,
       trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
@@ -161,9 +167,11 @@ export class RevokeDeviceUseCase {
       syncState,
       persistedSnapshot.snapshot,
       unlockedVault,
+      sessionId,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       persistedUnlockedVault,
       persistedSnapshot.snapshotVersionVector,
     );

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -181,6 +181,7 @@ function createContext() {
     "restoreLocalVaultSnapshot",
   );
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       ...createUnlockedVaultWithEntries(values, []),
       vault: localVault,
@@ -365,8 +366,9 @@ describe("ApplySyncResolutionUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -694,12 +696,9 @@ describe("ApplySyncResolutionUseCase", () => {
       }),
       expect.objectContaining({ vaultId: ctx.values.vaultId }),
     );
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -72,7 +72,7 @@ export class ApplySyncResolutionUseCase {
   async execute(
     params: ApplySyncResolutionCommandParams,
   ): Promise<ApplySyncResolutionResult> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "apply sync resolution",
@@ -331,12 +331,18 @@ export class ApplySyncResolutionUseCase {
             keySlots: acceptedCompletedEnrollmentTrustState.keySlots,
             nextTrust: remoteTrust,
           };
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-      persistOptions,
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+            persistOptions,
+          ),
+      );
 
     const resolvedSnapshot = persistedSnapshot.snapshot;
 
@@ -347,19 +353,17 @@ export class ApplySyncResolutionUseCase {
         params.remoteSnapshotDescriptor,
       );
     } catch (error) {
-      try {
-        await this.vaultSnapshot.restoreLocalVaultSnapshot(
-          localSnapshot,
-          resolvedSnapshot,
-          unlockedVault,
-        );
-      } catch {
-        try {
-          await this.unlockedVaultSession.remove();
-        } catch {
-          // Preserve the upload failure as the root cause.
-        }
-      }
+      await this.unlockedVaultSession.restoreIfSessionIsActive(
+        sessionId,
+        params.vaultId,
+        async () => {
+          await this.vaultSnapshot.restoreLocalVaultSnapshot(
+            localSnapshot,
+            resolvedSnapshot,
+            unlockedVault,
+          );
+        },
+      );
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(params.vaultId);
@@ -369,6 +373,7 @@ export class ApplySyncResolutionUseCase {
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -36,6 +36,7 @@ function createContext(syncConfigured = true) {
   };
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault,
     sourceSnapshotVersionVector: {
       [values.deviceId]: 1,
@@ -233,8 +234,9 @@ describe("DisableSyncUseCase", () => {
         .invocationCallOrder[0],
     );
     expect(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mock
         .invocationCallOrder[0],
@@ -296,7 +298,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
@@ -326,7 +328,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
@@ -356,7 +358,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
@@ -385,7 +387,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
@@ -406,7 +408,7 @@ describe("DisableSyncUseCase", () => {
 
     expect(ctx.vaultSnapshot.persistUnlockedVault).toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).toHaveBeenCalled();
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
@@ -483,7 +485,7 @@ describe("DisableSyncUseCase", () => {
 
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -47,7 +47,7 @@ export class DisableSyncUseCase {
   }
 
   async execute(params: DisableSyncCommandParams): Promise<void> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "disable sync",
@@ -104,11 +104,17 @@ export class DisableSyncUseCase {
         ...unlockedVault,
         vault: markVaultSyncRemovalPending(unlockedVault.vault),
       };
-      const pendingSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-        params.vaultId,
-        pendingUnlockedVault,
-        sourceSnapshotVersionVector,
-      );
+      const pendingSnapshot =
+        await this.unlockedVaultSession.persistForActiveSession(
+          sessionId,
+          params.vaultId,
+          async () =>
+            this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              pendingUnlockedVault,
+              sourceSnapshotVersionVector,
+            ),
+        );
 
       currentUnlockedVault = {
         ...pendingUnlockedVault,
@@ -118,6 +124,7 @@ export class DisableSyncUseCase {
       currentSnapshot = pendingSnapshot.snapshot;
 
       await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
         currentUnlockedVault,
         currentSnapshotVersionVector,
       );
@@ -159,23 +166,31 @@ export class DisableSyncUseCase {
       currentUnlockedVault.devicePrivateSignKey,
     );
 
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      currentSnapshotVersionVector,
-      {
-        keySlots: {
-          deviceSlots: currentDeviceSlots,
-          completedEnrollments: currentSnapshot.keySlots.completedEnrollments,
-        },
-        nextTrust: {
-          chain: nextTrust.chain,
-          state: nextTrust.trust,
-        },
-      },
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            currentSnapshotVersionVector,
+            {
+              keySlots: {
+                deviceSlots: currentDeviceSlots,
+                completedEnrollments:
+                  currentSnapshot.keySlots.completedEnrollments,
+              },
+              nextTrust: {
+                chain: nextTrust.chain,
+                state: nextTrust.trust,
+              },
+            },
+          ),
+      );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
@@ -93,6 +93,7 @@ function createContext() {
   });
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       ...unlockedVault,
       vault: {
@@ -492,6 +493,7 @@ describe("PrepareSyncReviewUseCase", () => {
   it("fails before provider reads when sync is not configured", async () => {
     const ctx = createContext();
     ctx.saved.unlockedVaultSession = {
+      sessionId: ctx.values.sessionId,
       unlockedVault: createUnlockedVaultWithEntries(ctx.values, []),
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 3,

--- a/packages/core/src/use-cases/sync/setup-sync.test.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.test.ts
@@ -26,6 +26,7 @@ function createContext() {
   const unlockedVault = createUnlockedVaultWithEntries(values, []);
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault,
     sourceSnapshotVersionVector: {
       [values.deviceId]: 1,
@@ -106,8 +107,9 @@ describe("SetupSyncUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -141,7 +143,7 @@ describe("SetupSyncUseCase", () => {
 
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
@@ -176,7 +178,7 @@ describe("SetupSyncUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig).toBe(
       ctx.values.syncConfig,
@@ -209,7 +211,7 @@ describe("SetupSyncUseCase", () => {
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
@@ -230,7 +232,7 @@ describe("SetupSyncUseCase", () => {
     ).rejects.toThrow("persist failed");
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncConfig,
@@ -253,19 +255,16 @@ describe("SetupSyncUseCase", () => {
       }),
     ).rejects.toThrow("upload failed");
 
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
   });
 
   it("bubbles the session commit failure after snapshot persistence", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(
@@ -281,7 +280,7 @@ describe("SetupSyncUseCase", () => {
   it("preserves the session commit error", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(

--- a/packages/core/src/use-cases/sync/setup-sync.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.ts
@@ -33,7 +33,7 @@ export class SetupSyncUseCase {
   }
 
   async execute(params: SetupSyncCommandParams): Promise<void> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "setup sync",
@@ -75,11 +75,17 @@ export class SetupSyncUseCase {
       },
     };
 
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+          ),
+      );
 
     await this.vaultSyncGuard.uploadPersistedInitialSyncSnapshot(
       params.vaultId,
@@ -87,9 +93,11 @@ export class SetupSyncUseCase {
       syncState.localSnapshot,
       persistedSnapshot.snapshot,
       unlockedVault,
+      sessionId,
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -77,6 +77,7 @@ function createContext() {
   });
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       ...unlockedVault,
       vault: {
@@ -351,6 +352,7 @@ describe("SyncUploadUseCase", () => {
   it("fails when sync is not configured", async () => {
     const ctx = createContext();
     ctx.saved.unlockedVaultSession = {
+      sessionId: ctx.values.sessionId,
       unlockedVault: createUnlockedVaultWithEntries(ctx.values, []),
       sourceSnapshotVersionVector: {
         [ctx.values.deviceId]: 1,

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -105,8 +105,9 @@ describe("AddEntryUseCase", () => {
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -128,7 +129,7 @@ describe("AddEntryUseCase", () => {
 
     expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
   });
@@ -150,7 +151,7 @@ describe("AddEntryUseCase", () => {
 
     expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
   });
@@ -229,7 +230,7 @@ describe("AddEntryUseCase", () => {
     expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [],
@@ -293,8 +294,9 @@ describe("AddEntryUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -356,8 +358,68 @@ describe("AddEntryUseCase", () => {
       expect.objectContaining({ vaultId: ctx.values.vaultId }),
     );
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
+  });
+
+  it("does not restore or lock a newer session after a stale upload fails", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: {
+        [ctx.values.deviceId]: 1,
+      },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const originalSession = ctx.saved.unlockedVaultSession!;
+
+    ctx.saved.unlockedVaultSession = {
+      ...originalSession,
+      unlockedVault: {
+        ...originalSession.unlockedVault,
+        vault: {
+          ...originalSession.unlockedVault.vault,
+          syncConfig: ctx.values.syncConfig,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(async () => {
+      await ctx.ports.sessionServices.unlockedVaultSession.remove();
+      vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce(
+        "new-session-id",
+      );
+      const activationGeneration =
+        await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+          ctx.values.vaultId,
+        );
+      await ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        originalSession.unlockedVault,
+        originalSession.sourceSnapshotVersionVector,
+      );
+
+      throw new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: "secret-password",
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(ctx.vaultSnapshot.restoreLocalVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession?.sessionId).toBe("new-session-id");
   });
 
   it("invalidates the session when synced upload restoration fails", async () => {
@@ -403,9 +465,6 @@ describe("AddEntryUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 
@@ -428,7 +487,7 @@ describe("AddEntryUseCase", () => {
     ).rejects.toThrow("persist failed");
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [],
@@ -438,7 +497,7 @@ describe("AddEntryUseCase", () => {
   it("bubbles the session commit failure after snapshot persistence", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.crypto.encryptUnlockedVaultSessionPayload,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(
@@ -454,16 +513,13 @@ describe("AddEntryUseCase", () => {
     ).rejects.toThrow("session save failed");
 
     expect(ctx.vaultSnapshot.persistUnlockedVault).toHaveBeenCalled();
-    expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 
   it("preserves the session commit error", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(

--- a/packages/core/src/use-cases/vault-entries/add-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.ts
@@ -43,7 +43,7 @@ export class AddEntryUseCase {
   }
 
   async execute(params: AddEntryCommandParams): Promise<AddEntryResult> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "add entry",
@@ -86,11 +86,17 @@ export class AddEntryUseCase {
       ),
     };
 
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+          ),
+      );
 
     if (syncState.syncConfig !== undefined) {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
@@ -98,10 +104,12 @@ export class AddEntryUseCase {
         syncState,
         persistedSnapshot.snapshot,
         updatedUnlockedVault,
+        sessionId,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
@@ -77,8 +77,9 @@ describe("RemoveEntryUseCase", () => {
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -127,8 +128,9 @@ describe("RemoveEntryUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -155,7 +157,7 @@ describe("RemoveEntryUseCase", () => {
     ).rejects.toBeInstanceOf(PasswordEntryNotFoundError);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
   });
@@ -174,7 +176,7 @@ describe("RemoveEntryUseCase", () => {
     ).rejects.toThrow("persist failed");
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [firstPasswordEntry, secondPasswordEntry],
@@ -184,7 +186,7 @@ describe("RemoveEntryUseCase", () => {
   it("bubbles the session commit failure after snapshot persistence", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(
@@ -200,7 +202,7 @@ describe("RemoveEntryUseCase", () => {
   it("preserves the session commit error", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(

--- a/packages/core/src/use-cases/vault-entries/remove-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.ts
@@ -36,7 +36,7 @@ export class RemoveEntryUseCase {
   }
 
   async execute(params: RemoveEntryCommandParams): Promise<RemoveEntryResult> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "remove entry",
@@ -66,11 +66,17 @@ export class RemoveEntryUseCase {
       ),
     };
 
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+          ),
+      );
 
     if (syncState.syncConfig !== undefined) {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
@@ -78,10 +84,12 @@ export class RemoveEntryUseCase {
         syncState,
         persistedSnapshot.snapshot,
         updatedUnlockedVault,
+        sessionId,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -102,8 +102,9 @@ describe("UpdateEntryUseCase", () => {
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -158,8 +159,9 @@ describe("UpdateEntryUseCase", () => {
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.commit).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+      ).mock.invocationCallOrder[0],
     );
   });
 
@@ -180,7 +182,7 @@ describe("UpdateEntryUseCase", () => {
     ).rejects.toBeInstanceOf(InvalidPasswordEntryError);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
   });
@@ -220,7 +222,7 @@ describe("UpdateEntryUseCase", () => {
     ).rejects.toBeInstanceOf(PasswordEntryNotFoundError);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
   });
@@ -245,7 +247,7 @@ describe("UpdateEntryUseCase", () => {
     ).rejects.toThrow("persist failed");
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [firstPasswordEntry, secondPasswordEntry],
@@ -255,7 +257,7 @@ describe("UpdateEntryUseCase", () => {
   it("bubbles the session commit failure after snapshot persistence", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(
@@ -277,7 +279,7 @@ describe("UpdateEntryUseCase", () => {
   it("preserves the session commit error", async () => {
     const ctx = createContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).mockRejectedValueOnce(new Error("session save failed"));
 
     await expect(

--- a/packages/core/src/use-cases/vault-entries/update-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.ts
@@ -43,7 +43,7 @@ export class UpdateEntryUseCase {
   }
 
   async execute(params: UpdateEntryCommandParams): Promise<UpdateEntryResult> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "update entry",
@@ -92,11 +92,17 @@ export class UpdateEntryUseCase {
       ),
     };
 
-    const persistedSnapshot = await this.vaultSnapshot.persistUnlockedVault(
-      params.vaultId,
-      updatedUnlockedVault,
-      sourceSnapshotVersionVector,
-    );
+    const persistedSnapshot =
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.persistUnlockedVault(
+            params.vaultId,
+            updatedUnlockedVault,
+            sourceSnapshotVersionVector,
+          ),
+      );
 
     if (syncState.syncConfig !== undefined) {
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
@@ -104,10 +110,12 @@ export class UpdateEntryUseCase {
         syncState,
         persistedSnapshot.snapshot,
         updatedUnlockedVault,
+        sessionId,
       );
     }
 
     await this.unlockedVaultSession.commitPersistedSnapshot(
+      sessionId,
       {
         ...updatedUnlockedVault,
         trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -13,6 +13,7 @@ function createContext() {
   );
 
   ports.saved.unlockedVaultSession = {
+    sessionId: values.sessionId,
     unlockedVault: {
       vaultId: values.vaultId,
       deviceId: values.deviceId,

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -152,6 +152,7 @@ describe("InitializeVaultUseCase", () => {
     );
 
     expect(ctx.saved.unlockedVaultSession).toEqual({
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -192,7 +193,7 @@ describe("InitializeVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
     ).toHaveBeenCalledTimes(1);
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
     expect(
       ctx.ports.vaultLocalRepository.saveLocalVaultDescriptor,
@@ -210,7 +211,7 @@ describe("InitializeVaultUseCase", () => {
     const error = new Error("session commit failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).mockRejectedValueOnce(error);
 
     await expect(
@@ -238,7 +239,7 @@ describe("InitializeVaultUseCase", () => {
     const cleanupError = new Error("initialized local cleanup failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).mockRejectedValueOnce(commitError);
     vi.mocked(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
@@ -287,7 +288,7 @@ describe("InitializeVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -206,20 +206,20 @@ describe("InitializeVaultUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("removes initialized local vault when unlocked session commit fails", async () => {
+  it("removes initialized local vault when session activation fails", async () => {
     const ctx = createInitializeVaultTestContext();
-    const error = new Error("session commit failed");
+    const activationError = new Error("session activation failed");
 
     vi.mocked(
       ctx.ports.sessionServices.unlockedVaultSession.activate,
-    ).mockRejectedValueOnce(error);
+    ).mockRejectedValueOnce(activationError);
 
     await expect(
       ctx.useCase.execute({
         masterPassword: ctx.values.masterPassword,
         deviceName: "Work laptop",
       }),
-    ).rejects.toBe(error);
+    ).rejects.toBe(activationError);
 
     expect(
       ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
@@ -233,14 +233,14 @@ describe("InitializeVaultUseCase", () => {
     expect(ctx.saved.vaultSnapshot).toBeUndefined();
   });
 
-  it("preserves session commit error when initialized local cleanup fails", async () => {
+  it("preserves session activation error when initialized local cleanup fails", async () => {
     const ctx = createInitializeVaultTestContext();
-    const commitError = new Error("session commit failed");
+    const activationError = new Error("session activation failed");
     const cleanupError = new Error("initialized local cleanup failed");
 
     vi.mocked(
       ctx.ports.sessionServices.unlockedVaultSession.activate,
-    ).mockRejectedValueOnce(commitError);
+    ).mockRejectedValueOnce(activationError);
     vi.mocked(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).mockRejectedValueOnce(cleanupError);
@@ -250,7 +250,7 @@ describe("InitializeVaultUseCase", () => {
         masterPassword: ctx.values.masterPassword,
         deviceName: "Work laptop",
       }),
-    ).rejects.toBe(commitError);
+    ).rejects.toBe(activationError);
 
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -63,7 +63,8 @@ export class InitializeVaultUseCase {
     initializeVaultCommandParams: InitializeVaultCommandParams,
   ): Promise<InitializeVaultResult> {
     const vaultId = await this.ids.generateId();
-    await this.unlockedVaultSession.requireVaultCanBeActivated(vaultId);
+    const activationGeneration =
+      await this.unlockedVaultSession.requireVaultCanBeActivated(vaultId);
 
     const deviceId = await this.ids.generateId();
     const timestamp = this.clock.now();
@@ -240,7 +241,8 @@ export class InitializeVaultUseCase {
       checkpoint,
     });
     try {
-      await this.unlockedVaultSession.commit(
+      await this.unlockedVaultSession.activate(
+        activationGeneration,
         unlockedVault,
         vaultSnapshot.metadata.snapshotVersionVector,
       );

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   ActiveUnlockedVaultMismatchError,
   InvalidVaultLockDelayError,
+  UnlockedVaultSessionExpiredError,
 } from "../../errors/vault-session.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
 import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
@@ -69,6 +70,7 @@ describe("UnlockVaultUseCase", () => {
     );
 
     expect(ctx.saved.unlockedVaultSession).toEqual({
+      sessionId: ctx.values.sessionId,
       unlockedVault: {
         vaultId: ctx.values.vaultId,
         deviceId: ctx.values.deviceId,
@@ -162,6 +164,42 @@ describe("UnlockVaultUseCase", () => {
     );
   });
 
+  it("does not activate after vault lock invalidates an in-progress unlock", async () => {
+    const ctx = createUnlockVaultTestContext();
+    let allowUnlockToContinue!: () => void;
+    let markUnlockPaused!: () => void;
+    const unlockPaused = new Promise<void>((resolve) => {
+      markUnlockPaused = resolve;
+    });
+    const allowUnlock = new Promise<void>((resolve) => {
+      allowUnlockToContinue = resolve;
+    });
+
+    vi.mocked(ctx.ports.crypto.deriveLocalRootKey)
+      .mockReset()
+      .mockImplementation(async () => {
+        markUnlockPaused();
+        await allowUnlock;
+
+        return ctx.values.localRootKey;
+      });
+
+    const unlocking = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      masterPassword: ctx.values.masterPassword,
+      lockAfterMs: 600_000,
+    });
+
+    await unlockPaused;
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    allowUnlockToContinue();
+
+    await expect(unlocking).rejects.toBeInstanceOf(
+      UnlockedVaultSessionExpiredError,
+    );
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+  });
+
   it("rejects a local device revoked by the verified trust chain", async () => {
     const ctx = createUnlockVaultTestContext();
     const remainingDeviceId = "remaining-device-id";
@@ -198,7 +236,7 @@ describe("UnlockVaultUseCase", () => {
 
     expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -272,7 +310,7 @@ describe("UnlockVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.getVaultSnapshot,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -292,7 +330,7 @@ describe("UnlockVaultUseCase", () => {
       ctx.ports.crypto.verifyVaultSnapshotSignature,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -315,7 +353,7 @@ describe("UnlockVaultUseCase", () => {
     expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -339,7 +377,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -366,7 +404,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -397,7 +435,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -427,7 +465,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.deriveLocalRootKey).toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -462,7 +500,7 @@ describe("UnlockVaultUseCase", () => {
 
     expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -503,7 +541,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -540,7 +578,7 @@ describe("UnlockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.crypto.unwrapVaultMasterKey).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -561,7 +599,7 @@ describe("UnlockVaultUseCase", () => {
     ).rejects.toThrow(error);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
   });
@@ -587,7 +625,7 @@ describe("UnlockVaultUseCase", () => {
     ).rejects.toThrow(scheduleError);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
   });
@@ -597,7 +635,7 @@ describe("UnlockVaultUseCase", () => {
     const error = new Error("save failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).mockRejectedValueOnce(error);
 
     await expect(
@@ -655,7 +693,7 @@ describe("UnlockVaultUseCase", () => {
     expect(ctx.ports.vaultLockTasks.save).not.toHaveBeenCalled();
     expect(ctx.ports.scheduledTasks.scheduleTask).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).not.toHaveBeenCalled();
   });
 
@@ -665,7 +703,7 @@ describe("UnlockVaultUseCase", () => {
     const cancelError = new Error("cancel failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.commit,
+      ctx.ports.sessionServices.unlockedVaultSession.activate,
     ).mockRejectedValueOnce(saveError);
     vi.mocked(ctx.ports.scheduledTasks.cancelTask).mockRejectedValueOnce(
       cancelError,

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
@@ -74,7 +74,10 @@ export class UnlockVaultUseCase {
       throw new InvalidVaultLockDelayError(lockDelayResult.error);
     }
 
-    await this.unlockedVaultSession.requireVaultCanBeActivated(params.vaultId);
+    const activationGeneration =
+      await this.unlockedVaultSession.requireVaultCanBeActivated(
+        params.vaultId,
+      );
 
     const deviceAccessMaterial =
       await this.vaultLocalRepository.getDeviceAccessMaterial(params.vaultId);
@@ -298,7 +301,8 @@ export class UnlockVaultUseCase {
     }
 
     try {
-      await this.unlockedVaultSession.commit(
+      await this.unlockedVaultSession.activate(
+        activationGeneration,
         unlockedVault,
         vaultSnapshot.metadata.snapshotVersionVector,
       );


### PR DESCRIPTION
## Summary
- bind vault-session activation and persisted snapshot commits to the active session generation
- serialize session record updates and prevent stale workflows from restoring state after lock
- invalidate the in-memory session before record removal, including failed material removal

## Verification
- pnpm core:test
- pnpm core:type-check
- git diff --check

Closes review finding #3 from the core review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-aware vault lifecycle management to improve protection against stale or concurrent operations.
  * Added session expiration handling with clear error reporting.
  * Updated vault changes, synchronization, enrollment, and entry management to safely coordinate active sessions.

* **Bug Fixes**
  * Prevented expired or stale sessions from restoring, overwriting, or removing newer vault state.
  * Improved cleanup and rollback behavior when persistence or synchronization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->