### PR TITLE
test(core): verify uploads use persisted snapshots

### DIFF
--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -53,6 +53,60 @@ export type SavedCoreRecords = {
 
 export type CoreTestPorts = ReturnType<typeof createCoreTestPorts>;
 
+function requirePersistedSnapshot(
+  snapshot: VaultSnapshot | undefined,
+): VaultSnapshot {
+  if (snapshot === undefined) {
+    throw new Error("Expected the workflow to persist a vault snapshot.");
+  }
+
+  return snapshot;
+}
+
+export function replaceVaultSnapshotAfterNextSave(
+  ports: CoreTestPorts,
+  replacement: VaultSnapshot,
+): () => VaultSnapshot {
+  const save = vi.mocked(
+    ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+  );
+  const saveImplementation = save.getMockImplementation();
+  let persistedSnapshot: VaultSnapshot | undefined;
+
+  if (saveImplementation === undefined) {
+    throw new Error("Expected the local snapshot save fixture implementation.");
+  }
+
+  save.mockImplementationOnce(async (params) => {
+    await saveImplementation(params);
+    persistedSnapshot = params.snapshot;
+    ports.saved.vaultSnapshot = replacement;
+  });
+
+  return () => requirePersistedSnapshot(persistedSnapshot);
+}
+
+export function replaceVaultSnapshotAfterNextInitializedSave(
+  ports: CoreTestPorts,
+  replacement: VaultSnapshot,
+): () => VaultSnapshot {
+  const save = vi.mocked(ports.vaultLocalRepository.saveInitializedLocalVault);
+  const saveImplementation = save.getMockImplementation();
+  let persistedSnapshot: VaultSnapshot | undefined;
+
+  if (saveImplementation === undefined) {
+    throw new Error("Expected the initialized vault save fixture implementation.");
+  }
+
+  save.mockImplementationOnce(async (params) => {
+    await saveImplementation(params);
+    persistedSnapshot = params.snapshot;
+    ports.saved.vaultSnapshot = replacement;
+  });
+
+  return () => requirePersistedSnapshot(persistedSnapshot);
+}
+
 export function createCoreTestPorts(
   values: CoreTestValues = createCoreTestValues(),
 ) {

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import {
+  createCoreTestPorts,
+  replaceVaultSnapshotAfterNextSave,
+} from "../../__tests__/fixtures/ports";
 import {
   createCoreTestValues,
   type CoreTestValues,
@@ -662,6 +665,43 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
 });
 
 describe("ConsumeDeviceRevocationUseCase", () => {
+  it("uploads the signed consumption even when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const remoteVault = {
+      ...ctx.remoteVault,
+      tags: [
+        {
+          id: 1,
+          name: "Remote tag",
+          versionVector: { [ctx.values.deviceId]: 3 },
+        },
+      ],
+    };
+    vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue(
+      remoteVault,
+    );
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      ctx.localSnapshot,
+    );
+
+    await ctx.useCase.execute({
+      ...createCommand(ctx),
+      resolution: {
+        entryResolutions: [],
+        tagResolutions: [{ tagId: 1, action: "use_remote" }],
+        deviceProfileResolutions: [],
+      },
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
+    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.localSnapshot);
+  });
+
   it("opens the survivor envelope and commits the rotated snapshot", async () => {
     const ctx = createContext();
     const survivorSlot = ctx.remoteSnapshot.keySlots.deviceSlots[0];

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
+import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import type {
   DevicePublicSignKey,
@@ -47,6 +48,49 @@ function createContext() {
 }
 
 describe("InitializeDeviceEnrollmentUseCase", () => {
+  it("uploads the signed snapshot even when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession;
+
+    if (session === undefined) {
+      throw new Error("Expected an unlocked test session.");
+    }
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    ctx.saved.deviceSyncCredentialState =
+      ctx.values.encryptedDeviceSyncCredentialState;
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+    );
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      ctx.vaultSnapshot,
+    );
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      request: ctx.values.enrollmentRequest,
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
+    expect(ctx.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
+  });
+
   it("authorizes a signed public request and creates a normal target envelope", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import {
+  createCoreTestPorts,
+  replaceVaultSnapshotAfterNextInitializedSave,
+} from "../../__tests__/fixtures/ports";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import { singlePasswordEntry } from "../../__tests__/fixtures/vault-entries";
@@ -121,6 +124,28 @@ function createContext(synced = false) {
 }
 
 describe("PerformDeviceEnrollmentUseCase", () => {
+  it("uploads the signed enrollment even when local storage replaces it after save", async () => {
+    const ctx = createContext(true);
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextInitializedSave(
+      ctx.ports,
+      ctx.response.snapshot,
+    );
+
+    await ctx.useCase.execute({
+      enrollmentResponse: ctx.response,
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "New laptop",
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
+    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.response.snapshot);
+  });
+
   it("uses retained target keys and removes pending state only after completion", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import {
+  createCoreTestPorts,
+  replaceVaultSnapshotAfterNextSave,
+} from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import { singlePasswordEntry } from "../../__tests__/fixtures/vault-entries";
 import type {
@@ -160,6 +163,27 @@ function createContext() {
 }
 
 describe("RevokeDeviceUseCase", () => {
+  it("uploads the signed revocation even when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      ctx.snapshot,
+    );
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      deviceId: ctx.values.pendingDeviceId,
+      replacementSyncConfig: ctx.values.replacementSyncConfigInput,
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
+    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.snapshot);
+  });
+
   it("rotates the vault key and creates envelopes only for survivors", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
+import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
 import {
   createUnlockedVaultWithEntries,
   singlePasswordEntry,
@@ -94,6 +95,36 @@ function createContext() {
 }
 
 describe("ApplySyncResolutionUseCase", () => {
+  it("uploads the signed resolution even when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      ctx.vaultSnapshot,
+    );
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      reviewedSnapshotDescriptors: {
+        local: ctx.localDescriptor,
+        remote: ctx.remoteDescriptor,
+      },
+      resolution: {
+        entryResolutions: [
+          { entryId: singlePasswordEntry.id, action: "use_remote" },
+        ],
+        tagResolutions: [],
+        deviceProfileResolutions: [],
+      },
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
+    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
+  });
+
   it("applies ordinary content resolution with local credentials", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
+++ b/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
+import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import { InvalidDeviceRevocationTransitionError } from "../../errors/device-revocation.errors";
@@ -94,6 +95,29 @@ function createContext() {
 }
 
 describe("CompleteProviderCredentialRevocationUseCase", () => {
+  it("uploads the signed completion even when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const replacedSnapshot = ctx.saved.vaultSnapshot;
+
+    if (replacedSnapshot === undefined) {
+      throw new Error("Expected an existing local snapshot.");
+    }
+
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      replacedSnapshot,
+    );
+
+    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
+    expect(ctx.saved.vaultSnapshot).toBe(replacedSnapshot);
+  });
+
   it("removes previous credentials only after provider authentication rejects them", async () => {
     const ctx = createContext();
 

--- a/packages/core/src/use-cases/sync/setup-sync.test.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
+import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import {
   InvalidSyncConfigError,
@@ -42,6 +43,26 @@ function createContext() {
 }
 
 describe("SetupSyncUseCase", () => {
+  it("uploads the signed initial-sync snapshot when local storage replaces it after save", async () => {
+    const ctx = createContext();
+    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
+      ctx.ports,
+      ctx.vaultSnapshot,
+    );
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    const uploadedSnapshot = vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mock.calls[0]?.[1];
+    expect(uploadedSnapshot).toBe(getPersistedSnapshot());
+    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
+    expect(ctx.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
+  });
+
   it("stores only the target in the vault and encrypts credentials locally", async () => {
     const ctx = createContext();
 


### PR DESCRIPTION
## Summary

- Add fixture helpers that capture snapshots persisted before local replacement.
- Cover device trust and sync workflows to ensure uploads use the saved snapshot.
- Verify uploaded snapshots differ from subsequently replaced local state.

## Testing

- Not run (change request content generated from the provided diff).