### PR TITLE
fix(core): enforce strict synchronized mutations

### DIFF
--- a/docs/design/sync-strategy.md
+++ b/docs/design/sync-strategy.md
@@ -1,7 +1,33 @@
 # Sync Strategy
 
-> Sync is optional, local-first, and user-controlled. The project operates no
-> credential or coordination server.
+> Vault data is locally owned and sync is optional and user-controlled. The
+> project operates no credential or coordination server.
+
+## Operating modes
+
+A vault without sync configured operates locally and permits offline mutations.
+Once sync is configured, every mutation requires network access and an exact
+match between the verified local snapshot and the current remote descriptor.
+This synchronized mode assumes one user operates one device at a time.
+
+The remote object coordinates synchronized state but remains hostile storage.
+Remote content is authenticated and is never accepted silently. Local unlock
+and read behavior is unchanged by the mutation gate.
+
+Before a synchronized mutation, descriptor relations are handled as follows:
+
+| Relation                    | Behavior                                                         |
+| --------------------------- | ---------------------------------------------------------------- |
+| Exact descriptor equality   | Permit the mutation                                              |
+| `remote_ahead`              | Block and require explicit verified download and review          |
+| `local_ahead`               | Block and require explicit upload of the existing local snapshot |
+| `broken` or crossed vectors | Reject as an integrity failure or unsupported concurrency        |
+| Remote snapshot missing     | Reject because synchronized state cannot be confirmed            |
+
+A local-ahead snapshot is a recovery state, not a valid base for another
+mutation. The normal upload workflow must synchronize it before the mutation is
+retried. Concurrent or offline edits from multiple synchronized devices are not
+supported.
 
 ## Shared target and local credentials
 

--- a/packages/core/src/domain/versioning/version-vector.type.ts
+++ b/packages/core/src/domain/versioning/version-vector.type.ts
@@ -4,8 +4,8 @@ export type VersionVector = Record<string, number>;
  * Snapshot-level relation between local and remote version vectors.
  *
  * equal: local and remote describe the same snapshot version.
- * local_ahead: local has newer local-device snapshot changes and may be
- * uploaded or extended with more local changes.
+ * local_ahead: local has newer snapshot changes and must be uploaded before
+ * another synchronized mutation can continue.
  * remote_ahead: remote has newer snapshot changes and local writes must wait
  * for sync/review.
  * remote_missing: remote descriptor is absent even though sync is configured;

