### PR TITLE
fix(core): expose services for extension composition

### DIFF
--- a/apps/extension/config/vite.config.ts
+++ b/apps/extension/config/vite.config.ts
@@ -81,8 +81,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "..", "src"),
-      "@lfspm/core": resolve(coreSourceRoot, "index.ts"),
-      "@lfspm/core/": `${coreSourceRoot}/`,
+      "@lfspm/core": coreSourceRoot,
     },
   },
   optimizeDeps: {

--- a/apps/extension/src/core-composition-api.typecheck.ts
+++ b/apps/extension/src/core-composition-api.typecheck.ts
@@ -1,0 +1,102 @@
+import {
+  AddEntryUseCase,
+  CopyEntryPasswordUseCase,
+  InitializeVaultUseCase,
+  SyncUploadUseCase,
+} from "@lfspm/core";
+import type {
+  Bip39Port,
+  ClipboardClearTaskRepositoryPort,
+  ClipboardPort,
+  ClockPort,
+  CryptoPort,
+  EncryptedUnlockedVaultSessionPayloadRepositoryPort,
+  IdPort,
+  ScheduledTaskPort,
+  SyncProviderPort,
+  UnlockedVaultSessionMaterialRepositoryPort,
+  VaultDisplayNamePort,
+  VaultLocalRepositoryPort,
+} from "@lfspm/core";
+import {
+  ClipboardClearService,
+  UnlockedVaultSessionService,
+  VaultSnapshotService,
+  VaultSyncGuardService,
+} from "@lfspm/core/services";
+
+type CoreCompositionPorts = {
+  readonly bip39: Bip39Port;
+  readonly clipboard: ClipboardPort;
+  readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
+  readonly clock: ClockPort;
+  readonly crypto: CryptoPort;
+  readonly encryptedSessionPayloads: EncryptedUnlockedVaultSessionPayloadRepositoryPort;
+  readonly ids: IdPort;
+  readonly scheduledTasks: ScheduledTaskPort;
+  readonly sessionMaterials: UnlockedVaultSessionMaterialRepositoryPort;
+  readonly syncProvider: SyncProviderPort;
+  readonly vaultDisplayName: VaultDisplayNamePort;
+  readonly vaults: VaultLocalRepositoryPort;
+};
+
+export function composeCoreApi(ports: CoreCompositionPorts) {
+  const unlockedVaultSession = new UnlockedVaultSessionService(
+    ports.sessionMaterials,
+    ports.encryptedSessionPayloads,
+    ports.crypto,
+    ports.ids,
+  );
+  const vaultSnapshot = new VaultSnapshotService(
+    ports.crypto,
+    ports.clock,
+    ports.vaults,
+  );
+  const vaultSyncGuard = new VaultSyncGuardService(
+    ports.syncProvider,
+    vaultSnapshot,
+    unlockedVaultSession,
+    ports.crypto,
+    ports.vaults,
+  );
+  const clipboardClear = new ClipboardClearService(
+    ports.clipboard,
+    ports.clipboardClearTasks,
+    ports.clock,
+    ports.crypto,
+  );
+
+  return {
+    vaultLifecycle: new InitializeVaultUseCase(
+      ports.crypto,
+      ports.bip39,
+      ports.vaults,
+      unlockedVaultSession,
+      ports.ids,
+      ports.clock,
+      ports.vaultDisplayName,
+    ),
+    vaultEntry: new AddEntryUseCase(
+      ports.ids,
+      unlockedVaultSession,
+      vaultSyncGuard,
+      vaultSnapshot,
+    ),
+    clipboard: new CopyEntryPasswordUseCase(
+      ports.clipboard,
+      clipboardClear,
+      ports.crypto,
+      ports.ids,
+      ports.clipboardClearTasks,
+      ports.scheduledTasks,
+      ports.clock,
+      unlockedVaultSession,
+    ),
+    sync: new SyncUploadUseCase(
+      ports.syncProvider,
+      unlockedVaultSession,
+      vaultSnapshot,
+      vaultSyncGuard,
+    ),
+  };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./lib": "./src/lib/index.ts"
+    "./lib": "./src/lib/index.ts",
+    "./services": "./src/services/index.ts"
   },
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
## Summary

- Expose core services through the `@lfspm/core/services` package export.
- Simplify the extension's core alias configuration.
- Add a compile-time composition API check for extension consumers.

## Testing

- Not run.