### PR TITLE
fix(core): reject local resolution of remote-only state

### DIFF
--- a/packages/core/src/domain/sync/device-profile-resolution.utils.ts
+++ b/packages/core/src/domain/sync/device-profile-resolution.utils.ts
@@ -122,6 +122,15 @@ function selectDeviceProfileState(
   deviceProfileReview: DeviceProfileReviewItem,
   deviceProfileResolution: DeviceProfileReviewResolution,
 ): ReviewableDeviceProfile {
+  if (
+    deviceProfileReview.relation === "remote_only" &&
+    deviceProfileResolution.action === "use_local"
+  ) {
+    throw new InvalidVaultSyncResolutionError(
+      `Device profile "${deviceProfileReview.deviceId}" cannot use local absence to resolve remote-only state.`,
+    );
+  }
+
   return deviceProfileResolution.action === "use_local"
     ? deviceProfileReview.localDeviceProfile
     : deviceProfileReview.remoteDeviceProfile;

--- a/packages/core/src/domain/sync/entry-resolution.utils.ts
+++ b/packages/core/src/domain/sync/entry-resolution.utils.ts
@@ -110,6 +110,15 @@ function selectEntryState(
   entryReview: EntryReviewItem,
   entryResolution: EntryReviewResolution,
 ): ReviewableEntry {
+  if (
+    entryReview.relation === "remote_only" &&
+    entryResolution.action === "use_local"
+  ) {
+    throw new InvalidVaultSyncResolutionError(
+      `Entry "${entryReview.entryId}" cannot use local absence to resolve remote-only state.`,
+    );
+  }
+
   return entryResolution.action === "use_local"
     ? entryReview.localEntry
     : entryReview.remoteEntry;

--- a/packages/core/src/domain/sync/sync-resolution.utils.test.ts
+++ b/packages/core/src/domain/sync/sync-resolution.utils.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import type { DeviceProfile } from "../device-profile";
+import type { PasswordEntry } from "../entry/password-entry.type";
+import type { Tag } from "../entry/tag.type";
+import type { Vault } from "../vault";
+import { InvalidVaultSyncResolutionError } from "../../errors/sync.errors";
+import type { DeviceProfileReviewItem } from "./device-profile-review.type";
+import type { EntryReviewItem } from "./entry-review.type";
+import type { VaultSyncResolution } from "./sync-resolution.type";
+import { applyVaultSyncResolution } from "./sync-resolution.utils";
+import type { TagReviewItem } from "./tag-review.type";
+
+const resolvingDeviceId = "resolving-device";
+
+function createVault(overrides: Partial<Vault> = {}): Vault {
+  return {
+    versionVector: { [resolvingDeviceId]: 1 },
+    entries: [],
+    deletedEntries: [],
+    deviceProfiles: [],
+    deletedDeviceProfiles: [],
+    tags: [],
+    deletedTags: [],
+    ...overrides,
+  };
+}
+
+function applyResolution(
+  localVault: Vault,
+  remoteVault: Vault,
+  review: {
+    readonly entryReviews: readonly EntryReviewItem[];
+    readonly tagReviews: readonly TagReviewItem[];
+    readonly deviceProfileReviews: readonly DeviceProfileReviewItem[];
+  },
+  resolution: VaultSyncResolution,
+): Vault {
+  return applyVaultSyncResolution(
+    localVault,
+    remoteVault,
+    review,
+    resolution,
+    resolvingDeviceId,
+  );
+}
+
+describe("applyVaultSyncResolution", () => {
+  it("rejects local absence for a remote-only entry", () => {
+    const remoteEntry = {
+      id: "remote-entry",
+      password: "password",
+      login: "user@example.com",
+      tags: [],
+      sanitizedUrl: "https://example.com",
+      versionVector: { "remote-device": 1 },
+    } satisfies PasswordEntry;
+    const localVault = createVault();
+    const remoteVault = createVault({ entries: [remoteEntry] });
+
+    expect(() =>
+      applyResolution(
+        localVault,
+        remoteVault,
+        {
+          entryReviews: [
+            {
+              entryId: remoteEntry.id,
+              relation: "remote_only",
+              preselectedAction: "use_remote",
+              localEntry: { state: "missing" },
+              remoteEntry: { state: "entry", entry: remoteEntry },
+            },
+          ],
+          tagReviews: [],
+          deviceProfileReviews: [],
+        },
+        {
+          entryResolutions: [
+            { entryId: remoteEntry.id, action: "use_local" },
+          ],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      ),
+    ).toThrow(InvalidVaultSyncResolutionError);
+  });
+
+  it("rejects local absence for a remote-only tag", () => {
+    const remoteTag = {
+      id: 1,
+      name: "Remote",
+      versionVector: { "remote-device": 1 },
+    } satisfies Tag;
+    const localVault = createVault();
+    const remoteVault = createVault({ tags: [remoteTag] });
+
+    expect(() =>
+      applyResolution(
+        localVault,
+        remoteVault,
+        {
+          entryReviews: [],
+          tagReviews: [
+            {
+              tagId: remoteTag.id,
+              relation: "remote_only",
+              preselectedAction: "use_remote",
+              localTag: { state: "missing" },
+              remoteTag: { state: "tag", tag: remoteTag },
+            },
+          ],
+          deviceProfileReviews: [],
+        },
+        {
+          entryResolutions: [],
+          tagResolutions: [{ tagId: remoteTag.id, action: "use_local" }],
+          deviceProfileResolutions: [],
+        },
+      ),
+    ).toThrow(InvalidVaultSyncResolutionError);
+  });
+
+  it("rejects local absence for a remote-only device profile", () => {
+    const remoteDeviceProfile = {
+      id: "remote-device",
+      name: "Remote device",
+      createdAt: 1,
+      versionVector: { "remote-device": 1 },
+    } satisfies DeviceProfile;
+    const localVault = createVault();
+    const remoteVault = createVault({
+      deviceProfiles: [remoteDeviceProfile],
+    });
+
+    expect(() =>
+      applyResolution(
+        localVault,
+        remoteVault,
+        {
+          entryReviews: [],
+          tagReviews: [],
+          deviceProfileReviews: [
+            {
+              deviceId: remoteDeviceProfile.id,
+              relation: "remote_only",
+              preselectedAction: "use_remote",
+              localDeviceProfile: { state: "missing" },
+              remoteDeviceProfile: {
+                state: "device_profile",
+                deviceProfile: remoteDeviceProfile,
+              },
+            },
+          ],
+        },
+        {
+          entryResolutions: [],
+          tagResolutions: [],
+          deviceProfileResolutions: [
+            { deviceId: remoteDeviceProfile.id, action: "use_local" },
+          ],
+        },
+      ),
+    ).toThrow(InvalidVaultSyncResolutionError);
+  });
+});

--- a/packages/core/src/domain/sync/tag-resolution.utils.ts
+++ b/packages/core/src/domain/sync/tag-resolution.utils.ts
@@ -105,6 +105,15 @@ function selectTagState(
   tagReview: TagReviewItem,
   tagResolution: TagReviewResolution,
 ): ReviewableTag {
+  if (
+    tagReview.relation === "remote_only" &&
+    tagResolution.action === "use_local"
+  ) {
+    throw new InvalidVaultSyncResolutionError(
+      `Tag "${tagReview.tagId}" cannot use local absence to resolve remote-only state.`,
+    );
+  }
+
   return tagResolution.action === "use_local"
     ? tagReview.localTag
     : tagReview.remoteTag;


### PR DESCRIPTION
## Summary

- Reject `use_local` resolutions when entries, tags, or device profiles exist only remotely.
- Add regression coverage for all three remote-only sync entity types.

## Testing

- `pnpm core:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid “use local” choices when entries, tags, or device profiles exist only in the remote vault.
  * Sync now reports an error instead of incorrectly treating remotely available items as absent locally.

* **Tests**
  * Added coverage for invalid sync resolutions across entries, tags, and device profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->