### PR TITLE
fix(core): redact sensitive entry URLs from errors

### DIFF
--- a/packages/core/src/__tests__/fixtures/error-inspection.ts
+++ b/packages/core/src/__tests__/fixtures/error-inspection.ts
@@ -1,0 +1,41 @@
+export function objectGraphContainsString(
+  value: unknown,
+  substring: string,
+): boolean {
+  const visited = new Set<object>();
+
+  function visit(current: unknown): boolean {
+    if (typeof current === "string") {
+      return current.includes(substring);
+    }
+
+    if (
+      current === null ||
+      (typeof current !== "object" && typeof current !== "function")
+    ) {
+      return false;
+    }
+
+    if (visited.has(current)) {
+      return false;
+    }
+
+    visited.add(current);
+
+    return Reflect.ownKeys(current).some((propertyKey) => {
+      if (String(propertyKey).includes(substring)) {
+        return true;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(current, propertyKey);
+
+      return (
+        descriptor !== undefined &&
+        "value" in descriptor &&
+        visit(descriptor.value)
+      );
+    });
+  }
+
+  return visit(value);
+}

--- a/packages/core/src/domain/entry/sanitized-entry-url.utils.test.ts
+++ b/packages/core/src/domain/entry/sanitized-entry-url.utils.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { UnsupportedEntryUrlProtocolError } from "../../errors/vault-entry.errors";
+import { objectGraphContainsString } from "../../__tests__/fixtures/error-inspection";
+import {
+  InvalidEntryUrlError,
+  UnsupportedEntryUrlProtocolError,
+} from "../../errors/vault-entry.errors";
 import { sanitizeEntryUrl } from "./sanitized-entry-url.utils";
 
+function captureError(action: () => void): unknown {
+  try {
+    action();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("Expected action to throw.");
+}
+
 describe("sanitizeEntryUrl", () => {
-  it("removes query string and hash from entry urls", () => {
+  it("removes credentials, query string, and hash from entry urls", () => {
     expect(
       sanitizeEntryUrl(
-        "https://example.com/login?session=secret&utm_source=test#section",
+        "https://user:password@example.com/login?session=secret&utm_source=test#section",
       ),
     ).toBe("https://example.com/login");
   });
@@ -17,10 +31,16 @@ describe("sanitizeEntryUrl", () => {
     );
   });
 
-  it("removes credentials from entry urls", () => {
-    expect(
-      sanitizeEntryUrl("https://user:password@example.com/accounts/login"),
-    ).toBe("https://example.com/accounts/login");
+  it("redacts malformed entry urls from parse errors", () => {
+    const credentialSecret = "credential-secret";
+    const querySecret = "query-secret";
+    const malformedUrl = `https://user:${credentialSecret}@?token=${querySecret}`;
+
+    const error = captureError(() => sanitizeEntryUrl(malformedUrl));
+
+    expect(error).toBeInstanceOf(InvalidEntryUrlError);
+    expect(objectGraphContainsString(error, credentialSecret)).toBe(false);
+    expect(objectGraphContainsString(error, querySecret)).toBe(false);
   });
 
   it("rejects javascript entry urls", () => {
@@ -35,5 +55,23 @@ describe("sanitizeEntryUrl", () => {
 
     expect(action).toThrow(UnsupportedEntryUrlProtocolError);
     expect(action).toThrow('Unsupported entry URL protocol "data:".');
+  });
+
+  it("reports only the protocol for unsupported ftp entry urls", () => {
+    const credentialSecret = "credential-secret";
+    const querySecret = "query-secret";
+    const fragmentSecret = "fragment-secret";
+    const unsupportedUrl = `ftp://user:${credentialSecret}@example.com/path?token=${querySecret}#${fragmentSecret}`;
+
+    const error = captureError(() => sanitizeEntryUrl(unsupportedUrl));
+
+    expect(error).toBeInstanceOf(UnsupportedEntryUrlProtocolError);
+    expect(error).toHaveProperty(
+      "message",
+      'Unsupported entry URL protocol "ftp:".',
+    );
+    expect(objectGraphContainsString(error, credentialSecret)).toBe(false);
+    expect(objectGraphContainsString(error, querySecret)).toBe(false);
+    expect(objectGraphContainsString(error, fragmentSecret)).toBe(false);
   });
 });

--- a/packages/core/src/domain/entry/sanitized-entry-url.utils.ts
+++ b/packages/core/src/domain/entry/sanitized-entry-url.utils.ts
@@ -1,9 +1,18 @@
-import { UnsupportedEntryUrlProtocolError } from "../../errors/vault-entry.errors";
+import {
+  InvalidEntryUrlError,
+  UnsupportedEntryUrlProtocolError,
+} from "../../errors/vault-entry.errors";
 
 const ALLOWED_ENTRY_URL_PROTOCOLS = new Set(["http:", "https:"]);
 
 export function sanitizeEntryUrl(rawUrl: string): string {
-  const parsedUrl = new URL(rawUrl);
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    throw new InvalidEntryUrlError();
+  }
 
   if (!ALLOWED_ENTRY_URL_PROTOCOLS.has(parsedUrl.protocol)) {
     throw new UnsupportedEntryUrlProtocolError(parsedUrl.protocol);

--- a/packages/core/src/errors/vault-entry.errors.ts
+++ b/packages/core/src/errors/vault-entry.errors.ts
@@ -23,6 +23,13 @@ export class InvalidSearchEntryQueryError extends Error {
   }
 }
 
+export class InvalidEntryUrlError extends Error {
+  constructor() {
+    super("Entry URL is invalid.");
+    this.name = "InvalidEntryUrlError";
+  }
+}
+
 export class UnsupportedEntryUrlProtocolError extends Error {
   constructor(protocol: string) {
     super(`Unsupported entry URL protocol "${protocol}".`);

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { objectGraphContainsString } from "../../__tests__/fixtures/error-inspection";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
@@ -13,7 +14,10 @@ import {
   SyncRemovalPendingError,
   SyncConflictDetectedError,
 } from "../../errors/sync.errors";
-import { InvalidPasswordEntryError } from "../../errors/vault-entry.errors";
+import {
+  InvalidEntryUrlError,
+  InvalidPasswordEntryError,
+} from "../../errors/vault-entry.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
 import { VaultSyncGuardService } from "../../services/sync";
 import { AddEntryUseCase } from "./add-entry";
@@ -154,6 +158,42 @@ describe("AddEntryUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(InvalidPasswordEntryError);
 
+    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("does not retain a malformed entry url in the public validation error", async () => {
+    const ctx = createContext();
+    const credentialSecret = "credential-secret";
+    const querySecret = "query-secret";
+    let caught: unknown;
+
+    try {
+      await ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: "secret-password",
+          login: "user@example.com",
+          tags: [],
+          url: `https://user:${credentialSecret}@?token=${querySecret}`,
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(InvalidPasswordEntryError);
+
+    if (!(caught instanceof InvalidPasswordEntryError)) {
+      return;
+    }
+
+    expect(caught.cause).toBeInstanceOf(InvalidEntryUrlError);
+    expect(objectGraphContainsString(caught, credentialSecret)).toBe(false);
+    expect(objectGraphContainsString(caught, querySecret)).toBe(false);
     expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { objectGraphContainsString } from "../../__tests__/fixtures/error-inspection";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import {
@@ -9,6 +10,7 @@ import {
   standardPasswordEntries,
 } from "../../__tests__/fixtures/vault-entries";
 import {
+  InvalidEntryUrlError,
   InvalidPasswordEntryError,
   PasswordEntryNotFoundError,
 } from "../../errors/vault-entry.errors";
@@ -183,6 +185,42 @@ describe("UpdateEntryUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(InvalidPasswordEntryError);
 
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("does not retain a malformed entry url in the public validation error", async () => {
+    const ctx = createContext();
+    const credentialSecret = "credential-secret";
+    const querySecret = "query-secret";
+    let caught: unknown;
+
+    try {
+      await ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entryId: firstPasswordEntry.id,
+        entry: {
+          password: "updated-password",
+          login: "updated@example.com",
+          tags: [],
+          url: `https://user:${credentialSecret}@?token=${querySecret}`,
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(InvalidPasswordEntryError);
+
+    if (!(caught instanceof InvalidPasswordEntryError)) {
+      return;
+    }
+
+    expect(caught.cause).toBeInstanceOf(InvalidEntryUrlError);
+    expect(objectGraphContainsString(caught, credentialSecret)).toBe(false);
+    expect(objectGraphContainsString(caught, querySecret)).toBe(false);
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Sanitize malformed entry URL errors without retaining credentials, query strings, or fragments.
- Limit unsupported-protocol errors to the protocol name.
- Add regression coverage for URL sanitization and add/update entry validation.

## Testing

- Not run.