### PR TITLE
fix(core): make vault snapshot saves atomic

### DIFF
--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -26,12 +26,14 @@ import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-rep
 import { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import { createCoreTestValues, type CoreTestValues } from "./values";
 import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
+import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 
 export type SavedCoreRecords = {
   localVaultDescriptor?: LocalVaultDescriptor;
   deviceAccessMaterial?: DeviceAccessMaterial;
   deviceAccessRecoveryBackup?: DeviceAccessRecoveryBackup;
   vaultSnapshot?: VaultSnapshot;
+  vaultSnapshotDigest?: string;
   localVaultTrustCheckpoint?: LocalVaultTrustCheckpoint;
   unlockedVaultSession?: UnlockedVaultSession;
   unlockedVaultSessionMaterial?: UnlockedVaultSessionMaterial;
@@ -46,7 +48,9 @@ export type CoreTestPorts = ReturnType<typeof createCoreTestPorts>;
 export function createCoreTestPorts(
   values: CoreTestValues = createCoreTestValues(),
 ) {
-  const saved: SavedCoreRecords = {};
+  const saved: SavedCoreRecords = {
+    vaultSnapshotDigest: values.vaultSnapshotDigest,
+  };
   let unlockedVaultSessionMirror: UnlockedVaultSession | undefined;
 
   function writeSplitUnlockedVaultSessionRecords(
@@ -245,6 +249,7 @@ export function createCoreTestPorts(
         saved.deviceAccessMaterial = deviceAccessMaterial;
         saved.deviceAccessRecoveryBackup = deviceAccessRecoveryBackup;
         saved.vaultSnapshot = snapshot;
+        saved.vaultSnapshotDigest = checkpoint.payload.snapshotDigest;
         saved.localVaultTrustCheckpoint = checkpoint;
       },
     ),
@@ -253,6 +258,7 @@ export function createCoreTestPorts(
       saved.deviceAccessMaterial = undefined;
       saved.deviceAccessRecoveryBackup = undefined;
       saved.vaultSnapshot = undefined;
+      saved.vaultSnapshotDigest = undefined;
       saved.localVaultTrustCheckpoint = undefined;
     }),
     saveLocalVaultDescriptor: vi.fn(async (descriptor) => {
@@ -313,10 +319,23 @@ export function createCoreTestPorts(
       return vaultSnapshot.metadata.id === vaultId ? vaultSnapshot : null;
     }),
     removeVaultSnapshot: vi.fn(),
-    saveVaultSnapshotWithCheckpoint: vi.fn(async ({ snapshot, checkpoint }) => {
-      saved.vaultSnapshot = snapshot;
-      saved.localVaultTrustCheckpoint = checkpoint;
-    }),
+    saveVaultSnapshotWithCheckpoint: vi.fn(
+      async ({ expectedSnapshotDigest, snapshot, checkpoint }) => {
+        const currentSnapshot = saved.vaultSnapshot;
+
+        if (
+          currentSnapshot === undefined ||
+          currentSnapshot.metadata.id !== snapshot.metadata.id ||
+          saved.vaultSnapshotDigest !== expectedSnapshotDigest
+        ) {
+          throw new LocalVaultSnapshotChangedError(snapshot.metadata.id);
+        }
+
+        saved.vaultSnapshot = snapshot;
+        saved.vaultSnapshotDigest = checkpoint.payload.snapshotDigest;
+        saved.localVaultTrustCheckpoint = checkpoint;
+      },
+    ),
     getLocalVaultTrustCheckpoint: vi.fn(async (vaultId) => {
       const checkpoint = saved.localVaultTrustCheckpoint;
 

--- a/packages/core/src/errors/vault-snapshot.errors.ts
+++ b/packages/core/src/errors/vault-snapshot.errors.ts
@@ -22,6 +22,13 @@ export class VaultSnapshotVersionMismatchError extends Error {
   }
 }
 
+export class LocalVaultSnapshotChangedError extends Error {
+  constructor(vaultId: string) {
+    super(`Local vault snapshot for vault "${vaultId}" changed before save.`);
+    this.name = "LocalVaultSnapshotChangedError";
+  }
+}
+
 export class SnapshotSigningDeviceNotTrustedError extends Error {
   constructor(vaultId: string, deviceId: string) {
     super(`Device "${deviceId}" is not trusted to sign vault "${vaultId}".`);

--- a/packages/core/src/ports/vault/vault-local-repository.port.ts
+++ b/packages/core/src/ports/vault/vault-local-repository.port.ts
@@ -55,7 +55,9 @@ export interface VaultLocalRepositoryPort {
 
   /**
    * Atomically replaces the snapshot and signed rollback checkpoint only when
-   * the persisted snapshot still matches `expectedSnapshotDigest`.
+   * the persisted snapshot still matches `expectedSnapshotDigest`. Rejects
+   * with `LocalVaultSnapshotChangedError` without changing either record when
+   * the expected snapshot is no longer current.
    */
   saveVaultSnapshotWithCheckpoint: (params: {
     readonly expectedSnapshotDigest: string;

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
-import { createCoreTestValues } from "../../__tests__/fixtures/values";
+import { b64, createCoreTestValues } from "../../__tests__/fixtures/values";
 import {
   createUnlockedVaultWithEntries,
   singlePasswordEntry,
@@ -16,6 +16,7 @@ import {
   VaultSnapshotSignerNotTrustedError,
 } from "../../errors/unlock-vault.errors";
 import {
+  LocalVaultSnapshotChangedError,
   PersistedVaultMismatchError,
   SnapshotSigningDeviceNotTrustedError,
   VaultSnapshotVersionMismatchError,
@@ -86,6 +87,14 @@ describe("VaultSnapshotService", () => {
     };
 
     ports.saved.vaultSnapshot = currentSnapshot;
+    ports.saved.localVaultTrustCheckpoint = {
+      ...values.localVaultTrustCheckpoint,
+      payload: {
+        ...values.localVaultTrustCheckpoint.payload,
+        snapshotVersionVector: currentSnapshot.metadata.snapshotVersionVector,
+        snapshotDigest: values.vaultSnapshotDigest,
+      },
+    };
 
     return {
       values,
@@ -151,6 +160,108 @@ describe("VaultSnapshotService", () => {
       trustChain: ctx.currentSnapshot.trustChain,
       signature: ctx.values.snapshotSignature,
     });
+  });
+
+  it("rejects the second concurrent save based on the same snapshot", async () => {
+    const ctx = createContext();
+    const firstUnlockedVault = {
+      ...ctx.unlockedVault,
+      vault: {
+        ...ctx.unlockedVault.vault,
+        entries: [singlePasswordEntry],
+      },
+    };
+    const secondUnlockedVault = {
+      ...ctx.unlockedVault,
+      vault: {
+        ...ctx.unlockedVault.vault,
+        entries: [],
+      },
+    };
+    const firstEncryptedVault = {
+      ...ctx.values.encryptedVault,
+      ciphertext: b64("first-encrypted-vault"),
+    };
+    const secondEncryptedVault = {
+      ...ctx.values.encryptedVault,
+      ciphertext: b64("second-encrypted-vault"),
+    };
+    const snapshotDigests = new Map<VaultSnapshot, string>([
+      [ctx.currentSnapshot, ctx.values.vaultSnapshotDigest],
+    ]);
+    let nextSnapshotDigest = 1;
+    const saveSnapshot = vi.mocked(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    );
+    const saveSnapshotOriginal = saveSnapshot.getMockImplementation();
+
+    if (saveSnapshotOriginal === undefined) {
+      throw new Error("Expected the local snapshot save fixture.");
+    }
+
+    let saveAttempts = 0;
+    let releaseSaveAttempts!: () => void;
+    const bothSaveAttemptsReady = new Promise<void>((resolve) => {
+      releaseSaveAttempts = resolve;
+    });
+
+    vi.mocked(ctx.ports.crypto.encryptVaultSnapshotContent).mockImplementation(
+      async (vault) =>
+        vault === firstUnlockedVault.vault
+          ? firstEncryptedVault
+          : secondEncryptedVault,
+    );
+    vi.mocked(ctx.ports.crypto.digestVaultSnapshot).mockImplementation(
+      async (snapshot) => {
+        const existingDigest = snapshotDigests.get(snapshot);
+
+        if (existingDigest !== undefined) {
+          return existingDigest;
+        }
+
+        const digest = `next-snapshot-digest-${nextSnapshotDigest}`;
+        nextSnapshotDigest += 1;
+        snapshotDigests.set(snapshot, digest);
+
+        return digest;
+      },
+    );
+    saveSnapshot.mockImplementation(async (params) => {
+      saveAttempts += 1;
+
+      if (saveAttempts === 2) {
+        releaseSaveAttempts();
+      }
+
+      await bothSaveAttemptsReady;
+      await saveSnapshotOriginal(params);
+    });
+
+    const results = await Promise.allSettled([
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        firstUnlockedVault,
+        ctx.currentSnapshot.metadata.snapshotVersionVector,
+      ),
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        secondUnlockedVault,
+        ctx.currentSnapshot.metadata.snapshotVersionVector,
+      ),
+    ]);
+    const winner = results.find((result) => result.status === "fulfilled");
+    const loser = results.find((result) => result.status === "rejected");
+
+    if (winner?.status !== "fulfilled" || loser?.status !== "rejected") {
+      throw new Error("Expected exactly one concurrent snapshot save to win.");
+    }
+
+    expect(loser.reason).toBeInstanceOf(LocalVaultSnapshotChangedError);
+    expect(saveSnapshot).toHaveBeenCalledTimes(2);
+    expect(ctx.saved.vaultSnapshot).toBe(winner.value.snapshot);
+    expect(ctx.saved.localVaultTrustCheckpoint?.payload.snapshotDigest).toBe(
+      winner.value.trustedSnapshotContext.snapshotDigest,
+    );
   });
 
   it("requires the current snapshot for an unlocked vault without saving", async () => {

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -61,6 +61,16 @@ function createContext() {
     content: values.encryptedVault,
     signature: values.snapshotSignature,
   } satisfies VaultSnapshot;
+  ports.saved.localVaultTrustCheckpoint = {
+    ...values.localVaultTrustCheckpoint,
+    payload: {
+      ...values.localVaultTrustCheckpoint.payload,
+      snapshotVersionVector: {
+        [values.deviceId]: 1,
+      },
+      snapshotDigest: values.vaultSnapshotDigest,
+    },
+  };
 
   ports.saved.unlockedVaultSession = {
     sessionId: values.sessionId,

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -477,7 +477,8 @@ describe("RecoverDeviceAccessUseCase", () => {
 
   it("updates a newer checkpoint with the snapshot-and-checkpoint compare-and-set", async () => {
     const ctx = createContext();
-    ctx.ports.saved.vaultSnapshot = {
+    const newerSnapshotDigest = "newer-vault-snapshot-digest";
+    const newerSnapshot = {
       ...ctx.vaultSnapshot,
       metadata: {
         ...ctx.vaultSnapshot.metadata,
@@ -486,6 +487,14 @@ describe("RecoverDeviceAccessUseCase", () => {
         },
       },
     };
+    ctx.ports.saved.vaultSnapshot = newerSnapshot;
+    ctx.ports.saved.vaultSnapshotDigest = newerSnapshotDigest;
+    vi.mocked(ctx.ports.crypto.digestVaultSnapshot).mockImplementation(
+      async (snapshot) =>
+        snapshot === newerSnapshot
+          ? newerSnapshotDigest
+          : ctx.values.vaultSnapshotDigest,
+    );
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
@@ -496,10 +505,11 @@ describe("RecoverDeviceAccessUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledWith({
-      expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+      expectedSnapshotDigest: newerSnapshotDigest,
       snapshot: ctx.ports.saved.vaultSnapshot,
       checkpoint: expect.objectContaining({
         payload: expect.objectContaining({
+          snapshotDigest: newerSnapshotDigest,
           snapshotVersionVector: { [ctx.values.deviceId]: 2 },
         }),
       }),

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -191,6 +191,14 @@ function createContext() {
     },
   };
   ports.saved.vaultSnapshot = localSnapshot;
+  ports.saved.localVaultTrustCheckpoint = {
+    ...values.localVaultTrustCheckpoint,
+    payload: {
+      ...values.localVaultTrustCheckpoint.payload,
+      snapshotVersionVector: localSnapshot.metadata.snapshotVersionVector,
+      snapshotDigest: values.vaultSnapshotDigest,
+    },
+  };
 
   return {
     values,

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -265,7 +265,8 @@ describe("UnlockVaultUseCase", () => {
 
   it("updates a newer checkpoint with the snapshot-and-checkpoint compare-and-set", async () => {
     const ctx = createUnlockVaultTestContext();
-    ctx.saved.vaultSnapshot = {
+    const newerSnapshotDigest = "newer-vault-snapshot-digest";
+    const newerSnapshot = {
       ...ctx.vaultSnapshot,
       metadata: {
         ...ctx.vaultSnapshot.metadata,
@@ -274,6 +275,14 @@ describe("UnlockVaultUseCase", () => {
         },
       },
     };
+    ctx.saved.vaultSnapshot = newerSnapshot;
+    ctx.saved.vaultSnapshotDigest = newerSnapshotDigest;
+    vi.mocked(ctx.ports.crypto.digestVaultSnapshot).mockImplementation(
+      async (snapshot) =>
+        snapshot === newerSnapshot
+          ? newerSnapshotDigest
+          : ctx.values.vaultSnapshotDigest,
+    );
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
@@ -284,10 +293,11 @@ describe("UnlockVaultUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenCalledWith({
-      expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+      expectedSnapshotDigest: newerSnapshotDigest,
       snapshot: ctx.saved.vaultSnapshot,
       checkpoint: expect.objectContaining({
         payload: expect.objectContaining({
+          snapshotDigest: newerSnapshotDigest,
           snapshotVersionVector: { [ctx.values.deviceId]: 2 },
         }),
       }),


### PR DESCRIPTION
## Summary

- enforce expected-digest compare-and-set semantics for local vault snapshot persistence
- reject stale writes without changing the snapshot or rollback checkpoint
- cover forced concurrent saves and checkpoint repair with distinct snapshot/checkpoint digests

## Review finding

Resolves finding #4: non-atomic snapshot check-and-save could silently lose password updates.

## Validation

- `pnpm core:test` — 370/370 passed
- `pnpm core:type-check` — passed
- `git diff --check` — passed
- repeated two-agent reviews — no remaining in-scope findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent vault saves from overwriting one another.
  * Vault snapshots and trust checkpoints are now saved only when the expected snapshot is still current.
  * Added clear error handling when a local vault snapshot changes before saving.
* **Tests**
  * Added coverage for concurrent saves and snapshot/checkpoint consistency across vault lifecycle, device trust, and synchronization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->