### PR TITLE
test(core): cover trust chain integrity boundaries

### DIFF
--- a/packages/core/src/__tests__/fixtures/device-trust.ts
+++ b/packages/core/src/__tests__/fixtures/device-trust.ts
@@ -1,0 +1,38 @@
+import type { VaultTrustCertificate } from "../../domain/device-trust/vault-trust";
+import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
+
+export function createDivergedTrustBaselineFixture(params: {
+  readonly remoteSnapshot: VaultSnapshot;
+  readonly remotePrefix: readonly VaultTrustCertificate[];
+  readonly localBaseline: VaultTrustCertificate;
+  readonly remoteTransition: VaultTrustCertificate;
+  readonly replacementSignature: VaultTrustCertificate["signature"];
+}) {
+  const divergedBaseline = {
+    ...params.localBaseline,
+    signature: params.replacementSignature,
+  };
+  const divergedBaselineDigest = "diverged-trust-baseline-digest";
+  const forgedRemoteSnapshot = {
+    ...params.remoteSnapshot,
+    trustChain: {
+      certificates: [
+        ...params.remotePrefix,
+        divergedBaseline,
+        {
+          ...params.remoteTransition,
+          payload: {
+            ...params.remoteTransition.payload,
+            previousCertificateDigest: divergedBaselineDigest,
+          },
+        },
+      ],
+    },
+  };
+
+  return {
+    divergedBaseline,
+    divergedBaselineDigest,
+    forgedRemoteSnapshot,
+  };
+}

--- a/packages/core/src/services/trust/vault-trust.service.test.ts
+++ b/packages/core/src/services/trust/vault-trust.service.test.ts
@@ -3,10 +3,14 @@ import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import type {
   DevicePublicSignKey,
+  DeviceTrustIdentity,
   DeviceVaultPublicKey,
 } from "../../domain/device-trust";
 import type { VaultSnapshot } from "../../domain/snapshot";
