### PR TITLE
fix(core): make sync disable recovery-safe

### DIFF
--- a/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import {
+  clearVaultSyncRemovalPending,
   clearVaultProviderCredentialRevocationPending,
   markVaultProviderCredentialRevocationPending,
   markVaultSyncRemovalPending,
@@ -9,11 +11,38 @@ import {
 
 describe("vault sync target mutations", () => {
   it("marks remote removal pending", () => {
-    const values = createCoreTestValues();
+    const { values, vaultSnapshot } = createUnlockVaultTestContext();
+    const expectedRemoteSnapshotDescriptor = {
+      vaultId: values.vaultId,
+      snapshotVersionVector: { [values.deviceId]: 1 },
+      revisionTimestamp: values.timestamp,
+    };
 
     expect(
-      markVaultSyncRemovalPending(values.decryptedVault).syncRemovalPending,
-    ).toBe(true);
+      markVaultSyncRemovalPending(
+        values.decryptedVault,
+        expectedRemoteSnapshotDescriptor,
+        vaultSnapshot,
+      ).syncRemovalPending,
+    ).toEqual({
+      expectedRemoteSnapshotDescriptor,
+      rollbackSnapshot: vaultSnapshot,
+    });
+  });
+
+  it("clears pending remote removal without removing the sync target", () => {
+    const { values, vaultSnapshot } = createUnlockVaultTestContext();
+    const result = clearVaultSyncRemovalPending({
+      ...values.decryptedVault,
+      syncTarget: values.syncTarget,
+      syncRemovalPending: {
+        expectedRemoteSnapshotDescriptor: null,
+        rollbackSnapshot: vaultSnapshot,
+      },
+    });
+
+    expect(result.syncTarget).toEqual(values.syncTarget);
+    expect("syncRemovalPending" in result).toBe(false);
   });
 
   it("marks and clears provider credential revocation", () => {
@@ -35,11 +64,14 @@ describe("vault sync target mutations", () => {
   });
 
   it("removes target and pending marker", () => {
-    const values = createCoreTestValues();
+    const { values, vaultSnapshot } = createUnlockVaultTestContext();
     const result = removeVaultSyncTarget({
       ...values.decryptedVault,
       syncTarget: values.syncTarget,
-      syncRemovalPending: true,
+      syncRemovalPending: {
+        expectedRemoteSnapshotDescriptor: null,
+        rollbackSnapshot: vaultSnapshot,
+      },
       providerCredentialRevocationPending: {
         revokedDeviceIds: [values.pendingDeviceId],
         vaultKeyGeneration: 2,

--- a/packages/core/src/domain/vault/vault-sync-config.mutations.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.ts
@@ -1,10 +1,26 @@
+import type { VaultSnapshotDescriptor } from "../snapshot/vault-snapshot-descriptor.type";
+import type { VaultSnapshot } from "../snapshot/vault-snapshot";
 import type { Vault } from "./vault";
 
-export function markVaultSyncRemovalPending(vault: Vault): Vault {
+export function markVaultSyncRemovalPending(
+  vault: Vault,
+  expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
+  rollbackSnapshot: VaultSnapshot,
+): Vault {
   return {
     ...vault,
-    syncRemovalPending: true,
+    syncRemovalPending: {
+      expectedRemoteSnapshotDescriptor,
+      rollbackSnapshot,
+    },
   };
+}
+
+export function clearVaultSyncRemovalPending(vault: Vault): Vault {
+  const { syncRemovalPending, ...vaultWithoutSyncRemovalPending } = vault;
+  void syncRemovalPending;
+
+  return vaultWithoutSyncRemovalPending;
 }
 
 export function markVaultProviderCredentialRevocationPending(

--- a/packages/core/src/domain/vault/vault.ts
+++ b/packages/core/src/domain/vault/vault.ts
@@ -7,6 +7,8 @@ import type {
   PasswordEntry,
 } from "../entry/password-entry.type";
 import type { SyncTarget } from "../sync/sync-config.type";
+import type { VaultSnapshotDescriptor } from "../snapshot/vault-snapshot-descriptor.type";
+import type { VaultSnapshot } from "../snapshot/vault-snapshot";
 import type { VersionVector } from "../versioning/version-vector.type";
 import type { DeletedTag, Tag } from "../entry/tag.type";
 
@@ -17,7 +19,10 @@ export interface Vault {
   deviceProfiles: DeviceProfile[];
   deletedDeviceProfiles: DeletedDeviceProfile[];
   syncTarget?: SyncTarget;
-  syncRemovalPending?: true;
+  syncRemovalPending?: {
+    readonly expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null;
+    readonly rollbackSnapshot: VaultSnapshot;
+  };
   providerCredentialRevocationPending?: {
     readonly revokedDeviceIds: readonly string[];
     readonly vaultKeyGeneration: number;

--- a/packages/core/src/ports/sync/sync-provider.port.ts
+++ b/packages/core/src/ports/sync/sync-provider.port.ts
@@ -27,12 +27,16 @@ export interface SyncProviderPort {
     expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
   ) => Promise<void>;
   /**
-   * Removes all remote state for a vault. This operation must be idempotent:
-   * attempting to remove an already-absent vault is successful.
+   * Removes all remote state for a vault only when the latest snapshot still
+   * matches the expected descriptor. A different current descriptor must fail
+   * with RemoteVaultSnapshotChangedError without removing remote state. This
+   * operation must be idempotent: attempting to remove an already-absent vault
+   * is successful.
    */
   removeVaultSnapshots: (
     syncAccess: SyncAccess,
     vaultId: string,
+    expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
   ) => Promise<void>;
   /**
    * Returns authentication rejection only when the provider definitively

--- a/packages/core/src/ports/sync/sync-provider.port.ts
+++ b/packages/core/src/ports/sync/sync-provider.port.ts
@@ -28,8 +28,10 @@ export interface SyncProviderPort {
   ) => Promise<void>;
   /**
    * Removes all remote state for a vault only when the latest snapshot still
-   * matches the expected descriptor. A different current descriptor must fail
-   * with RemoteVaultSnapshotChangedError without removing remote state. This
+   * matches the expected descriptor. A null expected descriptor means that no
+   * remote snapshot may exist. A different current descriptor, including a
+   * snapshot appearing when null was expected, must fail with
+   * RemoteVaultSnapshotChangedError without removing remote state. This
    * operation must be idempotent: attempting to remove an already-absent vault
    * is successful.
    */

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -83,7 +83,7 @@ export class VaultSyncGuardService {
       };
     }
 
-    if (unlockedVault.vault.syncRemovalPending === true) {
+    if (unlockedVault.vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(vaultId, "modify vault data");
     }
 

--- a/packages/core/src/services/trust/device-enrollment-consumption.service.ts
+++ b/packages/core/src/services/trust/device-enrollment-consumption.service.ts
@@ -54,7 +54,7 @@ export class DeviceEnrollmentConsumptionService {
       throw new SyncNotConfiguredError(params.vaultId, params.operation);
     }
 
-    if (params.unlockedVault.vault.syncRemovalPending === true) {
+    if (params.unlockedVault.vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(params.vaultId, params.operation);
     }
 
@@ -177,8 +177,10 @@ export class DeviceEnrollmentConsumptionService {
         remoteVault.syncTarget,
         params.unlockedVault.vault.syncTarget,
       ) ||
-      remoteVault.syncRemovalPending !==
-        params.unlockedVault.vault.syncRemovalPending ||
+      !areJsonEqual(
+        remoteVault.syncRemovalPending,
+        params.unlockedVault.vault.syncRemovalPending,
+      ) ||
       (!areJsonEqual(
         remoteVault.providerCredentialRevocationPending,
         params.unlockedVault.vault.providerCredentialRevocationPending,

--- a/packages/core/src/services/trust/device-revocation-consumption.service.ts
+++ b/packages/core/src/services/trust/device-revocation-consumption.service.ts
@@ -251,8 +251,10 @@ export class DeviceRevocationConsumptionService {
 
     if (
       !areJsonEqual(remoteVault.syncTarget, syncTarget) ||
-      remoteVault.syncRemovalPending !==
-        params.unlockedVault.vault.syncRemovalPending
+      !areJsonEqual(
+        remoteVault.syncRemovalPending,
+        params.unlockedVault.vault.syncRemovalPending,
+      )
     ) {
       throw new InvalidDeviceRevocationTransitionError(
         params.vaultId,

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import type {
   DeviceEnrollmentResponse,
@@ -181,10 +182,15 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("rejects enrollment while remote sync removal is pending", async () => {
     const ctx = createContext(true);
+    const rollbackSnapshot = createUnlockVaultTestContext().vaultSnapshot;
+
     vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue({
       ...ctx.values.decryptedVault,
       syncTarget: ctx.values.syncTarget,
-      syncRemovalPending: true,
+      syncRemovalPending: {
+        expectedRemoteSnapshotDescriptor: null,
+        rollbackSnapshot,
+      },
     });
 
     await expect(

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -474,7 +474,7 @@ export class PerformDeviceEnrollmentUseCase {
     syncConfig: SyncSetupInput | undefined,
     authorizedSnapshot: VaultSnapshot,
   ): Promise<SyncAccess | undefined> {
-    if (vault.syncRemovalPending === true) {
+    if (vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(vaultId, "complete device enrollment");
     }
 

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -77,7 +77,7 @@ export class ApplySyncResolutionUseCase {
       throw new SyncNotConfiguredError(params.vaultId, "apply sync resolution");
     }
 
-    if (unlockedVault.vault.syncRemovalPending === true) {
+    if (unlockedVault.vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(
         params.vaultId,
         "apply sync resolution",
@@ -187,8 +187,10 @@ export class ApplySyncResolutionUseCase {
 
     if (
       !areJsonEqual(remoteVault.syncTarget, unlockedVault.vault.syncTarget) ||
-      remoteVault.syncRemovalPending !==
-        unlockedVault.vault.syncRemovalPending ||
+      !areJsonEqual(
+        remoteVault.syncRemovalPending,
+        unlockedVault.vault.syncRemovalPending,
+      ) ||
       (!areJsonEqual(
         remoteVault.providerCredentialRevocationPending,
         unlockedVault.vault.providerCredentialRevocationPending,

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -8,6 +8,7 @@ import type {
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import {
   ProviderCredentialRevocationPendingError,
+  RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotAheadError,
   RemoteVaultSnapshotIntegrityError,
 } from "../../errors/sync.errors";
@@ -67,12 +68,17 @@ function createContext() {
 describe("DisableSyncUseCase", () => {
   it("removes remote state, local target, and local credentials", async () => {
     const ctx = createContext();
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
 
     await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
     expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       ctx.values.vaultId,
+      expectedRemoteSnapshotDescriptor,
     );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
@@ -88,19 +94,174 @@ describe("DisableSyncUseCase", () => {
     );
   });
 
-  it("keeps the target and credentials when remote removal fails", async () => {
+  it("restores the exact pre-disable snapshot when the remote generation changed", async () => {
     const ctx = createContext();
-    vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mockRejectedValue(
-      new Error("remove failed"),
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
+    const remoteAheadDescriptor = {
+      ...expectedRemoteSnapshotDescriptor,
+      snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+    };
+    vi.mocked(ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor)
+      .mockResolvedValueOnce(expectedRemoteSnapshotDescriptor)
+      .mockResolvedValueOnce(remoteAheadDescriptor);
+    vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mockRejectedValueOnce(
+      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
-    ).rejects.toThrow("remove failed");
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
 
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
     ).toEqual(ctx.values.syncTarget);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toBeUndefined();
+    expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(
+      ctx.saved.unlockedVaultSession?.sourceSnapshotVersionVector,
+    ).toEqual(ctx.vaultSnapshot.metadata.snapshotVersionVector);
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotAheadError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).toHaveBeenCalledTimes(2);
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledOnce();
+  });
+
+  it("retains pending removal when a remote failure has an unknown outcome", async () => {
+    const ctx = createContext();
+    const removalError = new Error("remove failed");
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
+    vi.mocked(
+      ctx.ports.syncProvider.removeVaultSnapshots,
+    ).mockRejectedValueOnce(removalError);
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(removalError);
+
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toEqual({
+      expectedRemoteSnapshotDescriptor,
+      rollbackSnapshot: ctx.vaultSnapshot,
+    });
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+
+    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).toHaveBeenCalledOnce();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledTimes(2);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
+    ).toBeUndefined();
+  });
+
+  it("retains pending removal when exact snapshot restoration fails", async () => {
+    const ctx = createContext();
+    const restorationError = new Error("snapshot restoration failed");
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
+    const saveSnapshot = vi.mocked(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    );
+    const saveSnapshotImplementation = saveSnapshot.getMockImplementation();
+
+    if (saveSnapshotImplementation === undefined) {
+      throw new Error("Expected a snapshot persistence implementation.");
+    }
+
+    saveSnapshot
+      .mockImplementationOnce(saveSnapshotImplementation)
+      .mockRejectedValueOnce(restorationError);
+    vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots)
+      .mockRejectedValueOnce(new Error("remove outcome unknown"))
+      .mockRejectedValueOnce(
+        new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+      );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toThrow("remove outcome unknown");
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(restorationError);
+
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toEqual({
+      expectedRemoteSnapshotDescriptor,
+      rollbackSnapshot: ctx.vaultSnapshot,
+    });
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+  });
+
+  it("conditions removal on remote state remaining absent after preflight", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(null);
+
+    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
+      ctx.values.syncAccess,
+      ctx.values.vaultId,
+      null,
+    );
+  });
+
+  it("retains the pending transition when final local persistence fails", async () => {
+    const ctx = createContext();
+    const finalPersistError = new Error("final persistence failed");
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
+    vi.mocked(ctx.ports.crypto.encryptVaultSnapshotContent)
+      .mockResolvedValueOnce(ctx.values.encryptedVault)
+      .mockRejectedValueOnce(finalPersistError);
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(finalPersistError);
+
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
+      ctx.values.syncAccess,
+      ctx.values.vaultId,
+      expectedRemoteSnapshotDescriptor,
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
+    ).toEqual(ctx.values.syncTarget);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
+    ).toEqual({
+      expectedRemoteSnapshotDescriptor,
+      rollbackSnapshot: ctx.vaultSnapshot,
+    });
     expect(ctx.saved.deviceSyncCredentialState).toBe(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
@@ -170,6 +331,10 @@ describe("DisableSyncUseCase", () => {
   it("resumes remote cleanup without repeating the preflight", async () => {
     const ctx = createContext();
     const session = ctx.saved.unlockedVaultSession;
+    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
 
     if (session === undefined) {
       throw new Error("Expected an unlocked test session.");
@@ -181,7 +346,10 @@ describe("DisableSyncUseCase", () => {
         ...session.unlockedVault,
         vault: {
           ...session.unlockedVault.vault,
-          syncRemovalPending: true,
+          syncRemovalPending: {
+            expectedRemoteSnapshotDescriptor,
+            rollbackSnapshot: ctx.vaultSnapshot,
+          },
         },
       },
     };
@@ -191,7 +359,11 @@ describe("DisableSyncUseCase", () => {
     expect(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).not.toHaveBeenCalled();
-    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledOnce();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
+      ctx.values.syncAccess,
+      ctx.values.vaultId,
+      expectedRemoteSnapshotDescriptor,
+    );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
     ).toBeUndefined();

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -7,12 +7,14 @@ import {
   toVaultSnapshotDescriptor,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 import {
+  clearVaultSyncRemovalPending,
   markVaultSyncRemovalPending,
   removeVaultSyncTarget,
 } from "../../domain/vault/vault-sync-config.mutations";
 import { removeOtherDeviceProfilesFromVault } from "../../domain/vault/vault-device.mutations";
 import {
   RemoteVaultSnapshotAheadError,
+  RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
   SyncNotConfiguredError,
 } from "../../errors/sync.errors";
@@ -82,21 +84,25 @@ export class DisableSyncUseCase {
         currentSnapshotVersionVector,
       );
 
-    if (currentUnlockedVault.vault.syncRemovalPending !== true) {
-      const remoteSnapshotDescriptor =
+    let expectedRemoteSnapshotDescriptor =
+      currentUnlockedVault.vault.syncRemovalPending
+        ?.expectedRemoteSnapshotDescriptor;
+
+    if (expectedRemoteSnapshotDescriptor === undefined) {
+      expectedRemoteSnapshotDescriptor =
         await this.syncProvider.getLatestVaultSnapshotDescriptor(
           syncAccess,
           params.vaultId,
         );
 
-      if (remoteSnapshotDescriptor !== null) {
+      if (expectedRemoteSnapshotDescriptor !== null) {
         const localSnapshotDescriptor = toVaultSnapshotDescriptor(
           params.vaultId,
           currentSnapshot,
         );
         const relation = compareVaultSnapshotDescriptors(
           localSnapshotDescriptor,
-          remoteSnapshotDescriptor,
+          expectedRemoteSnapshotDescriptor,
         );
 
         if (relation === "remote_ahead") {
@@ -107,7 +113,7 @@ export class DisableSyncUseCase {
           relation === "broken" ||
           (relation === "equal" &&
             !areVaultSnapshotDescriptorsEqual(
-              remoteSnapshotDescriptor,
+              expectedRemoteSnapshotDescriptor,
               localSnapshotDescriptor,
             ))
         ) {
@@ -117,7 +123,11 @@ export class DisableSyncUseCase {
 
       const pendingUnlockedVault = {
         ...unlockedVault,
-        vault: markVaultSyncRemovalPending(unlockedVault.vault),
+        vault: markVaultSyncRemovalPending(
+          unlockedVault.vault,
+          expectedRemoteSnapshotDescriptor,
+          currentSnapshot,
+        ),
       };
       const pendingSnapshot =
         await this.unlockedVaultSession.persistForActiveSession(
@@ -145,7 +155,54 @@ export class DisableSyncUseCase {
       );
     }
 
-    await this.syncProvider.removeVaultSnapshots(syncAccess, params.vaultId);
+    try {
+      await this.syncProvider.removeVaultSnapshots(
+        syncAccess,
+        params.vaultId,
+        expectedRemoteSnapshotDescriptor,
+      );
+    } catch (error) {
+      if (!(error instanceof RemoteVaultSnapshotChangedError)) {
+        throw error;
+      }
+
+      const rollbackSnapshot =
+        currentUnlockedVault.vault.syncRemovalPending?.rollbackSnapshot;
+
+      if (rollbackSnapshot === undefined) {
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+      }
+
+      const rollbackSnapshotDigest =
+        await this.crypto.digestVaultSnapshot(rollbackSnapshot);
+      const rolledBackUnlockedVault = {
+        ...currentUnlockedVault,
+        vault: clearVaultSyncRemovalPending(currentUnlockedVault.vault),
+        trustedSnapshotContext: {
+          snapshotDigest: rollbackSnapshotDigest,
+          trust: currentUnlockedVault.trustedSnapshotContext.trust,
+        },
+      };
+
+      await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () =>
+          this.vaultSnapshot.restoreLocalVaultSnapshot(
+            rollbackSnapshot,
+            currentSnapshot,
+            currentUnlockedVault,
+          ),
+      );
+
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        rolledBackUnlockedVault,
+        rollbackSnapshot.metadata.snapshotVersionVector,
+      );
+
+      throw error;
+    }
 
     const revisionTimestamp = this.clock.now();
     const updatedVault = removeVaultSyncTarget(

--- a/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
@@ -270,7 +270,10 @@ describe("PrepareSyncReviewUseCase", () => {
 
     vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue({
       ...session.unlockedVault.vault,
-      syncRemovalPending: true,
+      syncRemovalPending: {
+        expectedRemoteSnapshotDescriptor: null,
+        rollbackSnapshot: ctx.vaultSnapshot,
+      },
     });
 
     await expect(

--- a/packages/core/src/use-cases/sync/prepare-sync-review.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.ts
@@ -87,7 +87,7 @@ export class PrepareSyncReviewUseCase {
       throw new SyncNotConfiguredError(params.vaultId, "prepare sync review");
     }
 
-    if (unlockedVault.vault.syncRemovalPending === true) {
+    if (unlockedVault.vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(params.vaultId, "prepare sync review");
     }
 
@@ -201,8 +201,10 @@ export class PrepareSyncReviewUseCase {
 
     if (
       !areJsonEqual(remoteVault.syncTarget, unlockedVault.vault.syncTarget) ||
-      remoteVault.syncRemovalPending !==
-        unlockedVault.vault.syncRemovalPending ||
+      !areJsonEqual(
+        remoteVault.syncRemovalPending,
+        unlockedVault.vault.syncRemovalPending,
+      ) ||
       (!areJsonEqual(
         remoteVault.providerCredentialRevocationPending,
         unlockedVault.vault.providerCredentialRevocationPending,

--- a/packages/core/src/use-cases/sync/sync-upload.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.ts
@@ -50,7 +50,7 @@ export class SyncUploadUseCase {
       throw new SyncNotConfiguredError(params.vaultId, "sync upload");
     }
 
-    if (unlockedVault.vault.syncRemovalPending === true) {
+    if (unlockedVault.vault.syncRemovalPending !== undefined) {
       throw new SyncRemovalPendingError(params.vaultId, "sync upload");
     }
 

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import {
   createVaultSnapshotServiceMock,
@@ -163,6 +164,8 @@ describe("AddEntryUseCase", () => {
   it("rejects local changes while sync removal is pending", async () => {
     const ctx = createContext();
     const session = ctx.saved.unlockedVaultSession!;
+    const rollbackSnapshot = createUnlockVaultTestContext().vaultSnapshot;
+
     ctx.saved.unlockedVaultSession = {
       ...session,
       unlockedVault: {
@@ -170,7 +173,10 @@ describe("AddEntryUseCase", () => {
         vault: {
           ...session.unlockedVault.vault,
           syncTarget: ctx.values.syncTarget,
-          syncRemovalPending: true,
+          syncRemovalPending: {
+            expectedRemoteSnapshotDescriptor: null,
+            rollbackSnapshot,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary

- Preserve the exact local snapshot while sync removal is pending.
- Guard remote cleanup with an expected snapshot descriptor.
- Restore local state safely when the remote snapshot changes.
- Expand pending-removal handling and regression coverage across sync and trust flows.

## Testing

- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync removal safety by detecting unexpected remote snapshot changes before deleting remote data.
  * Automatically restores local vault data when remote changes prevent removal, supporting safer recovery and resumable operations.
  * Prevented vault edits, uploads, reviews, and device enrollment while sync removal is pending.
  * Improved integrity checks for pending removal state and preserved sync targets when clearing pending status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->