### PR TITLE
fix(core): mark type-only imports explicitly

### DIFF
--- a/packages/core/src/domain/entry/password-entry.type.ts
+++ b/packages/core/src/domain/entry/password-entry.type.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { VersionVector } from "../versioning/version-vector.type";
-import { passwordEntryInputSchema } from "./password-entry.schema";
+import type { passwordEntryInputSchema } from "./password-entry.schema";
 
 export type PasswordEntryInput = z.infer<typeof passwordEntryInputSchema>;
 

--- a/packages/core/src/domain/entry/search-entry-query.type.ts
+++ b/packages/core/src/domain/entry/search-entry-query.type.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import {
+import type { z } from "zod";
+import type {
   searchEntryAnyQuerySchema,
   searchEntryFieldsQuerySchema,
   searchEntryQuerySchema,

--- a/packages/core/src/domain/entry/tag.type.ts
+++ b/packages/core/src/domain/entry/tag.type.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { VersionVector } from "../versioning/version-vector.type";
-import { tagSchema } from "./tag.schema";
+import type { tagSchema } from "./tag.schema";
 
 export type TagInput = z.infer<typeof tagSchema>;
 

--- a/packages/core/src/domain/scheduled-task/scheduled-task-delay.type.ts
+++ b/packages/core/src/domain/scheduled-task/scheduled-task-delay.type.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import {
+import type { z } from "zod";
+import type {
   clipboardClearDelayMsSchema,
   vaultLockDelayMsSchema,
 } from "./scheduled-task-delay.schema";

--- a/packages/core/src/errors/generate-password.errors.ts
+++ b/packages/core/src/errors/generate-password.errors.ts
@@ -1,4 +1,4 @@
-import { ZodError } from "zod";
+import type { ZodError } from "zod";
 
 export class InvalidGeneratedPasswordSettingsError extends Error {
   constructor(cause: ZodError) {

--- a/packages/core/src/errors/generate-username.errors.ts
+++ b/packages/core/src/errors/generate-username.errors.ts
@@ -1,4 +1,4 @@
-import { ZodError } from "zod";
+import type { ZodError } from "zod";
 
 export class InvalidGeneratedUsernameSettingsError extends Error {
   constructor(cause: ZodError) {

--- a/packages/core/src/lib/generate-password/generated-password.type.ts
+++ b/packages/core/src/lib/generate-password/generated-password.type.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import { generatedPasswordSettingsSchema } from "./generated-password.schema";
+import type { generatedPasswordSettingsSchema } from "./generated-password.schema";
 
 export type GeneratedPasswordSettings = z.infer<
   typeof generatedPasswordSettingsSchema

--- a/packages/core/src/lib/generate-username/generated-username.type.ts
+++ b/packages/core/src/lib/generate-username/generated-username.type.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import { generatedUsernameSettingsSchema } from "./generated-username.schema";
+import type { z } from "zod";
+import type { generatedUsernameSettingsSchema } from "./generated-username.schema";
 
 export type GeneratedUsernameSettings = z.infer<
   typeof generatedUsernameSettingsSchema


### PR DESCRIPTION
## Summary

- Mark Zod types and schema references as type-only imports across core type definitions and generator errors.
- Prevent unnecessary runtime imports while satisfying TypeScript module rules.

## Testing

- Not run.