--- a/packages/core/src/errors/sync.errors.ts
+++ b/packages/core/src/errors/sync.errors.ts
@@ -121,7 +121,7 @@ export class LocalVaultSnapshotNotAheadError extends Error {
 export class LocalVaultSnapshotAheadError extends Error {
   constructor(vaultId: string) {
     super(
-      `Local vault snapshot for vault "${vaultId}" must be uploaded before preparing sync review.`,
+      `Local vault snapshot for vault "${vaultId}" must be uploaded before another synchronized operation can continue.`,
     );
     this.name = "LocalVaultSnapshotAheadError";
   }

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -14,6 +14,7 @@ import {
   RemoteVaultSnapshotIntegrityError,
   RemoteVaultSnapshotNotFoundError,
   SyncConflictDetectedError,
+  LocalVaultSnapshotAheadError,
   LocalSyncCredentialsMissingError,
   ProviderCredentialRevocationPendingError,
   SyncRemovalPendingError,
@@ -108,6 +109,10 @@ export class VaultSyncGuardService {
 
     if (relation === "remote_ahead") {
       throw new RemoteVaultSnapshotAheadError(vaultId);
+    }
+
+    if (relation === "local_ahead") {
+      throw new LocalVaultSnapshotAheadError(vaultId);
     }
 
     if (relation === "broken") {

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -7,11 +7,11 @@ import type {
 } from "../../domain/device-trust";
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import { UnsupportedAlgorithmSuiteError } from "../../errors/algorithm-suite.errors";
+import { DeviceEnrollmentIntegrityError } from "../../errors/device-enrollment.errors";
 import {
-  DeviceEnrollmentIntegrityError,
-  DeviceEnrollmentVaultNotSynchronizedError,
-} from "../../errors/device-enrollment.errors";
-import { ProviderCredentialRevocationPendingError } from "../../errors/sync.errors";
+  LocalVaultSnapshotAheadError,
+  ProviderCredentialRevocationPendingError,
+} from "../../errors/sync.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { InitializeDeviceEnrollmentUseCase } from "./initialize-device-enrollment";
@@ -141,7 +141,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("rejects authorization when the remote snapshot differs from local state", async () => {
+  it("rejects authorization when the local snapshot is ahead", async () => {
     const ctx = createContext();
     const session = ctx.saved.unlockedVaultSession;
 
@@ -173,7 +173,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
         vaultId: ctx.values.vaultId,
         request: ctx.values.enrollmentRequest,
       }),
-    ).rejects.toBeInstanceOf(DeviceEnrollmentVaultNotSynchronizedError);
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
 
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -2,15 +2,8 @@ import type {
   DeviceEnrollmentRequest,
   DeviceEnrollmentResponse,
 } from "../../domain/device-trust";
-import {
-  areVaultSnapshotDescriptorsEqual,
-  toVaultSnapshotDescriptor,
-} from "../../domain/snapshot";
 import { UnsupportedAlgorithmSuiteError } from "../../errors/algorithm-suite.errors";
-import {
-  DeviceEnrollmentIntegrityError,
-  DeviceEnrollmentVaultNotSynchronizedError,
-} from "../../errors/device-enrollment.errors";
+import { DeviceEnrollmentIntegrityError } from "../../errors/device-enrollment.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
@@ -93,16 +86,6 @@ export class InitializeDeviceEnrollmentUseCase {
         params.vaultId,
         "request trust anchor does not match the vault",
       );
-    }
-
-    if (
-      syncState.remoteSnapshotDescriptor !== undefined &&
-      !areVaultSnapshotDescriptorsEqual(
-        syncState.remoteSnapshotDescriptor,
-        toVaultSnapshotDescriptor(params.vaultId, currentSnapshot),
-      )
-    ) {
-      throw new DeviceEnrollmentVaultNotSynchronizedError(params.vaultId);
     }
 
     const currentIdentity =

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -5,10 +5,7 @@ import type {
 } from "../../domain/sync";
 import type { SyncAccess, SyncSetupInput } from "../../domain/sync";
 import { requireDeviceProfilesMatchTrust } from "../../domain/sync/device-profile-review.utils";
-import {
-  areVaultSnapshotDescriptorsEqual,
-  toVaultSnapshotDescriptor,
-} from "../../domain/snapshot";
+import { areVaultSnapshotDescriptorsEqual } from "../../domain/snapshot";
 import type { Vault } from "../../domain/vault/vault";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device.mutations";
 import { markVaultProviderCredentialRevocationPending } from "../../domain/vault/vault-sync-config.mutations";
@@ -133,19 +130,6 @@ export class RevokeDeviceUseCase {
         params.vaultId,
         "device profiles do not match the trusted identities",
         { cause: error },
-      );
-    }
-
-    if (
-      syncState.remoteSnapshotDescriptor !== undefined &&
-      !areVaultSnapshotDescriptorsEqual(
-        syncState.remoteSnapshotDescriptor,
-        toVaultSnapshotDescriptor(params.vaultId, currentSnapshot),
-      )
-    ) {
-      throw new InvalidDeviceRevocationTransitionError(
-        params.vaultId,
-        "local and remote snapshots must match",
       );
     }
 

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -75,6 +75,44 @@ describe("SyncUploadUseCase", () => {
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
 
+  it("uploads a local-ahead snapshot using the remote descriptor as the expected state", async () => {
+    const ctx = createContext();
+    const localSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        revisionTimestamp: ctx.values.timestamp + 1,
+        snapshotVersionVector: {
+          [ctx.values.deviceId]: 2,
+        },
+      },
+    };
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: {
+        [ctx.values.deviceId]: 1,
+      },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.vaultSnapshot = localSnapshot;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      sourceSnapshotVersionVector: localSnapshot.metadata.snapshotVersionVector,
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(remoteSnapshotDescriptor);
+
+    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
+      ctx.values.syncAccess,
+      localSnapshot,
+      remoteSnapshotDescriptor,
+    );
+  });
+
   it("blocks upload when remote is ahead", async () => {
     const ctx = createContext();
     vi.mocked(

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -6,6 +6,7 @@ import {
   saveUnlockedVaultWithEntries,
 } from "../../__tests__/fixtures/vault-entries";
 import {
+  LocalVaultSnapshotAheadError,
   RemoteVaultSnapshotAheadError,
   RemoteVaultSnapshotChangedError,
   SyncRemovalPendingError,
@@ -232,6 +233,73 @@ describe("AddEntryUseCase", () => {
 
     expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
     expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
+      [],
+    );
+  });
+
+  it("does not extend a local-ahead synchronized snapshot", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    const localSnapshot =
+      await ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault(
+        ctx.values.vaultId,
+        session.unlockedVault,
+        session.sourceSnapshotVersionVector,
+      );
+    const localSnapshotVersionVector = {
+      [ctx.values.deviceId]: 2,
+    };
+    vi.mocked(ctx.vaultSnapshot.requireCurrentSnapshotForUnlockedVault)
+      .mockClear()
+      .mockResolvedValue({
+        ...localSnapshot,
+        metadata: {
+          ...localSnapshot.metadata,
+          revisionTimestamp: ctx.values.timestamp + 1,
+          snapshotVersionVector: localSnapshotVersionVector,
+        },
+      });
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      sourceSnapshotVersionVector: localSnapshotVersionVector,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+          versionVector: localSnapshotVersionVector,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce({
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: {
+        [ctx.values.deviceId]: 1,
+      },
+      revisionTimestamp: ctx.values.timestamp,
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: "secret-password",
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
+
+    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- block synchronized mutations when the local snapshot is ahead
- preserve explicit sync upload as the recovery path
- remove redundant enrollment and revocation descriptor checks
- document local-only and synchronized operating modes

## Validation

- focused mutation, upload, enrollment, and revocation suites passed
- full core test suite passed: 349 tests
- core and extension type-checks passed
- lint-staged formatting and lint checks passed
- git diff check passed

The local review findings file is intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented synchronized mutations when local vault data is ahead of the remote snapshot.
  * Clarified that local changes must be uploaded before additional synchronized operations.
  * Improved device enrollment and revocation behavior when snapshot states differ.
  * Added clearer error messaging for blocked synchronized operations.

* **Documentation**
  * Documented local and synchronized modes, snapshot state handling, and offline/concurrent edit restrictions.

* **Tests**
  * Added coverage for successful uploads and rejected mutations when local data is ahead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->