### PR TITLE
test(core): enforce unique generated username words

### DIFF
--- a/packages/core/src/lib/generate-username/generated-username.const.ts
+++ b/packages/core/src/lib/generate-username/generated-username.const.ts
@@ -7752,7 +7752,6 @@ export const GENERATED_USERNAME_WORDS = [
   "yoga",
   "yogurt",
   "yonder",
-  "yoyo",
   "yummy",
   "zap",
   "zealous",

--- a/packages/core/src/use-cases/password-tools/generate-username.test.ts
+++ b/packages/core/src/use-cases/password-tools/generate-username.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
+import {
+  GENERATED_USERNAME_NUMBER_DIGITS,
+  GENERATED_USERNAME_WORD_COUNT,
+  GENERATED_USERNAME_WORDS,
+} from "../../lib/generate-username/generated-username.const";
 import { RandomSamplerService } from "../../services/randomness/random-sampler.service";
 import type { RandomBytes } from "../../domain/crypto/brand-keys";
 import { InvalidGeneratedUsernameSettingsError } from "../../errors/generate-username.errors";
@@ -27,18 +32,19 @@ function createContext(randomValues: number[] = []) {
       return randomBytesFromUint32(randomValues.shift() ?? 0);
     },
   );
+  const randomSampler = new RandomSamplerService(ports.crypto);
 
   return {
     ports,
-    useCase: new GenerateUsernameUseCase(
-      new RandomSamplerService(ports.crypto),
-    ),
+    randomSampler,
+    useCase: new GenerateUsernameUseCase(randomSampler),
   };
 }
 
 describe("GenerateUsernameUseCase", () => {
   it("generates a default username that fits password entry login storage", async () => {
     const ctx = createContext([0, 1, 2, 3, 4, 5]);
+    const pickIndexSpy = vi.spyOn(ctx.randomSampler, "pickIndex");
 
     const result = await ctx.useCase.execute();
 
@@ -47,11 +53,36 @@ describe("GenerateUsernameUseCase", () => {
     });
     expect(result.username.length).toBeLessThanOrEqual(128);
     expect(result.username).toMatch(/^[a-z0-9]+$/);
+    expect(pickIndexSpy).toHaveBeenNthCalledWith(
+      1,
+      GENERATED_USERNAME_WORDS.length,
+    );
+    expect(pickIndexSpy).toHaveBeenNthCalledWith(
+      2,
+      GENERATED_USERNAME_WORDS.length,
+    );
     expect(
       vi
         .mocked(ctx.ports.crypto.generateRandomBytes)
         .mock.calls.every(([byteLength]) => byteLength === 4),
     ).toBe(true);
+  });
+
+  it("keeps every normalized source word unique and within login storage", () => {
+    const normalizedWords = GENERATED_USERNAME_WORDS.map((word) =>
+      word.toLowerCase().replaceAll(/[^a-z0-9]/g, ""),
+    );
+    const maximumGeneratedUsernameLength =
+      Math.max(...normalizedWords.map((word) => word.length)) *
+        GENERATED_USERNAME_WORD_COUNT +
+      GENERATED_USERNAME_NUMBER_DIGITS;
+
+    expect(GENERATED_USERNAME_WORDS).toHaveLength(7_775);
+    expect(new Set(normalizedWords).size).toBe(normalizedWords.length);
+    expect(normalizedWords.every((word) => /^[a-z0-9]+$/.test(word))).toBe(
+      true,
+    );
+    expect(maximumGeneratedUsernameLength).toBeLessThanOrEqual(128);
   });
 
   it("can generate a capitalized username without a number suffix", async () => {

--- a/packages/core/src/use-cases/password-tools/generate-username.test.ts
+++ b/packages/core/src/use-cases/password-tools/generate-username.test.ts
@@ -3,9 +3,9 @@ import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import {
   GENERATED_USERNAME_NUMBER_DIGITS,
-  GENERATED_USERNAME_WORD_COUNT,
   GENERATED_USERNAME_WORDS,
 } from "../../lib/generate-username/generated-username.const";
+import { generateUsernameValue } from "../../lib/generate-username/generated-username.utils";
 import { RandomSamplerService } from "../../services/randomness/random-sampler.service";
 import type { RandomBytes } from "../../domain/crypto/brand-keys";
 import { InvalidGeneratedUsernameSettingsError } from "../../errors/generate-username.errors";
@@ -68,21 +68,25 @@ describe("GenerateUsernameUseCase", () => {
     ).toBe(true);
   });
 
-  it("keeps every normalized source word unique and within login storage", () => {
-    const normalizedWords = GENERATED_USERNAME_WORDS.map((word) =>
-      word.toLowerCase().replaceAll(/[^a-z0-9]/g, ""),
+  it("keeps every normalized source word unique and within login storage", async () => {
+    const generatedUsernames = await Promise.all(
+      GENERATED_USERNAME_WORDS.map((_, wordIndex) =>
+        generateUsernameValue(
+          { capitalize: false, includeNumber: false },
+          async () => wordIndex,
+        ),
+      ),
     );
-    const maximumGeneratedUsernameLength =
-      Math.max(...normalizedWords.map((word) => word.length)) *
-        GENERATED_USERNAME_WORD_COUNT +
-      GENERATED_USERNAME_NUMBER_DIGITS;
 
     expect(GENERATED_USERNAME_WORDS).toHaveLength(7_775);
-    expect(new Set(normalizedWords).size).toBe(normalizedWords.length);
-    expect(normalizedWords.every((word) => /^[a-z0-9]+$/.test(word))).toBe(
-      true,
-    );
-    expect(maximumGeneratedUsernameLength).toBeLessThanOrEqual(128);
+    expect(new Set(generatedUsernames).size).toBe(generatedUsernames.length);
+    expect(
+      generatedUsernames.every((username) => /^[a-z0-9]+$/.test(username)),
+    ).toBe(true);
+    expect(
+      Math.max(...generatedUsernames.map((username) => username.length)) +
+        GENERATED_USERNAME_NUMBER_DIGITS,
+    ).toBeLessThanOrEqual(128);
   });
 
   it("can generate a capitalized username without a number suffix", async () => {


### PR DESCRIPTION
## Summary
- Remove the duplicate normalized username word `yoyo`.
- Add coverage for unique, normalized username words within login storage limits.
- Verify default generation samples from the configured word list.

## Testing
- Added Vitest coverage for username word uniqueness, normalization, length limits, and sampling bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a previously available word from generated username suggestions.
  * Preserved the remaining username word options and generation behavior.

* **Tests**
  * Expanded coverage for username uniqueness, allowed characters, length limits, numeric suffixes, word-list boundaries, and random selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->