-import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
+import {
+  VaultSnapshotRollbackDetectedError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
 import { VaultTrustService } from "./vault-trust.service";
 
 function createContext() {
@@ -145,6 +149,237 @@ describe("VaultTrustService", () => {
         ctx.values.devicePrivateSignKey,
       ),
     ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+  });
+
+  it("rejects removed or mutated certificates in the trusted prefix", async () => {
+    const ctx = createContext();
+    const targetIdentity = {
+      deviceId: ctx.values.pendingDeviceId,
+      publicSignKey: ctx.values.pendingDevicePublicSignKey,
+      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+    };
+    const enrollment = await ctx.service.appendTrustTransition(
+      ctx.values.vaultId,
+      ctx.values.vaultTrustChain,
+      ctx.values.verifiedVaultTrustState,
+      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
+      1,
+      ctx.values.deviceId,
+      ctx.values.devicePrivateSignKey,
+    );
+    const trustedCertificate = enrollment.chain.certificates[1];
+
+    if (trustedCertificate === undefined) {
+      throw new Error("Expected an appended trust certificate.");
+    }
+
+    const mutatedCertificate = {
+      ...trustedCertificate,
+      signature: ctx.values.enrollmentRequestSignature,
+    };
+    vi.mocked(
+      ctx.ports.crypto.digestVaultTrustCertificate,
+    ).mockImplementation(async (certificate) =>
+      certificate === mutatedCertificate
+        ? "mutated-trust-certificate-digest"
+        : ctx.values.vaultTrustCertificateDigest,
+    );
+
+    await expect(
+      ctx.service.requireTrustDescendsFrom(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustChain,
+        enrollment.trust,
+        enrollment.trust,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+    await expect(
+      ctx.service.requireTrustDescendsFrom(
+        ctx.values.vaultId,
+        {
+          certificates: [
+            ...ctx.values.vaultTrustChain.certificates,
+            mutatedCertificate,
+          ],
+        },
+        enrollment.trust,
+        enrollment.trust,
+      ),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+  });
+
+  it("rejects disconnected or unauthorized trust certificates", async () => {
+    const ctx = createContext();
+    const targetIdentity = {
+      deviceId: ctx.values.pendingDeviceId,
+      publicSignKey: ctx.values.pendingDevicePublicSignKey,
+      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+    };
+    const enrollment = await ctx.service.appendTrustTransition(
+      ctx.values.vaultId,
+      ctx.values.vaultTrustChain,
+      ctx.values.verifiedVaultTrustState,
+      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
+      1,
+      ctx.values.deviceId,
+      ctx.values.devicePrivateSignKey,
+    );
+    const certificate = enrollment.chain.certificates[1];
+
+    if (certificate === undefined) {
+      throw new Error("Expected an appended trust certificate.");
+    }
+
+    await expect(
+      ctx.service.verifyTrustChain(ctx.values.vaultId, ctx.values.vaultTrustAnchor, {
+        certificates: [
+          ...ctx.values.vaultTrustChain.certificates,
+          {
+            ...certificate,
+            payload: {
+              ...certificate.payload,
+              previousCertificateDigest: "disconnected-certificate-digest",
+            },
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+    await expect(
+      ctx.service.verifyTrustChain(ctx.values.vaultId, ctx.values.vaultTrustAnchor, {
+        certificates: [
+          ...ctx.values.vaultTrustChain.certificates,
+          {
+            ...certificate,
+            payload: {
+              ...certificate.payload,
+              generation: certificate.payload.generation + 1,
+            },
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+    await expect(
+      ctx.service.verifyTrustChain(ctx.values.vaultId, ctx.values.vaultTrustAnchor, {
+        certificates: [
+          ...ctx.values.vaultTrustChain.certificates,
+          {
+            ...certificate,
+            payload: {
+              ...certificate.payload,
+              authorizedByDeviceId: "untrusted-authorizer",
+            },
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    vi.mocked(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).mockReset().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await expect(
+      ctx.service.verifyTrustChain(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustAnchor,
+        enrollment.chain,
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+  });
+
+  it("rejects a certificate signed by a trusted device other than its declared authorizer", async () => {
+    const ctx = createContext();
+    const targetIdentity = {
+      deviceId: ctx.values.pendingDeviceId,
+      publicSignKey: ctx.values.pendingDevicePublicSignKey,
+      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+    };
+    const enrollment = await ctx.service.appendTrustTransition(
+      ctx.values.vaultId,
+      ctx.values.vaultTrustChain,
+      ctx.values.verifiedVaultTrustState,
+      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
+      1,
+      ctx.values.deviceId,
+      ctx.values.devicePrivateSignKey,
+    );
+    const revocation = await ctx.service.appendTrustTransition(
+      ctx.values.vaultId,
+      enrollment.chain,
+      enrollment.trust,
+      [targetIdentity],
+      2,
+      targetIdentity.deviceId,
+      ctx.values.pendingDevicePrivateSignKey,
+    );
+    const revocationCertificate = revocation.chain.certificates[2];
+
+    if (revocationCertificate === undefined) {
+      throw new Error("Expected an appended revocation certificate.");
+    }
+
+    const certificateSignedByAnotherDevice = {
+      ...revocationCertificate,
+      signature: ctx.values.enrollmentRequestSignature,
+    };
+    vi.mocked(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).mockImplementation(async (certificate, publicKey) =>
+      certificate === certificateSignedByAnotherDevice
+        ? publicKey === ctx.values.devicePublicSignKey
+        : true,
+    );
+
+    await expect(
+      ctx.service.verifyTrustChain(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustAnchor,
+        {
+          certificates: [
+            ...revocation.chain.certificates.slice(0, -1),
+            certificateSignedByAnotherDevice,
+          ],
+        },
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(
+      ctx.ports.crypto.verifyVaultTrustCertificateSignature,
+    ).toHaveBeenCalledWith(
+      certificateSignedByAnotherDevice,
+      targetIdentity.publicSignKey,
+    );
+  });
+
+  it("rejects appending a transition with another device's private signing key", async () => {
+    const ctx = createContext();
+    const targetIdentity = {
+      deviceId: ctx.values.pendingDeviceId,
+      publicSignKey: ctx.values.pendingDevicePublicSignKey,
+      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+    };
+    vi.mocked(ctx.ports.crypto.verifyDeviceSignKeyPair).mockImplementation(
+      async (publicKey, privateKey) =>
+        publicKey === ctx.values.devicePublicSignKey &&
+        privateKey === ctx.values.devicePrivateSignKey,
+    );
+
+    await expect(
+      ctx.service.appendTrustTransition(
+        ctx.values.vaultId,
+        ctx.values.vaultTrustChain,
+        ctx.values.verifiedVaultTrustState,
+        [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
+        1,
+        ctx.values.deviceId,
+        ctx.values.pendingDevicePrivateSignKey,
+      ),
+    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+
+    expect(ctx.ports.crypto.verifyDeviceSignKeyPair).toHaveBeenCalledWith(
+      ctx.values.devicePublicSignKey,
+      ctx.values.pendingDevicePrivateSignKey,
+    );
+    expect(ctx.ports.crypto.signVaultTrustCertificate).not.toHaveBeenCalled();
   });
 
   it("validates multiple consecutive revocations after an offline baseline", async () => {
@@ -356,11 +591,38 @@ describe("VaultTrustService", () => {
 
   it("rejects re-enrollment of a historically revoked device identity", async () => {
     const ctx = createContext();
+    const freshPublicSignKey = new Uint8Array([5])
+      .buffer as DevicePublicSignKey;
+    const freshPublicVaultKey = new Uint8Array([6])
+      .buffer as DeviceVaultPublicKey;
     const targetIdentity = {
       deviceId: ctx.values.pendingDeviceId,
       publicSignKey: ctx.values.pendingDevicePublicSignKey,
       publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
     };
+    const reusedDeviceIdWithFreshKeys = {
+      deviceId: targetIdentity.deviceId,
+      publicSignKey: freshPublicSignKey,
+      publicVaultKey: freshPublicVaultKey,
+    };
+    vi.mocked(ctx.ports.crypto.digestDevicePublicSignKey).mockImplementation(
+      async (key) => {
+        if (key === targetIdentity.publicSignKey) {
+          return "revoked-sign";
+        }
+
+        return key === freshPublicSignKey ? "fresh-sign" : "initial-sign";
+      },
+    );
+    vi.mocked(ctx.ports.crypto.digestDevicePublicVaultKey).mockImplementation(
+      async (key) => {
+        if (key === targetIdentity.publicVaultKey) {
+          return "revoked-vault";
+        }
+
+        return key === freshPublicVaultKey ? "fresh-vault" : "initial-vault";
+      },
+    );
     const enrollment = await ctx.service.appendTrustTransition(
       ctx.values.vaultId,
       ctx.values.vaultTrustChain,
@@ -385,7 +647,7 @@ describe("VaultTrustService", () => {
         ctx.values.vaultId,
         revocation.chain,
         revocation.trust,
-        [...revocation.trust.trustedDevices, targetIdentity],
+        [...revocation.trust.trustedDevices, reusedDeviceIdWithFreshKeys],
         2,
         ctx.values.deviceId,
         ctx.values.devicePrivateSignKey,
@@ -400,7 +662,10 @@ describe("VaultTrustService", () => {
         vaultKeyGeneration: 2,
         previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
         authorizedByDeviceId: ctx.values.deviceId,
-        trustedDevices: [...revocation.trust.trustedDevices, targetIdentity],
+        trustedDevices: [
+          ...revocation.trust.trustedDevices,
+          reusedDeviceIdWithFreshKeys,
+        ],
       },
       signature: ctx.values.vaultTrustCertificateSignature,
     };
@@ -505,37 +770,48 @@ describe("VaultTrustService", () => {
       ),
     ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
 
-    await expect(
-      ctx.service.verifyTrustChain(
-        ctx.values.vaultId,
-        ctx.values.vaultTrustAnchor,
-        {
-          certificates: [
-            ...revocation.chain.certificates,
-            {
-              payload: {
-                version: 1,
-                vaultId: ctx.values.vaultId,
-                generation: 3,
-                vaultKeyGeneration: 2,
-                previousCertificateDigest:
-                  ctx.values.vaultTrustCertificateDigest,
-                authorizedByDeviceId: ctx.values.deviceId,
-                trustedDevices: [
-                  ...revocation.trust.trustedDevices,
-                  {
-                    deviceId: "fresh-device-with-historical-key",
-                    publicSignKey: revokedIdentity.publicSignKey,
-                    publicVaultKey: freshPublicVaultKey,
-                  },
-                ],
+    const hostileRemoteIdentities = [
+      {
+        deviceId: "fresh-device-with-historical-signing-key",
+        publicSignKey: revokedIdentity.publicSignKey,
+        publicVaultKey: freshPublicVaultKey,
+      },
+      {
+        deviceId: "fresh-device-with-historical-vault-key",
+        publicSignKey: freshPublicSignKey,
+        publicVaultKey: revokedIdentity.publicVaultKey,
+      },
+    ] satisfies readonly DeviceTrustIdentity[];
+
+    for (const hostileRemoteIdentity of hostileRemoteIdentities) {
+      await expect(
+        ctx.service.verifyTrustChain(
+          ctx.values.vaultId,
+          ctx.values.vaultTrustAnchor,
+          {
+            certificates: [
+              ...revocation.chain.certificates,
+              {
+                payload: {
+                  version: 1,
+                  vaultId: ctx.values.vaultId,
+                  generation: 3,
+                  vaultKeyGeneration: 2,
+                  previousCertificateDigest:
+                    ctx.values.vaultTrustCertificateDigest,
+                  authorizedByDeviceId: ctx.values.deviceId,
+                  trustedDevices: [
+                    ...revocation.trust.trustedDevices,
+                    hostileRemoteIdentity,
+                  ],
+                },
+                signature: ctx.values.vaultTrustCertificateSignature,
               },
-              signature: ctx.values.vaultTrustCertificateSignature,
-            },
-          ],
-        },
-      ),
-    ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+            ],
+          },
+        ),
+      ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+    }
   });
 
   it("verifies a snapshot with exactly one current-generation slot per trusted device", async () => {

--- a/packages/core/src/services/trust/vault-trust.service.test.ts
+++ b/packages/core/src/services/trust/vault-trust.service.test.ts
@@ -45,6 +45,25 @@ function createContext() {
   return { values, ports, service, snapshot };
 }
 
+async function createEnrollmentFixture(ctx: ReturnType<typeof createContext>) {
+  const targetIdentity = {
+    deviceId: ctx.values.pendingDeviceId,
+    publicSignKey: ctx.values.pendingDevicePublicSignKey,
+    publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+  };
+  const enrollment = await ctx.service.appendTrustTransition(
+    ctx.values.vaultId,
+    ctx.values.vaultTrustChain,
+    ctx.values.verifiedVaultTrustState,
+    [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
+    1,
+    ctx.values.deviceId,
+    ctx.values.devicePrivateSignKey,
+  );
+
+  return { targetIdentity, enrollment };
+}
+
 describe("VaultTrustService", () => {
   it("creates genesis that authenticates both device public keys", async () => {
     const ctx = createContext();
@@ -71,20 +90,7 @@ describe("VaultTrustService", () => {
 
   it("preserves the key generation for enrollment and increments it for revocation", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { enrollment } = await createEnrollmentFixture(ctx);
     const revocation = await ctx.service.appendTrustTransition(
       ctx.values.vaultId,
       enrollment.chain,
@@ -101,20 +107,8 @@ describe("VaultTrustService", () => {
 
   it("rejects empty, generation-breaking, and self-removing transitions", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { targetIdentity, enrollment } =
+      await createEnrollmentFixture(ctx);
 
     await expect(
       ctx.service.appendTrustTransition(
@@ -153,20 +147,7 @@ describe("VaultTrustService", () => {
 
   it("rejects removed or mutated certificates in the trusted prefix", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { enrollment } = await createEnrollmentFixture(ctx);
     const trustedCertificate = enrollment.chain.certificates[1];
 
     if (trustedCertificate === undefined) {
@@ -210,20 +191,7 @@ describe("VaultTrustService", () => {
 
   it("rejects disconnected or unauthorized trust certificates", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { enrollment } = await createEnrollmentFixture(ctx);
     const certificate = enrollment.chain.certificates[1];
 
     if (certificate === undefined) {
@@ -288,20 +256,8 @@ describe("VaultTrustService", () => {
 
   it("rejects a certificate signed by a trusted device other than its declared authorizer", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { targetIdentity, enrollment } =
+      await createEnrollmentFixture(ctx);
     const revocation = await ctx.service.appendTrustTransition(
       ctx.values.vaultId,
       enrollment.chain,
@@ -520,20 +476,8 @@ describe("VaultTrustService", () => {
 
   it("validates an enrollment-only suffix without rotating the vault key", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { targetIdentity, enrollment } =
+      await createEnrollmentFixture(ctx);
 
     await expect(
       ctx.service.verifyDeviceEnrollmentSuffix(
@@ -555,20 +499,7 @@ describe("VaultTrustService", () => {
 
   it("rejects a revocation inside an enrollment-consumption suffix", async () => {
     const ctx = createContext();
-    const targetIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const enrollment = await ctx.service.appendTrustTransition(
-      ctx.values.vaultId,
-      ctx.values.vaultTrustChain,
-      ctx.values.verifiedVaultTrustState,
-      [...ctx.values.verifiedVaultTrustState.trustedDevices, targetIdentity],
-      1,
-      ctx.values.deviceId,
-      ctx.values.devicePrivateSignKey,
-    );
+    const { enrollment } = await createEnrollmentFixture(ctx);
     const revocation = await ctx.service.appendTrustTransition(
       ctx.values.vaultId,
       enrollment.chain,

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  createDivergedTrustBaselineFixture,
+} from "../../__tests__/fixtures/device-trust";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import type {
@@ -323,27 +326,17 @@ describe("device enrollment consumption", () => {
       throw new Error("Expected local and remote trust transitions.");
     }
 
-    const divergedBaseline = {
-      ...localBaseline,
-      signature: ctx.values.enrollmentRequestSignature,
-    };
-    const divergedBaselineDigest = "diverged-trust-baseline-digest";
-    const forgedRemoteSnapshot = {
-      ...ctx.remoteSnapshot,
-      trustChain: {
-        certificates: [
-          ...ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
-          divergedBaseline,
-          {
-            ...remoteTransition,
-            payload: {
-              ...remoteTransition.payload,
-              previousCertificateDigest: divergedBaselineDigest,
-            },
-          },
-        ],
-      },
-    };
+    const {
+      divergedBaseline,
+      divergedBaselineDigest,
+      forgedRemoteSnapshot,
+    } = createDivergedTrustBaselineFixture({
+      remoteSnapshot: ctx.remoteSnapshot,
+      remotePrefix: ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
+      localBaseline,
+      remoteTransition,
+      replacementSignature: ctx.values.enrollmentRequestSignature,
+    });
     vi.mocked(
       ctx.ports.crypto.digestVaultTrustCertificate,
     ).mockImplementation(async (certificate) =>

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
@@ -17,6 +17,7 @@ import {
   SyncResolutionIncompleteError,
 } from "../../errors/sync.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
+import { VaultSnapshotRollbackDetectedError } from "../../errors/vault-trust.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { ConsumeDeviceEnrollmentUseCase } from "./consume-device-enrollment";
@@ -311,6 +312,57 @@ describe("device enrollment consumption", () => {
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects an enrollment chain that diverges from the local trust baseline", async () => {
+    const ctx = createContext();
+    const localBaseline = ctx.localSnapshot.trustChain.certificates[1];
+    const remoteTransition = ctx.remoteSnapshot.trustChain.certificates[2];
+
+    if (localBaseline === undefined || remoteTransition === undefined) {
+      throw new Error("Expected local and remote trust transitions.");
+    }
+
+    const divergedBaseline = {
+      ...localBaseline,
+      signature: ctx.values.enrollmentRequestSignature,
+    };
+    const divergedBaselineDigest = "diverged-trust-baseline-digest";
+    const forgedRemoteSnapshot = {
+      ...ctx.remoteSnapshot,
+      trustChain: {
+        certificates: [
+          ...ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
+          divergedBaseline,
+          {
+            ...remoteTransition,
+            payload: {
+              ...remoteTransition.payload,
+              previousCertificateDigest: divergedBaselineDigest,
+            },
+          },
+        ],
+      },
+    };
+    vi.mocked(
+      ctx.ports.crypto.digestVaultTrustCertificate,
+    ).mockImplementation(async (certificate) =>
+      certificate === divergedBaseline
+        ? divergedBaselineDigest
+        : ctx.values.vaultTrustCertificateDigest,
+    );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      forgedRemoteSnapshot,
+    );
+
+    await expect(
+      ctx.prepareUseCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
   });
 
   it("does not allow resolution to remove the enrolled profile", async () => {

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../../errors/sync.errors";
 import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
+import { VaultSnapshotRollbackDetectedError } from "../../errors/vault-trust.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { ConsumeDeviceRevocationUseCase } from "./consume-device-revocation";
 import { PrepareDeviceRevocationConsumptionUseCase } from "./prepare-device-revocation-consumption";
@@ -305,6 +306,68 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
       ctx.ports.crypto.encryptDeviceSyncCredentialState,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects a revocation chain that diverges from the local trust baseline", async () => {
+    const ctx = createContext();
+    const localBaseline = ctx.localSnapshot.trustChain.certificates[1];
+    const remoteTransition = ctx.remoteSnapshot.trustChain.certificates[2];
+
+    if (localBaseline === undefined || remoteTransition === undefined) {
+      throw new Error("Expected local and remote trust transitions.");
+    }
+
+    const divergedBaseline = {
+      ...localBaseline,
+      signature: ctx.values.enrollmentRequestSignature,
+    };
+    const divergedBaselineDigest = "diverged-trust-baseline-digest";
+    const forgedRemoteSnapshot = {
+      ...ctx.remoteSnapshot,
+      trustChain: {
+        certificates: [
+          ...ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
+          divergedBaseline,
+          {
+            ...remoteTransition,
+            payload: {
+              ...remoteTransition.payload,
+              previousCertificateDigest: divergedBaselineDigest,
+            },
+          },
+        ],
+      },
+    };
+    vi.mocked(
+      ctx.ports.crypto.digestVaultTrustCertificate,
+    ).mockImplementation(async (certificate) =>
+      certificate === divergedBaseline
+        ? divergedBaselineDigest
+        : ctx.values.vaultTrustCertificateDigest,
+    );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      forgedRemoteSnapshot,
+    );
+    const useCase = new PrepareDeviceRevocationConsumptionUseCase(
+      ctx.ports.crypto,
+      ctx.ports.syncProvider,
+      ctx.ports.sessionServices.unlockedVaultSession,
+      ctx.snapshotService,
+      ctx.ports.vaultLocalRepository,
+    );
+
+    await expect(
+      useCase.execute({
+        vaultId: ctx.values.vaultId,
+        replacementSyncConfig: ctx.values.replacementSyncConfigInput,
+      }),
+    ).rejects.toBeInstanceOf(VaultSnapshotRollbackDetectedError);
+
+    expect(ctx.ports.crypto.openDeviceVaultKeyEnvelope).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
   });
 
   it("replaces a locally stale completed marker through verified revocation consumption", async () => {

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  createDivergedTrustBaselineFixture,
+} from "../../__tests__/fixtures/device-trust";
+import {
   createCoreTestPorts,
   replaceVaultSnapshotAfterNextSave,
 } from "../../__tests__/fixtures/ports";
@@ -317,27 +320,17 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
       throw new Error("Expected local and remote trust transitions.");
     }
 
-    const divergedBaseline = {
-      ...localBaseline,
-      signature: ctx.values.enrollmentRequestSignature,
-    };
-    const divergedBaselineDigest = "diverged-trust-baseline-digest";
-    const forgedRemoteSnapshot = {
-      ...ctx.remoteSnapshot,
-      trustChain: {
-        certificates: [
-          ...ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
-          divergedBaseline,
-          {
-            ...remoteTransition,
-            payload: {
-              ...remoteTransition.payload,
-              previousCertificateDigest: divergedBaselineDigest,
-            },
-          },
-        ],
-      },
-    };
+    const {
+      divergedBaseline,
+      divergedBaselineDigest,
+      forgedRemoteSnapshot,
+    } = createDivergedTrustBaselineFixture({
+      remoteSnapshot: ctx.remoteSnapshot,
+      remotePrefix: ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
+      localBaseline,
+      remoteTransition,
+      replacementSignature: ctx.values.enrollmentRequestSignature,
+    });
     vi.mocked(
       ctx.ports.crypto.digestVaultTrustCertificate,
     ).mockImplementation(async (certificate) =>

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -14,6 +14,7 @@ import {
   InvalidVaultSyncReviewError,
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
+  SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
@@ -216,6 +217,67 @@ describe("ApplySyncResolutionUseCase", () => {
         },
       }),
     ).rejects.toBeInstanceOf(VaultTrustStateInvalidError);
+  });
+
+  it("routes a signed trust transition away from generic resolution", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue({
+      ...ctx.remoteSnapshot,
+      trustChain: {
+        certificates: [
+          ...ctx.remoteSnapshot.trustChain.certificates,
+          {
+            payload: {
+              version: 1,
+              vaultId: ctx.values.vaultId,
+              generation: 1,
+              vaultKeyGeneration: 1,
+              previousCertificateDigest:
+                ctx.values.vaultTrustCertificateDigest,
+              authorizedByDeviceId: ctx.values.deviceId,
+              trustedDevices: [
+                ...ctx.values.verifiedVaultTrustState.trustedDevices,
+                {
+                  deviceId: ctx.values.pendingDeviceId,
+                  publicSignKey: ctx.values.pendingDevicePublicSignKey,
+                  publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+                },
+              ],
+            },
+            signature: ctx.values.vaultTrustCertificateSignature,
+          },
+        ],
+      },
+      keySlots: {
+        deviceSlots: [
+          ...ctx.remoteSnapshot.keySlots.deviceSlots,
+          {
+            deviceId: ctx.values.pendingDeviceId,
+            vaultKeyGeneration: 1,
+            envelope: ctx.values.pendingDeviceVaultKeyEnvelope,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        reviewedSnapshotDescriptors: {
+          local: ctx.localDescriptor,
+          remote: ctx.remoteDescriptor,
+        },
+        resolution: {
+          entryResolutions: [
+            { entryId: singlePasswordEntry.id, action: "use_remote" },
+          ],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncTrustChangeRequiresDeviceTrustFlowError);
+
+    expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
   });
 
   it("rejects when the remote descriptor changes after review", async () => {


### PR DESCRIPTION
## Summary

- Add coverage for mutated, disconnected, unauthorized, and incorrectly signed trust certificates.
- Verify trust baseline divergence is rejected before decrypting or persisting snapshots.
- Ensure signed trust transitions use the device-trust flow instead of generic sync resolution.

## Testing

- Not run; test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protection against invalid, unauthorized, revoked, or mismatched device trust credentials.
  * Added safeguards to detect rollback or divergence in remote trust and revocation updates.
  * Prevented vault decryption and state changes when trust validation fails.
  * Ensured sync operations requiring trusted-device changes are routed through the appropriate verification flow.

* **Tests**
  * Expanded coverage for trust-chain integrity, revoked devices, rollback detection, and signed trust transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->