### PR TITLE
fix(core): harden vault session lifecycle cleanup

### DIFF
--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   DeviceLocalProtectionKey,
   DevicePrivateSignKey,
@@ -35,6 +35,11 @@ vi.mock("@lfspm/core/lib", async (importOriginal) => {
     bestEffortWipeArrayBuffers: bestEffortWipeArrayBuffersSpy,
     secureWipe: secureWipeSpy,
   };
+});
+
+beforeEach(() => {
+  bestEffortWipeArrayBuffersSpy.mockClear();
+  secureWipeSpy.mockClear();
 });
 
 function createStorageArea(initialRecords: Record<string, unknown> = {}) {
@@ -166,7 +171,6 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("restores session material from storage", async () => {
-    secureWipeSpy.mockClear();
     const { storageArea } = createStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
@@ -221,6 +225,69 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
     }
   });
 
+  it("returns one decoded material identity to concurrent cold readers", async () => {
+    const { storageArea } = createStorageArea();
+    const writer = new ChromeUnlockedVaultSessionMaterialRepository(
+      storageArea,
+    );
+    await writer.saveUnlockedVaultSessionMaterial(createMaterial());
+    const get = vi.fn(storageArea.get);
+    const reader = new ChromeUnlockedVaultSessionMaterialRepository({
+      ...storageArea,
+      get,
+    });
+
+    const [first, second] = await Promise.all([
+      reader.getUnlockedVaultSessionMaterial(),
+      reader.getUnlockedVaultSessionMaterial(),
+    ]);
+
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+    expect(get).toHaveBeenCalledOnce();
+  });
+
+  it("does not let a delayed cold read repopulate material after removal", async () => {
+    const { storageArea } = createStorageArea();
+    const writer = new ChromeUnlockedVaultSessionMaterialRepository(
+      storageArea,
+    );
+    await writer.saveUnlockedVaultSessionMaterial(createMaterial());
+    const storedRecords = await storageArea.get(
+      UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY,
+    );
+    let markGetStarted!: () => void;
+    let resolveGet!: (records: Record<string, unknown>) => void;
+    const getStarted = new Promise<void>((resolve) => {
+      markGetStarted = resolve;
+    });
+    const delayedRecords = new Promise<Record<string, unknown>>((resolve) => {
+      resolveGet = resolve;
+    });
+    const get = vi.fn(async () => {
+      markGetStarted();
+      return delayedRecords;
+    });
+    const remove = vi.fn(storageArea.remove);
+    const reader = new ChromeUnlockedVaultSessionMaterialRepository({
+      ...storageArea,
+      get,
+      remove,
+    });
+
+    const pendingRead = reader.getUnlockedVaultSessionMaterial();
+    await getStarted;
+    const pendingRemoval = reader.removeUnlockedVaultSessionMaterial();
+
+    expect(remove).not.toHaveBeenCalled();
+    resolveGet(storedRecords);
+    await expect(pendingRead).resolves.not.toBeNull();
+    await expect(pendingRemoval).resolves.toBeUndefined();
+    await expect(reader.getUnlockedVaultSessionMaterial()).resolves.toBeNull();
+    expect(get).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+
   it("returns null when session material is missing", async () => {
     const { storageArea } = createStorageArea();
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
@@ -258,8 +325,6 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("wipes decoded secret copies when a later secret cannot be decoded", async () => {
-    bestEffortWipeArrayBuffersSpy.mockClear();
-    secureWipeSpy.mockClear();
     const { storageArea } = createStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
@@ -293,7 +358,9 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
       storageArea,
     );
 
-    await expect(repository.getUnlockedVaultSessionMaterial()).rejects.toThrow();
+    await expect(
+      repository.getUnlockedVaultSessionMaterial(),
+    ).rejects.toThrow();
 
     expect(secureWipeSpy).toHaveBeenCalledTimes(2);
     expect(bestEffortWipeArrayBuffersSpy).toHaveBeenCalledTimes(1);
@@ -320,6 +387,35 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
     await expect(
       repository.getUnlockedVaultSessionMaterial(),
     ).resolves.toBeNull();
+  });
+
+  it("keeps session material logically removed when storage removal fails", async () => {
+    const { getRecords, storageArea } = createStorageArea();
+    const get = vi.fn(storageArea.get);
+    const removeError = new Error("storage removal failed");
+    const failingStorageArea: ChromeStorageArea = {
+      ...storageArea,
+      get,
+      remove: vi.fn(async () => {
+        throw removeError;
+      }),
+    };
+    const repository = new ChromeUnlockedVaultSessionMaterialRepository(
+      failingStorageArea,
+    );
+    await repository.saveUnlockedVaultSessionMaterial(createMaterial());
+
+    await expect(repository.removeUnlockedVaultSessionMaterial()).rejects.toBe(
+      removeError,
+    );
+
+    expect(getRecords()).toHaveProperty(
+      UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY,
+    );
+    await expect(
+      repository.getUnlockedVaultSessionMaterial(),
+    ).resolves.toBeNull();
+    expect(get).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   DeviceLocalProtectionKey,
   DevicePrivateSignKey,
@@ -13,6 +13,29 @@ import {
   type ChromeStorageArea,
   UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY,
 } from "./chrome-unlocked-vault-session-material.repository";
+
+const { bestEffortWipeArrayBuffersSpy, secureWipeSpy } = vi.hoisted(() => ({
+  bestEffortWipeArrayBuffersSpy: vi.fn(
+    (buffers: readonly (ArrayBuffer | undefined)[]) => {
+      for (const buffer of buffers) {
+        if (buffer !== undefined) {
+          new Uint8Array(buffer).fill(0);
+        }
+      }
+    },
+  ),
+  secureWipeSpy: vi.fn((bytes: Uint8Array) => bytes.fill(0)),
+}));
+
+vi.mock("@lfspm/core/lib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lfspm/core/lib")>();
+
+  return {
+    ...actual,
+    bestEffortWipeArrayBuffers: bestEffortWipeArrayBuffersSpy,
+    secureWipe: secureWipeSpy,
+  };
+});
 
 function createStorageArea(initialRecords: Record<string, unknown> = {}) {
   let records = { ...initialRecords };
@@ -98,8 +121,9 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
+    const material = createMaterial();
 
-    await repository.saveUnlockedVaultSessionMaterial(createMaterial());
+    await repository.saveUnlockedVaultSessionMaterial(material);
 
     expect(getRecords()[UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]).toEqual({
       sessionId: "session-id",
@@ -136,9 +160,13 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
         genesisCertificateDigest: "genesis-certificate-digest",
       },
     });
+    await expect(repository.getUnlockedVaultSessionMaterial()).resolves.toBe(
+      material,
+    );
   });
 
   it("restores session material from storage", async () => {
+    secureWipeSpy.mockClear();
     const { storageArea } = createStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
@@ -181,8 +209,16 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
     );
 
     const result = await repository.getUnlockedVaultSessionMaterial();
+    const repeatedResult = await repository.getUnlockedVaultSessionMaterial();
 
     expect(result).toEqual(createMaterial());
+    expect(repeatedResult).toBe(result);
+    expect(secureWipeSpy).toHaveBeenCalledTimes(8);
+    for (const [temporaryBytes] of secureWipeSpy.mock.calls) {
+      expect(Array.from(temporaryBytes)).toEqual(
+        Array.from({ length: temporaryBytes.length }, () => 0),
+      );
+    }
   });
 
   it("returns null when session material is missing", async () => {
@@ -221,21 +257,69 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
     );
   });
 
-  it("removes session material", async () => {
-    const { getRecords, storageArea } = createStorageArea({
+  it("wipes decoded secret copies when a later secret cannot be decoded", async () => {
+    bestEffortWipeArrayBuffersSpy.mockClear();
+    secureWipeSpy.mockClear();
+    const { storageArea } = createStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
+        vaultId: "vault-id",
+        sourceSnapshotVersionVector: { "device-id": 7 },
+        deviceId: "device-id",
+        vaultMasterKey: "AQID",
+        devicePrivateSignKey: "BAUG",
+        devicePrivateVaultKey: "!",
+        deviceLocalProtectionKey: "CgsM",
+        payloadKey: "DQ4P",
+        trustedSnapshotContext: {
+          snapshotDigest: "snapshot-digest",
+          trust: {
+            generation: 2,
+            vaultKeyGeneration: 3,
+            certificateDigest: "certificate-digest",
+            trustedDevices: [],
+          },
+        },
+        vaultTrustAnchor: {
+          version: 1,
+          vaultId: "vault-id",
+          genesisDeviceId: "device-id",
+          genesisPublicSignKey: "FhcY",
+          genesisCertificateDigest: "genesis-certificate-digest",
+        },
       },
     });
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
 
+    await expect(repository.getUnlockedVaultSessionMaterial()).rejects.toThrow();
+
+    expect(secureWipeSpy).toHaveBeenCalledTimes(2);
+    expect(bestEffortWipeArrayBuffersSpy).toHaveBeenCalledTimes(1);
+    const decodedSecrets = bestEffortWipeArrayBuffersSpy.mock.calls[0]![0];
+    expect(decodedSecrets).toHaveLength(2);
+    for (const secret of decodedSecrets) {
+      expect(Array.from(new Uint8Array(secret!))).toEqual([0, 0, 0]);
+    }
+  });
+
+  it("removes session material", async () => {
+    const { getRecords, storageArea } = createStorageArea();
+    const repository = new ChromeUnlockedVaultSessionMaterialRepository(
+      storageArea,
+    );
+    const material = createMaterial();
+    await repository.saveUnlockedVaultSessionMaterial(material);
+
     await repository.removeUnlockedVaultSessionMaterial();
 
     expect(getRecords()).not.toHaveProperty(
       UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY,
     );
+    await expect(
+      repository.getUnlockedVaultSessionMaterial(),
+    ).resolves.toBeNull();
   });
 });
 

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
@@ -19,6 +19,7 @@ export type ChromeStorageArea = {
 export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVaultSessionMaterialRepositoryPort {
   private readonly storageArea: ChromeStorageArea;
   private readonly storageKey: string;
+  private cachedMaterial: UnlockedVaultSessionMaterial | undefined;
 
   constructor(
     storageArea: ChromeStorageArea = chrome.storage
@@ -35,9 +36,14 @@ export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVau
     await this.storageArea.set({
       [this.storageKey]: serializeUnlockedVaultSessionMaterial(material),
     });
+    this.cachedMaterial = material;
   }
 
   async getUnlockedVaultSessionMaterial(): Promise<UnlockedVaultSessionMaterial | null> {
+    if (this.cachedMaterial !== undefined) {
+      return this.cachedMaterial;
+    }
+
     const storedRecords = await this.storageArea.get(this.storageKey);
     const material = storedRecords[this.storageKey];
 
@@ -45,10 +51,13 @@ export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVau
       return null;
     }
 
-    return deserializeUnlockedVaultSessionMaterial(material);
+    const decodedMaterial = deserializeUnlockedVaultSessionMaterial(material);
+    this.cachedMaterial = decodedMaterial;
+    return decodedMaterial;
   }
 
   async removeUnlockedVaultSessionMaterial(): Promise<void> {
     await this.storageArea.remove(this.storageKey);
+    this.cachedMaterial = undefined;
   }
 }

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
@@ -19,7 +19,8 @@ export type ChromeStorageArea = {
 export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVaultSessionMaterialRepositoryPort {
   private readonly storageArea: ChromeStorageArea;
   private readonly storageKey: string;
-  private cachedMaterial: UnlockedVaultSessionMaterial | undefined;
+  private cachedMaterial: UnlockedVaultSessionMaterial | null | undefined;
+  private pendingOperation: Promise<void> = Promise.resolve();
 
   constructor(
     storageArea: ChromeStorageArea = chrome.storage
@@ -33,31 +34,49 @@ export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVau
   async saveUnlockedVaultSessionMaterial(
     material: UnlockedVaultSessionMaterial,
   ): Promise<void> {
-    await this.storageArea.set({
-      [this.storageKey]: serializeUnlockedVaultSessionMaterial(material),
+    await this.serializeOperation(async () => {
+      await this.storageArea.set({
+        [this.storageKey]: serializeUnlockedVaultSessionMaterial(material),
+      });
+      this.cachedMaterial = material;
     });
-    this.cachedMaterial = material;
   }
 
   async getUnlockedVaultSessionMaterial(): Promise<UnlockedVaultSessionMaterial | null> {
-    if (this.cachedMaterial !== undefined) {
-      return this.cachedMaterial;
-    }
+    return this.serializeOperation(async () => {
+      if (this.cachedMaterial !== undefined) {
+        return this.cachedMaterial;
+      }
 
-    const storedRecords = await this.storageArea.get(this.storageKey);
-    const material = storedRecords[this.storageKey];
+      const storedRecords = await this.storageArea.get(this.storageKey);
+      const material = storedRecords[this.storageKey];
 
-    if (material === undefined) {
-      return null;
-    }
+      if (material === undefined) {
+        return null;
+      }
 
-    const decodedMaterial = deserializeUnlockedVaultSessionMaterial(material);
-    this.cachedMaterial = decodedMaterial;
-    return decodedMaterial;
+      const decodedMaterial = deserializeUnlockedVaultSessionMaterial(material);
+      this.cachedMaterial = decodedMaterial;
+      return decodedMaterial;
+    });
   }
 
   async removeUnlockedVaultSessionMaterial(): Promise<void> {
-    await this.storageArea.remove(this.storageKey);
-    this.cachedMaterial = undefined;
+    await this.serializeOperation(async () => {
+      try {
+        await this.storageArea.remove(this.storageKey);
+      } finally {
+        this.cachedMaterial = null;
+      }
+    });
+  }
+
+  private serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pendingOperation.then(operation, operation);
+    this.pendingOperation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 }

--- a/apps/extension/src/adapters/storage/unlocked-vault-session-material.codec.ts
+++ b/apps/extension/src/adapters/storage/unlocked-vault-session-material.codec.ts
@@ -1,6 +1,8 @@
 import {
   decodeBase64Url,
   encodeBase64Url,
+  bestEffortWipeArrayBuffers,
+  secureWipe,
   type Base64URLString,
 } from "@lfspm/core/lib";
 import type {
@@ -92,52 +94,68 @@ export function deserializeUnlockedVaultSessionMaterial(
   material: unknown,
 ): UnlockedVaultSessionMaterial {
   assertStoredMaterial(material);
+  const decodedSecrets: ArrayBuffer[] = [];
 
-  return {
-    sessionId: material.sessionId,
-    vaultId: material.vaultId,
-    sourceSnapshotVersionVector: material.sourceSnapshotVersionVector,
-    deviceId: material.deviceId,
-    vaultMasterKey: base64UrlToArrayBuffer(
-      material.vaultMasterKey,
-    ) as UnlockedVaultSessionMaterial["vaultMasterKey"],
-    devicePrivateSignKey: base64UrlToArrayBuffer(
+  try {
+    const vaultMasterKey = base64UrlToArrayBuffer(material.vaultMasterKey);
+    decodedSecrets.push(vaultMasterKey);
+    const devicePrivateSignKey = base64UrlToArrayBuffer(
       material.devicePrivateSignKey,
-    ) as UnlockedVaultSessionMaterial["devicePrivateSignKey"],
-    devicePrivateVaultKey: base64UrlToArrayBuffer(
+    );
+    decodedSecrets.push(devicePrivateSignKey);
+    const devicePrivateVaultKey = base64UrlToArrayBuffer(
       material.devicePrivateVaultKey,
-    ) as DeviceVaultPrivateKey,
-    deviceLocalProtectionKey: base64UrlToArrayBuffer(
+    );
+    decodedSecrets.push(devicePrivateVaultKey);
+    const deviceLocalProtectionKey = base64UrlToArrayBuffer(
       material.deviceLocalProtectionKey,
-    ) as DeviceLocalProtectionKey,
-    payloadKey: base64UrlToArrayBuffer(
-      material.payloadKey,
-    ) as UnlockedVaultSessionMaterial["payloadKey"],
-    trustedSnapshotContext: {
-      ...material.trustedSnapshotContext,
-      trust: {
-        ...material.trustedSnapshotContext.trust,
-        trustedDevices:
-          material.trustedSnapshotContext.trust.trustedDevices.map(
-            (device) => ({
-              deviceId: device.deviceId,
-              publicSignKey: base64UrlToArrayBuffer(
-                device.publicSignKey,
-              ) as DevicePublicSignKey,
-              publicVaultKey: base64UrlToArrayBuffer(
-                device.publicVaultKey,
-              ) as DeviceVaultPublicKey,
-            }),
-          ),
+    );
+    decodedSecrets.push(deviceLocalProtectionKey);
+    const payloadKey = base64UrlToArrayBuffer(material.payloadKey);
+    decodedSecrets.push(payloadKey);
+
+    return {
+      sessionId: material.sessionId,
+      vaultId: material.vaultId,
+      sourceSnapshotVersionVector: material.sourceSnapshotVersionVector,
+      deviceId: material.deviceId,
+      vaultMasterKey:
+        vaultMasterKey as UnlockedVaultSessionMaterial["vaultMasterKey"],
+      devicePrivateSignKey:
+        devicePrivateSignKey as UnlockedVaultSessionMaterial["devicePrivateSignKey"],
+      devicePrivateVaultKey: devicePrivateVaultKey as DeviceVaultPrivateKey,
+      deviceLocalProtectionKey:
+        deviceLocalProtectionKey as DeviceLocalProtectionKey,
+      payloadKey: payloadKey as UnlockedVaultSessionMaterial["payloadKey"],
+      trustedSnapshotContext: {
+        ...material.trustedSnapshotContext,
+        trust: {
+          ...material.trustedSnapshotContext.trust,
+          trustedDevices:
+            material.trustedSnapshotContext.trust.trustedDevices.map(
+              (device) => ({
+                deviceId: device.deviceId,
+                publicSignKey: base64UrlToArrayBuffer(
+                  device.publicSignKey,
+                ) as DevicePublicSignKey,
+                publicVaultKey: base64UrlToArrayBuffer(
+                  device.publicVaultKey,
+                ) as DeviceVaultPublicKey,
+              }),
+            ),
+        },
       },
-    },
-    vaultTrustAnchor: {
-      ...material.vaultTrustAnchor,
-      genesisPublicSignKey: base64UrlToArrayBuffer(
-        material.vaultTrustAnchor.genesisPublicSignKey,
-      ) as DevicePublicSignKey,
-    },
-  };
+      vaultTrustAnchor: {
+        ...material.vaultTrustAnchor,
+        genesisPublicSignKey: base64UrlToArrayBuffer(
+          material.vaultTrustAnchor.genesisPublicSignKey,
+        ) as DevicePublicSignKey,
+      },
+    };
+  } catch (error) {
+    bestEffortWipeArrayBuffers(decodedSecrets);
+    throw error;
+  }
 }
 
 function arrayBufferToBase64Url(buffer: ArrayBuffer): Base64URLString {
@@ -146,7 +164,12 @@ function arrayBufferToBase64Url(buffer: ArrayBuffer): Base64URLString {
 
 function base64UrlToArrayBuffer(value: Base64URLString): ArrayBuffer {
   const bytes = decodeBase64Url(value);
-  return bytes.slice().buffer;
+
+  try {
+    return bytes.slice().buffer;
+  } finally {
+    secureWipe(bytes);
+  }
 }
 
 function assertStoredMaterial(

--- a/apps/extension/src/core-composition-api.typecheck.ts
+++ b/apps/extension/src/core-composition-api.typecheck.ts
@@ -1,7 +1,10 @@
 import {
   AddEntryUseCase,
   CopyEntryPasswordUseCase,
+  DeleteLocalVaultUseCase,
   InitializeVaultUseCase,
+  LockVaultUseCase,
+  PerformDeviceEnrollmentUseCase,
   SyncUploadUseCase,
 } from "@lfspm/core";
 import type {
@@ -22,6 +25,7 @@ import type {
 import {
   ClipboardClearService,
   UnlockedVaultSessionService,
+  VaultLifecycleCleanupService,
   VaultSnapshotService,
   VaultSyncGuardService,
 } from "@lfspm/core/services";
@@ -67,6 +71,13 @@ export function composeCoreApi(ports: CoreCompositionPorts) {
     ports.clock,
     ports.crypto,
   );
+  const lifecycleCleanup = new VaultLifecycleCleanupService(
+    clipboardClear,
+    ports.clipboardClearTasks,
+    ports.scheduledTasks,
+    ports.vaultLockTasks,
+    unlockedVaultSession,
+  );
 
   return {
     vaultLifecycle: new InitializeVaultUseCase(
@@ -77,6 +88,24 @@ export function composeCoreApi(ports: CoreCompositionPorts) {
       ports.ids,
       ports.clock,
       ports.vaultDisplayName,
+      ports.scheduledTasks,
+      ports.vaultLockTasks,
+    ),
+    lockVault: new LockVaultUseCase(lifecycleCleanup),
+    deleteLocalVault: new DeleteLocalVaultUseCase(
+      ports.vaults,
+      lifecycleCleanup,
+    ),
+    performDeviceEnrollment: new PerformDeviceEnrollmentUseCase(
+      ports.clock,
+      ports.crypto,
+      ports.ids,
+      ports.bip39,
+      ports.syncProvider,
+      unlockedVaultSession,
+      ports.vaultDisplayName,
+      ports.vaults,
+      lifecycleCleanup,
       ports.scheduledTasks,
       ports.vaultLockTasks,
     ),

--- a/apps/extension/src/core-composition-api.typecheck.ts
+++ b/apps/extension/src/core-composition-api.typecheck.ts
@@ -16,6 +16,7 @@ import type {
   SyncProviderPort,
   UnlockedVaultSessionMaterialRepositoryPort,
   VaultDisplayNamePort,
+  VaultLockTaskRepositoryPort,
   VaultLocalRepositoryPort,
 } from "@lfspm/core";
 import {
@@ -37,6 +38,7 @@ type CoreCompositionPorts = {
   readonly sessionMaterials: UnlockedVaultSessionMaterialRepositoryPort;
   readonly syncProvider: SyncProviderPort;
   readonly vaultDisplayName: VaultDisplayNamePort;
+  readonly vaultLockTasks: VaultLockTaskRepositoryPort;
   readonly vaults: VaultLocalRepositoryPort;
 };
 
@@ -75,6 +77,8 @@ export function composeCoreApi(ports: CoreCompositionPorts) {
       ports.ids,
       ports.clock,
       ports.vaultDisplayName,
+      ports.scheduledTasks,
+      ports.vaultLockTasks,
     ),
     vaultEntry: new AddEntryUseCase(
       ports.ids,

--- a/docs/security/security-specification.md
+++ b/docs/security/security-specification.md
@@ -304,13 +304,13 @@ than as a security boundary.
 caller. Implementations must not retain or alias them. Ownership is assigned as
 follows:
 
-| Secret buffer | Last owner | End of ownership |
-| --- | --- | --- |
-| Derived root, local-protection, device-slot-protection, enrollment-protection, and recovery keys | Creating lifecycle use case | Wiped in `finally` after the last crypto operation on success or failure |
-| Newly generated signing/wrapping private keys and local key-protection keys | Creating lifecycle use case, then unlocked session on successful activation | Wiped by the use case if activation fails; otherwise transferred to the session owner |
-| Vault master key returned by generation, unwrap, enrollment, recovery, or device-revocation processing | Creating use case or revocation-candidate service, then unlocked session on successful activation/commit | Wiped when validation fails or ownership is not transferred; prepare-only review wipes its candidate after building the review; an activated/committed key is wiped by the session owner |
-| Unlocked-session vault, signing, wrapping, local-protection, and payload keys | `UnlockedVaultSessionService` | Wiped inside serialized removal or when an owned generation is replaced/invalidated; conditional removal checks session ID, vault ID, and activation generation so a stale identity never wipes a newer generation |
-| Temporary base64-decoded bytes and partially decoded secret material | Chrome session-material codec | Temporary arrays are wiped after copying; owned secret copies are wiped if later decoding fails |
+| Secret buffer                                                                                          | Last owner                                                                                               | End of ownership                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Derived root, local-protection, device-slot-protection, enrollment-protection, and recovery keys       | Creating lifecycle use case                                                                              | Wiped in `finally` after the last crypto operation on success or failure                                                                                                                                           |
+| Newly generated signing/wrapping private keys and local key-protection keys                            | Creating lifecycle use case, then unlocked session on successful activation                              | Wiped by the use case if activation fails; otherwise transferred to the session owner                                                                                                                              |
+| Vault master key returned by generation, unwrap, enrollment, recovery, or device-revocation processing | Creating use case or revocation-candidate service, then unlocked session on successful activation/commit | Wiped when validation fails or ownership is not transferred; prepare-only review wipes its candidate after building the review; an activated/committed key is wiped by the session owner                           |
+| Unlocked-session vault, signing, wrapping, local-protection, and payload keys                          | `UnlockedVaultSessionService`                                                                            | Wiped inside serialized removal or when an owned generation is replaced/invalidated; conditional removal checks session ID, vault ID, and activation generation so a stale identity never wipes a newer generation |
+| Temporary base64-decoded bytes and partially decoded secret material                                   | Chrome session-material codec                                                                            | Temporary arrays are wiped after copying; owned secret copies are wiped if later decoding fails                                                                                                                    |
 
 The session-material repository retains one stable mutable material identity per
 active generation. A successful save transfers custody of the exact buffers to
@@ -319,7 +319,9 @@ wipe owner; a cold-start read decodes and caches one identity. Repeated reads
 therefore share the buffers that session removal wipes before it removes the
 repository record. Chrome storage still contains immutable encoded strings, and
 worker termination can only leave their former mutable buffers to garbage
-collection rather than guarantee overwriting them.
+collection rather than guarantee overwriting them. The Chrome repository
+serializes cold reads, saves, and removals so concurrent readers cannot create
+competing decoded secret identities or republish a read after logical removal.
 
 Repository removal is still attempted when wiping fails, and wiping is still
 attempted when repository removal fails. Public-key buffers are not secret and
@@ -328,12 +330,59 @@ serialized base64 values are strings at API or storage boundaries and cannot be
 reliably overwritten.
 
 Auto-lock installation and session activation share the session owner's
-serialized lifecycle boundary. Cleanup enters that same boundary before reading
-or canceling task metadata, so activation cannot advance during cleanup. A
+serialized lifecycle boundary. New-vault persistence for initialization and
+enrollment is prepared inside that boundary and conditionally rolled back there
+on failure, so a competing activation cannot win between persistence and
+cleanup. Cleanup enters that same boundary before reading or canceling task
+metadata, so activation cannot advance during cleanup. A
 scheduled action is authenticated against current metadata, including through
 atomic action-ID removal when a metadata read fails, before safe clipboard,
 task, and session cleanup continues. Manual cleanup also invalidates an
-already-authorized activation when no stored session remains.
+already-authorized activation when no stored session remains. Target-bound
+cleanup, including local deletion, fails closed before destructive cleanup when
+the active vault identity cannot be read; it cannot safely infer that an
+unreadable session belongs to the requested vault.
+Active-session persistence advances the activation generation before its
+callback can change local state, so an activation lease captured before a
+mutation or password rotation cannot later install stale vault or access
+material. Successful snapshot commits advance it again. Every activation,
+including same-vault reactivation, mints a fresh session ID and payload key;
+work authorized under the replaced identity therefore cannot persist or commit
+after reactivation. Ordinary snapshot commits retain the active identity while
+advancing its generation.
+Persisted-state rollback is likewise authenticated against its originating
+session ID and source snapshot vector before it runs, so an upload failure from
+stale work cannot roll back or wipe a replacement or advanced session. A
+rollback with no active material advances the generation before persistence is
+restored, invalidating activation leases that may have read the replaced state.
+Before each fallible remote upload, the snapshot owner signs and retains the
+previous snapshot's rollback checkpoint inside the same serialized session
+operation that persists its replacement, while the session signing key is
+still live and authenticated. The later conditional restore uses that
+non-secret prepared artifact and the persisted replacement digest, so lock-time
+wiping cannot break rollback. If session ownership cannot be read, callers
+preserve potentially active secret buffers and surface an explicit incomplete-
+rollback error. If a conditional restore fails for the known matching session,
+the session owner invalidates and wipes that session before callers surface the
+same explicit error. Neither case masks uncertain local state with only the
+upload error.
+
+Password copy revalidates its session and performs clipboard task replacement,
+scheduling, and the plaintext write inside that same serialized boundary. A
+completed lock therefore prevents a paused copy from writing afterward; when a
+copy enters first, lock waits and then clears its resulting clipboard task.
+
+Local-vault deletion removes persisted vault records after successful session
+cleanup but before releasing the same lifecycle boundary. A queued unlock cannot
+obtain an activation lease until deletion has completed, so it subsequently
+observes the removed local records instead of racing their removal.
+
+These in-memory serialization guarantees require one shared core composition
+per storage namespace. Extension UI contexts must route lifecycle and secret-
+using operations through that long-lived background owner; independently
+constructing session services in popup, options, and background contexts is not
+a supported composition because JavaScript object locks do not coordinate
+across contexts.
 
 ---
 
@@ -457,7 +506,8 @@ A new device joins through a two-file, asynchronous exchange:
 6.  **Persistence:** Access material, recovery backup, snapshot, checkpoint, and
     optional local credentials are initialized together. Pending request state
     is removed only after success. If session activation fails, the initialized
-    local records are removed and the pending request remains retryable. A
+    local records are conditionally removed inside the serialized activation
+    boundary and the pending request remains retryable. A
     later remote compare-and-set rollback may remove those records only while
     both the active session version and persisted snapshot digest still match
     the enrollment snapshot. That rollback uses the shared lifecycle owner to

--- a/docs/security/security-specification.md
+++ b/docs/security/security-specification.md
@@ -293,13 +293,47 @@ Each device records its location on every unlock/sync operation, appending to it
 - **Purpose:** User recognition only — allows users to verify "was this access from me?" Not used for security enforcement.
 - **New device detection:** On sync download, diff local vs remote `deviceRegistry.devices`. If new `deviceId`s appear, show notification with device name, environment info, and registration location.
 
-### 7.3 Memory Wiping (Critical) — New
+### 7.3 Best-Effort Secret Buffer Wiping
 
-Since JS Garbage Collection is unpredictable:
+JavaScript cannot guarantee erasure of immutable strings, engine copies,
+WebCrypto-internal state, or browser storage history. LFSPM therefore treats
+wiping as best-effort memory hygiene for mutable, caller-owned buffers rather
+than as a security boundary.
 
-- **TypedArrays:** Use Uint8Array for all keys/passwords (avoid Strings).
-- **Overwrite:** Immediately after use (or on logout), execute `buffer.fill(0)` on the array.
-- **Release:** Set references to `null` after filling.
+`CryptoPort` results containing raw secret bytes are fresh buffers owned by the
+caller. Implementations must not retain or alias them. Ownership is assigned as
+follows:
+
+| Secret buffer | Last owner | End of ownership |
+| --- | --- | --- |
+| Derived root, local-protection, device-slot-protection, enrollment-protection, and recovery keys | Creating lifecycle use case | Wiped in `finally` after the last crypto operation on success or failure |
+| Newly generated signing/wrapping private keys and local key-protection keys | Creating lifecycle use case, then unlocked session on successful activation | Wiped by the use case if activation fails; otherwise transferred to the session owner |
+| Vault master key returned by generation, unwrap, enrollment, recovery, or device-revocation processing | Creating use case or revocation-candidate service, then unlocked session on successful activation/commit | Wiped when validation fails or ownership is not transferred; prepare-only review wipes its candidate after building the review; an activated/committed key is wiped by the session owner |
+| Unlocked-session vault, signing, wrapping, local-protection, and payload keys | `UnlockedVaultSessionService` | Wiped inside serialized removal or when an owned generation is replaced/invalidated; conditional removal checks session ID, vault ID, and activation generation so a stale identity never wipes a newer generation |
+| Temporary base64-decoded bytes and partially decoded secret material | Chrome session-material codec | Temporary arrays are wiped after copying; owned secret copies are wiped if later decoding fails |
+
+The session-material repository retains one stable mutable material identity per
+active generation. A successful save transfers custody of the exact buffers to
+that repository instance while the serialized session service remains their
+wipe owner; a cold-start read decodes and caches one identity. Repeated reads
+therefore share the buffers that session removal wipes before it removes the
+repository record. Chrome storage still contains immutable encoded strings, and
+worker termination can only leave their former mutable buffers to garbage
+collection rather than guarantee overwriting them.
+
+Repository removal is still attempted when wiping fails, and wiping is still
+attempted when repository removal fails. Public-key buffers are not secret and
+are outside this wiping inventory. Master passwords, recovery mnemonics, and
+serialized base64 values are strings at API or storage boundaries and cannot be
+reliably overwritten.
+
+Auto-lock installation and session activation share the session owner's
+serialized lifecycle boundary. Cleanup enters that same boundary before reading
+or canceling task metadata, so activation cannot advance during cleanup. A
+scheduled action is authenticated against current metadata, including through
+atomic action-ID removal when a metadata read fails, before safe clipboard,
+task, and session cleanup continues. Manual cleanup also invalidates an
+already-authorized activation when no stored session remains.
 
 ---
 
@@ -426,7 +460,10 @@ A new device joins through a two-file, asynchronous exchange:
     local records are removed and the pending request remains retryable. A
     later remote compare-and-set rollback may remove those records only while
     both the active session version and persisted snapshot digest still match
-    the enrollment snapshot.
+    the enrollment snapshot. That rollback uses the shared lifecycle owner to
+    clear clipboard and auto-lock state before invalidating the matching
+    session, and wipes the enrollment operation's original secret buffers when
+    their ownership is no longer transferred to a live session.
 
 The devices never need to be connected simultaneously. Neither transported
 artifact contains private device keys or provider credentials.
@@ -462,7 +499,10 @@ Keep only unwrapped keys (`extractable:false`) and decrypted state.
 
 ### 10.2 Memory wiping (Hardened)
 
-**Rule:** Any Uint8Array holding password material or raw key bits must be overwritten with `.fill(0)` before scope exit.
+**Rule:** Every mutable, caller-owned buffer holding raw secret key material is
+best-effort overwritten after its final consumer or when its active session
+generation is removed. Wiping failures must not prevent remaining lifecycle
+cleanup.
 
 ### 10.3 Auto-lock
 

--- a/docs/v1/use-case/clipboard/copy-entry-password.activity.puml
+++ b/docs/v1/use-case/clipboard/copy-entry-password.activity.puml
@@ -25,6 +25,7 @@ if (entry missing?) then (yes)
   stop
 endif
 
+:Enter serialized active-session persistence boundary;
 :Compute clearScheduledAt = now + clearAfterMs;
 :Load previous clipboard clear task;
 if (previous task exists?) then (yes)

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
@@ -10,156 +10,93 @@ skinparam activity {
 }
 
 start
-:Input:\nenrollmentBundle, masterPassword, deviceName, lockAfterMs;
-:Source:\npackages/core/src/use-cases/device-trust/perform-device-enrollment.ts;
+:Input:\nenrollmentResponse, masterPassword, deviceName,\noptional syncConfig, lockAfterMs;
 :Validate lockAfterMs before pending-enrollment reads or crypto work;
 if (invalid delay?) then (yes)
   :Throw InvalidVaultLockDelayError;
   stop
 endif
-:Calculate masterPassword strength;
-if (password score below 4?) then (yes)
+:Validate the new master-password policy;
+if (password invalid?) then (yes)
   :Throw InvalidNewMasterPasswordError;
   stop
 endif
-:Require bundle vault can be activated locally;
-:Read latest remote snapshot descriptor with bundle syncConfig;
-if (remote descriptor missing?) then (yes)
-  :Throw RemoteVaultSnapshotNotFoundError;
+
+:Read pending enrollment by response.requestId;
+if (pending request missing or response identity/version mismatches?) then (yes)
+  :Throw pending-enrollment error;
   stop
 endif
-:Build expected descriptor from bundle vector and timestamp;
-if (remote descriptor differs from bundle descriptor?) then (yes)
-  :Throw DeviceEnrollmentRemoteSnapshotChangedError;
-  stop
+:Require no existing local vault/access material;
+:Acquire activation lease for response.vaultId;
+
+:Derive pending-state protection from the master password;
+:Unwrap pending private device state;
+:Verify request signature, request identity, and both private/public key pairs;
+:Validate authorized snapshot vault/schema/algorithm and request trust anchor;
+:Verify trust chain and authorized snapshot signature;
+:Require exactly one trusted target identity and matching vault-key envelope;
+:Open the target envelope and decrypt the authorized vault;
+:Add the new device profile;
+
+if (authorized vault has a sync target?) then (yes)
+  :Require and normalize syncConfig;
+  :Require its target to match the encrypted vault target;
+  :Require latest remote descriptor to equal the authorized snapshot;
 endif
 
-:Download remote enrollment snapshot;
-if (snapshot vault id differs?) then (yes)
-  :Throw DeviceEnrollmentSnapshotMismatchError;
-  stop
-endif
-if (snapshot algorithm unsupported?) then (yes)
-  :Throw UnsupportedAlgorithmSuiteError;
-  stop
-endif
-:Verify snapshot signature with bundle snapshotSignerPublicKey;
-if (signature invalid?) then (yes)
-  :Throw VaultSnapshotSignatureVerificationFailedError;
-  stop
-endif
+:Build, encrypt, sign, and verify the registered snapshot;
+:Generate recovery/local-protection material;
+:Build device access material and recovery backup\nwith one localAccessGenerationId;
+:Build local descriptor, trust checkpoint, digest,\nand optional encrypted sync credentials;
 
-:Read enrollmentKeySlot from remote snapshot;
-if (enrollment slot missing?) then (yes)
-  :Throw DeviceEnrollmentKeySlotNotFoundError;
+:Enter serialized activation boundary;
+:Save initialized local state as activation preparation;
+:Save lock metadata and schedule lockVault;
+if (scheduling or activation fails?) then (yes)
+  :Best effort cancel the matching scheduled lock;
+  :Best effort remove matching lock metadata;
+  :Best effort remove prepared local state\nonly if the snapshot digest still matches;
+  :Throw the original failure;
   stop
 endif
-if (enrollment already completed or pending device already trusted?) then (yes)
-  :Throw DeviceEnrollmentAlreadyCompletedError;
-  stop
-endif
+:Activate a fresh session identity and transfer session-key custody;
 
-:Verify pending public key digest;
-if (digest mismatch?) then (yes)
-  :Throw DeviceEnrollmentIntegrityError;
-  stop
-endif
-:Verify protected vault master key digest;
-if (digest mismatch?) then (yes)
-  :Throw DeviceEnrollmentIntegrityError;
-  stop
-endif
-:Find authorizer device slot;
-if (authorizer is not trusted?) then (yes)
-  :Throw DeviceEnrollmentIntegrityError;
-  stop
-endif
-:Verify enrollment authorization signature;
-if (authorization invalid?) then (yes)
-  :Throw DeviceEnrollmentIntegrityError;
-  stop
-endif
-
-:Derive enrollment protection key from bundle enrollmentSecret;
-:Unwrap vaultMasterKey from enrollment slot;
-:Decrypt remote snapshot content into vault;
-:Verify downloaded descriptor still equals remote descriptor;
-if (descriptor changed?) then (yes)
-  :Throw RemoteVaultSnapshotChangedError;
-  stop
-endif
-
-:Use pendingDeviceId and pending public/private signing keys;
-:Generate local vault display name;
-:Generate deviceSlotKey and local protection salts;
-:Derive localRootKey from new masterPassword;
-:Derive localKeysProtectionKey;
-:Wrap local keys payload for this device;
-:Generate recovery key and recovery mnemonic for this device;
-:Generate recovery local-keys protection salt;
-:Derive recovery local-keys protection key;
-:Wrap local keys payload for this device recovery backup;
-:Wrap vaultMasterKey for this device slot;
-:Add device profile to decrypted vault;
-:Build completed enrollment proof;
-:Build registered snapshot with new device slot and completed proof;
-:Encrypt registered vault content;
-:Sign registered snapshot with pending device private key;
-:Verify registered snapshot signature with pending public key;
-if (signature verification fails?) then (yes)
-  :Throw DeviceEnrollmentIntegrityError;
-  stop
-endif
-
-:Generate fresh localAccessGenerationId;
-if (localAccessGenerationId invalid?) then (yes)
-  :Throw DeviceAccessMaterialChangedError;
-  stop
-endif
-:Build device access material and recovery backup\nwith revision 1 and the same localAccessGenerationId;
-:Build local vault descriptor;
-:Save initialized local vault for new device\nincluding recovery backup;
-:Enter serialized session activation boundary;
-:Save vault lock task metadata;
-if (schedule lock task succeeds?) then (yes)
-  :Continue;
-else (no)
-  :Best effort remove matching lock task metadata;
-  :Best effort remove persisted local vault;
-  :Throw schedule failure;
-  stop
-endif
-if (activate unlocked session succeeds?) then (yes)
-  :Continue;
-else (no)
-  :Best effort cancel scheduled lock task;
-  :Best effort remove matching lock task metadata;
-  :Best effort remove persisted local vault;
-  :Throw original session activation failure;
-  stop
-endif
-
-if (upload registered snapshot succeeds?) then (yes)
-  :Return visible vault projection, snapshotVersionVector,\nrevisionTimestamp, deviceId,\nrecoveryMnemonicKey, syncUpload = complete;
-  stop
-else (no)
-  if (failure is RemoteVaultSnapshotChangedError?) then (yes)
-    :Enter shared lifecycle cleanup owner;
-    :Only while session ID, activation generation, and\nsource version still match, clear clipboard/task state,\nwipe and remove session records, then discard local snapshot;
-    if (session advanced?) then (yes)
-      :Preserve newer local state;
-      :Throw DeviceEnrollmentRollbackIncompleteError\nbecause rejected remote upload is not proven complete;
-      stop
+if (sync access exists?) then (yes)
+  :Upload registered snapshot against the authorized descriptor;
+  if (remote snapshot changed?) then (yes)
+    :Enter shared lifecycle cleanup and conditional-discard owner;
+    :Authenticate session ID, activation generation,\nvault ID, and source version;
+    if (originating session is current and cleanup succeeds?) then (yes)
+      :Clear clipboard/task state, wipe and remove session records;
+      :Remove local state by snapshot-digest CAS;
+      if (local discard completed?) then (yes)
+        :Throw DeviceEnrollmentRemoteSnapshotChangedError;
+        stop
+      else (no)
+        :Wipe original enrollment session buffers\nafter session custody ended;
+        :Throw DeviceEnrollmentRollbackIncompleteError;
+        stop
+      endif
     else (no)
-      :Wipe original enrollment session secrets\nwhose ownership is no longer transferred;
-      :If session was replaced or removed, preserve local state\nand throw DeviceEnrollmentRollbackIncompleteError;
-      :Otherwise throw DeviceEnrollmentRemoteSnapshotChangedError\nor DeviceEnrollmentRollbackIncompleteError;
-      stop
+      if (session advanced, replaced, or ownership unreadable?) then (yes)
+        :Preserve potentially active session-key custody and local state;
+        :Throw DeviceEnrollmentRollbackIncompleteError;
+        stop
+      else (unavailable or cleanup failed)
+        :Wipe original enrollment buffers after custody ended;
+        :Preserve local state and throw DeviceEnrollmentRollbackIncompleteError;
+        stop
+      endif
     endif
-  else (no)
-    :Retain the committed local enrollment;
-    :Return visible vault projection, snapshotVersionVector,\nrevisionTimestamp, deviceId,\nrecoveryMnemonicKey, syncUpload = pending;
-    stop
+  elseif (other upload failure?) then (yes)
+    :Keep committed local enrollment and mark syncUpload pending;
   endif
 endif
+
+:Best effort remove the pending enrollment request;
+:Always wipe ephemeral derivation/recovery buffers;
+:Wipe session buffers only when custody was not transferred\nor the originating session was definitively discarded;
+:Return visible vault projection, deviceId, recovery mnemonic,\nsnapshot vector/timestamp, and syncUpload status;
+stop
 @enduml

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
@@ -10,8 +10,13 @@ skinparam activity {
 }
 
 start
-:Input:\nenrollmentBundle, masterPassword, deviceName;
+:Input:\nenrollmentBundle, masterPassword, deviceName, lockAfterMs;
 :Source:\npackages/core/src/use-cases/device-trust/perform-device-enrollment.ts;
+:Validate lockAfterMs before pending-enrollment reads or crypto work;
+if (invalid delay?) then (yes)
+  :Throw InvalidVaultLockDelayError;
+  stop
+endif
 :Calculate masterPassword strength;
 if (password score below 4?) then (yes)
   :Throw InvalidNewMasterPasswordError;
@@ -114,9 +119,21 @@ endif
 :Build device access material and recovery backup\nwith revision 1 and the same localAccessGenerationId;
 :Build local vault descriptor;
 :Save initialized local vault for new device\nincluding recovery backup;
-if (commit unlocked session succeeds?) then (yes)
+:Enter serialized session activation boundary;
+:Save vault lock task metadata;
+if (schedule lock task succeeds?) then (yes)
   :Continue;
 else (no)
+  :Best effort remove matching lock task metadata;
+  :Best effort remove persisted local vault;
+  :Throw schedule failure;
+  stop
+endif
+if (activate unlocked session succeeds?) then (yes)
+  :Continue;
+else (no)
+  :Best effort cancel scheduled lock task;
+  :Best effort remove matching lock task metadata;
   :Best effort remove persisted local vault;
   :Throw original session activation failure;
   stop
@@ -127,12 +144,16 @@ if (upload registered snapshot succeeds?) then (yes)
   stop
 else (no)
   if (failure is RemoteVaultSnapshotChangedError?) then (yes)
-    :Discard session and local snapshot\nonly if they still match this enrollment;
+    :Enter shared lifecycle cleanup owner;
+    :Only while session ID, activation generation, and\nsource version still match, clear clipboard/task state,\nwipe and remove session records, then discard local snapshot;
     if (session advanced?) then (yes)
-      :Return visible vault projection, snapshotVersionVector,\nrevisionTimestamp, deviceId,\nrecoveryMnemonicKey, syncUpload = complete;
+      :Preserve newer local state;
+      :Throw DeviceEnrollmentRollbackIncompleteError\nbecause rejected remote upload is not proven complete;
       stop
     else (no)
-      :Throw DeviceEnrollmentRemoteSnapshotChangedError\nor DeviceEnrollmentRollbackIncompleteError;
+      :Wipe original enrollment session secrets\nwhose ownership is no longer transferred;
+      :If session was replaced or removed, preserve local state\nand throw DeviceEnrollmentRollbackIncompleteError;
+      :Otherwise throw DeviceEnrollmentRemoteSnapshotChangedError\nor DeviceEnrollmentRollbackIncompleteError;
       stop
     endif
   else (no)

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
@@ -16,88 +16,97 @@ participant "PerformDeviceEnrollmentUseCase" as UC
 participant "UnlockedVaultSessionService" as Session
 participant "VaultSessionActivationService" as Activation
 participant "VaultLifecycleCleanupService" as Lifecycle
+participant "VaultTrustService" as Trust
 participant "SyncProviderPort" as Sync
-participant "CryptoPort" as Crypto
-participant "IdPort" as Ids
+participant "CryptoPort / Bip39Port" as Crypto
+participant "IdPort / ClockPort" as System
 participant "VaultDisplayNamePort" as Names
 database "VaultLocalRepositoryPort" as LocalRepo
 database "VaultLockTaskRepositoryPort" as LockRepo
 participant "ScheduledTaskPort" as Tasks
 participant "ClipboardClearService" as Clipboard
-participant "Domain device mutation" as Domain
 
-Caller -> UC : execute(enrollmentBundle, masterPassword, deviceName, lockAfterMs)
+Caller -> UC : execute(enrollmentResponse, masterPassword,\ndeviceName, optional syncConfig, lockAfterMs)
 UC -> Activation : requireValidLockDelay(lockAfterMs)
-UC -> UC : calculate masterPassword strength
-break password score below 4
-  UC --> Caller : throw InvalidNewMasterPasswordError
+UC -> UC : assertNewMasterPasswordMeetsPolicy(masterPassword)
+UC -> LocalRepo : getPendingDeviceEnrollment(response.requestId)
+UC -> UC : validate response/pending identity, version, and suite
+UC -> LocalRepo : getLocalVaultDescriptor(vaultId)\ngetDeviceAccessMaterial(vaultId)
+UC -> Session : requireVaultCanBeActivated(vaultId)
+
+UC -> Crypto : derive pending-state protection\nand unwrap private device state
+UC -> Crypto : verify enrollment request and both device key pairs
+UC -> Trust : verifyTrustChain(anchor, response.snapshot.trustChain)
+UC -> Trust : verifySnapshot(response.snapshot, verifiedTrust)
+UC -> Crypto : verify target identity digests and\nopen target vault-key envelope
+UC -> Crypto : decrypt authorized snapshot content
+UC -> UC : add new device profile
+
+opt encrypted vault contains sync target
+  UC -> Sync : setup(syncConfig)
+  UC -> Sync : getLatestVaultSnapshotDescriptor(syncAccess, vaultId)
+  UC -> UC : require target and descriptor match authorized snapshot
 end
-UC -> Session : requireVaultCanBeActivated(bundle.vaultId)
-UC -> Sync : getLatestVaultSnapshotDescriptor(bundle.syncConfig, vaultId)
-UC -> UC : compare remote descriptor with bundle descriptor
-UC -> Sync : downloadVaultSnapshot(bundle.syncConfig, descriptor)
-UC -> Crypto : verifyVaultSnapshotSignature(remoteSnapshot, bundle.signerPublicKey)
-UC -> UC : validate enrollment slot, completion, digests, authorizer
-UC -> Crypto : verifyDeviceEnrollmentAuthorizationSignature(...)
-UC -> Crypto : deriveEnrollmentVaultMasterKeyProtectionKey(bundle.secret)
-UC -> Crypto : unwrapVaultMasterKey(enrollmentSlot.protectedVaultMasterKey, key)
-UC -> Crypto : decryptVaultSnapshotContent(remoteSnapshot.content, vaultMasterKey)
+
+UC -> Crypto : encrypt, sign, and verify registered snapshot
+UC -> Crypto : generate recovery/local-protection material\nand wrap local keys
+UC -> System : generate localAccessGenerationId
 UC -> Names : generateVaultDisplayName()
-UC -> Crypto : generate local salts, deviceSlotKey, wrap local keys
-UC -> Crypto : generate recovery key, derive recovery protection, wrap local keys
-UC -> Crypto : wrapVaultMasterKey(vaultMasterKey, deviceSlotProtectionKey)
-UC -> Domain : addDeviceProfileToVault(vault, pendingDeviceId, deviceName, now)
-UC -> Crypto : encryptVaultSnapshotContent(registeredVault, vaultMasterKey)
-UC -> Crypto : signVaultSnapshot(unsignedSnapshot, pendingPrivateSignKey)
-UC -> Crypto : verifyVaultSnapshotSignature(registeredSnapshot, pendingPublicSignKey)
-UC -> Ids : generateId() for fresh localAccessGenerationId
-UC -> UC : validate localAccessGenerationId
-UC -> LocalRepo : saveInitializedLocalVault(descriptor, accessMaterial, recoveryBackup, registeredSnapshot)
-UC -> Activation : activate(unlockedVault, registeredSnapshot.vector, lockAfterMs)
-Activation -> Session : enter serialized auto-lock activation boundary
+UC -> Trust : createCheckpoint(registered snapshot)
+UC -> Crypto : digest snapshot and optionally encrypt sync credentials
+
+UC -> Activation : activate(lease, unlockedVault, registered vector,\nlockAfterMs, prepare, rollback)
+Activation -> Session : activateWithAutoLock(...)
+Session -> Activation : invoke install-auto-lock callback
+Activation -> LocalRepo : prepare: saveInitializedLocalVault(...)
 Activation -> LockRepo : save(actionId, vaultId, expiresAt)
-Activation -> Tasks : scheduleTask(lockVault, runAt)
-alt scheduling fails
-  Activation -> LockRepo : removeIfActionIsActive(actionId)
-  UC -> LocalRepo : removePersistedLocalVault(vaultId)
-  UC --> Caller : throw scheduling failure
-else scheduled
-  Activation -> Session : activate(unlockedVault, registeredSnapshot.vector)
-  alt activation fails
-    Activation -> Tasks : cancelTask(lockVault)
-    Activation -> LockRepo : removeIfActionIsActive(actionId)
-    UC -> LocalRepo : removePersistedLocalVault(vaultId)
-    UC --> Caller : throw activation failure
-  else activated
-    UC -> Sync : uploadVaultSnapshot(syncConfig, registeredSnapshot, remoteDescriptor)
+Activation -> Tasks : scheduleTask(lockVault, actionId, expiresAt)
+alt scheduling or session activation fails
+  Session -> Activation : invoke rollback callback
+  Activation -> Tasks : best effort cancelTask(lockVault, actionId)
+  Activation -> LockRepo : best effort removeIfActionIsActive(actionId)
+  Activation -> LocalRepo : best effort removePersistedLocalVaultIfSnapshotMatches(...)
+  UC --> Caller : throw original activation failure
+else activated with fresh session identity
+  opt sync access exists
+    UC -> Sync : uploadVaultSnapshot(syncAccess, registeredSnapshot,\nauthorizedDescriptor)
     alt remote snapshot changed
       UC -> Lifecycle : discardIfSessionIsActive(sessionId, generation, vector)
-      Lifecycle -> Session : enter serialized conditional discard boundary
-      Session -> Lifecycle : run task cleanup callback while session is current
-      Lifecycle -> Clipboard : clear pending clipboard task
-      Lifecycle -> Tasks : cancel clearClipboard and lockVault tasks
-      Lifecycle -> LockRepo : removeIfActionIsActive(actionId)
-      Lifecycle -> Session : remove and wipe matching session records
-      alt session advanced
-        UC --> Caller : throw rollback-incomplete error; preserve newer local state
-      else session replaced or unavailable
-        UC --> Caller : throw rollback-incomplete error; preserve local state
-      else session current
-        UC -> LocalRepo : removePersistedLocalVaultIfSnapshotMatches(...)
-        alt rollback completed
-          UC -> UC : wipe original enrollment session secrets
-          UC --> Caller : throw remote-changed error
-        else rollback incomplete
-          UC -> UC : wipe original enrollment session secrets after invalidation
-          UC --> Caller : throw rollback-incomplete error
+      Lifecycle -> Session : enter serialized conditional discard
+      alt originating session is current
+        Session -> Lifecycle : run cleanup callback
+        Lifecycle -> Clipboard : clear matching clipboard task
+        Lifecycle -> Tasks : cancel matching clipboard and lock tasks
+        Lifecycle -> LockRepo : removeIfActionIsActive(lockActionId)
+        Session -> Session : wipe and remove matching session records
+        alt cleanup and session removal completed
+          Session -> LocalRepo : removePersistedLocalVaultIfSnapshotMatches(...)
+          alt local discard completed
+            UC --> Caller : throw DeviceEnrollmentRemoteSnapshotChangedError
+          else local discard incomplete
+            UC -> UC : wipe original buffers after session custody ended
+            UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
+          end
+        else cleanup or session removal incomplete
+          UC -> UC : wipe original buffers after session custody ended
+          UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
         end
+      else session advanced, replaced, or ownership unreadable
+        Session --> UC : non-discard outcome
+        UC -> UC : preserve potentially active session-key custody and local state
+        UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
+      else originating session unavailable
+        Session --> UC : session_unavailable
+        UC -> UC : wipe original buffers; preserve local state
+        UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
       end
     else other upload failure
-      UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=pending
-    else uploaded
-      UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=complete
+      UC -> UC : keep local enrollment; syncUpload = pending
     end
   end
+  UC -> LocalRepo : best effort removePendingDeviceEnrollment(requestId)
+  UC -> UC : wipe ephemeral buffers; retain transferred session buffers
+  UC --> Caller : visible vault, deviceId, recovery mnemonic,\nvector/timestamp, syncUpload status
 end
 
 @enduml

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
@@ -14,14 +14,20 @@ skinparam sequence {
 actor "New device caller" as Caller
 participant "PerformDeviceEnrollmentUseCase" as UC
 participant "UnlockedVaultSessionService" as Session
+participant "VaultSessionActivationService" as Activation
+participant "VaultLifecycleCleanupService" as Lifecycle
 participant "SyncProviderPort" as Sync
 participant "CryptoPort" as Crypto
 participant "IdPort" as Ids
 participant "VaultDisplayNamePort" as Names
 database "VaultLocalRepositoryPort" as LocalRepo
+database "VaultLockTaskRepositoryPort" as LockRepo
+participant "ScheduledTaskPort" as Tasks
+participant "ClipboardClearService" as Clipboard
 participant "Domain device mutation" as Domain
 
-Caller -> UC : execute(enrollmentBundle, masterPassword, deviceName)
+Caller -> UC : execute(enrollmentBundle, masterPassword, deviceName, lockAfterMs)
+UC -> Activation : requireValidLockDelay(lockAfterMs)
 UC -> UC : calculate masterPassword strength
 break password score below 4
   UC --> Caller : throw InvalidNewMasterPasswordError
@@ -47,28 +53,50 @@ UC -> Crypto : verifyVaultSnapshotSignature(registeredSnapshot, pendingPublicSig
 UC -> Ids : generateId() for fresh localAccessGenerationId
 UC -> UC : validate localAccessGenerationId
 UC -> LocalRepo : saveInitializedLocalVault(descriptor, accessMaterial, recoveryBackup, registeredSnapshot)
-UC -> Session : commit(unlockedVault, registeredSnapshot.vector)
-alt commit fails
+UC -> Activation : activate(unlockedVault, registeredSnapshot.vector, lockAfterMs)
+Activation -> Session : enter serialized auto-lock activation boundary
+Activation -> LockRepo : save(actionId, vaultId, expiresAt)
+Activation -> Tasks : scheduleTask(lockVault, runAt)
+alt scheduling fails
+  Activation -> LockRepo : removeIfActionIsActive(actionId)
   UC -> LocalRepo : removePersistedLocalVault(vaultId)
-  UC --> Caller : throw commit failure
-else committed
-  UC -> Sync : uploadVaultSnapshot(syncConfig, registeredSnapshot, remoteDescriptor)
-  alt remote snapshot changed
-    UC -> Session : discardIfSessionIsActive(...)
-    alt session advanced
-      UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=complete
-    else session current
-      UC -> LocalRepo : removePersistedLocalVaultIfSnapshotMatches(...)
-      alt rollback completed
-        UC --> Caller : throw remote-changed error
-      else rollback incomplete
-        UC --> Caller : throw rollback-incomplete error
+  UC --> Caller : throw scheduling failure
+else scheduled
+  Activation -> Session : activate(unlockedVault, registeredSnapshot.vector)
+  alt activation fails
+    Activation -> Tasks : cancelTask(lockVault)
+    Activation -> LockRepo : removeIfActionIsActive(actionId)
+    UC -> LocalRepo : removePersistedLocalVault(vaultId)
+    UC --> Caller : throw activation failure
+  else activated
+    UC -> Sync : uploadVaultSnapshot(syncConfig, registeredSnapshot, remoteDescriptor)
+    alt remote snapshot changed
+      UC -> Lifecycle : discardIfSessionIsActive(sessionId, generation, vector)
+      Lifecycle -> Session : enter serialized conditional discard boundary
+      Session -> Lifecycle : run task cleanup callback while session is current
+      Lifecycle -> Clipboard : clear pending clipboard task
+      Lifecycle -> Tasks : cancel clearClipboard and lockVault tasks
+      Lifecycle -> LockRepo : removeIfActionIsActive(actionId)
+      Lifecycle -> Session : remove and wipe matching session records
+      alt session advanced
+        UC --> Caller : throw rollback-incomplete error; preserve newer local state
+      else session replaced or unavailable
+        UC --> Caller : throw rollback-incomplete error; preserve local state
+      else session current
+        UC -> LocalRepo : removePersistedLocalVaultIfSnapshotMatches(...)
+        alt rollback completed
+          UC -> UC : wipe original enrollment session secrets
+          UC --> Caller : throw remote-changed error
+        else rollback incomplete
+          UC -> UC : wipe original enrollment session secrets after invalidation
+          UC --> Caller : throw rollback-incomplete error
+        end
       end
+    else other upload failure
+      UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=pending
+    else uploaded
+      UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=complete
     end
-  else other upload failure
-    UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=pending
-  else uploaded
-    UC --> Caller : visible vault projection, vector, timestamp, deviceId, recoveryMnemonicKey, syncUpload=complete
   end
 end
 

--- a/docs/v1/use-case/vault-lifecycle/delete-local-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/delete-local-vault.activity.puml
@@ -12,8 +12,12 @@ skinparam activity {
 start
 :Input:\nvaultId;
 :Source:\npackages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts;
-:Read unlocked vault session;
-if (session missing or different vault?) then (yes)
+:Read unlocked vault session and prove the target vault identity;
+if (session read fails?) then (yes)
+  :Preserve session/task state and throw the read failure;
+  stop
+endif
+if (session missing or identifies a different vault?) then (yes)
   :Throw VaultMustBeUnlockedForLocalDeletionError;
   stop
 endif
@@ -23,7 +27,7 @@ if (cleanup failed or active identity changed?) then (yes)
   :Withhold persisted deletion and throw cleanup failure;
   stop
 endif
-:Remove persisted local vault;
+:Inside the same serialized lifecycle boundary,\nremove persisted local vault;
 :Return void;
 stop
 @enduml

--- a/docs/v1/use-case/vault-lifecycle/delete-local-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/delete-local-vault.activity.puml
@@ -17,7 +17,12 @@ if (session missing or different vault?) then (yes)
   :Throw VaultMustBeUnlockedForLocalDeletionError;
   stop
 endif
-:Remove unlocked vault session;
+:Capture exact sessionId, vaultId, and activation generation;
+:Run shared lifecycle cleanup:\nclipboard, scheduled tasks, task metadata, session;
+if (cleanup failed or active identity changed?) then (yes)
+  :Withhold persisted deletion and throw cleanup failure;
+  stop
+endif
 :Remove persisted local vault;
 :Return void;
 stop

--- a/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
@@ -10,8 +10,13 @@ skinparam activity {
 }
 
 start
-:Input:\nmasterPassword, deviceName;
+:Input:\nmasterPassword, deviceName, lockAfterMs;
 :Source:\npackages/core/src/use-cases/vault-lifecycle/initialize-vault.ts;
+:Validate lockAfterMs before IDs, secrets, or persistence;
+if (invalid delay?) then (yes)
+  :Throw InvalidVaultLockDelayError;
+  stop
+endif
 :Calculate masterPassword strength;
 if (password score below 4?) then (yes)
   :Throw InvalidNewMasterPasswordError;
@@ -50,13 +55,26 @@ endif
 :Build local vault descriptor;
 :Build unlocked vault session object;
 :saveInitializedLocalVault(descriptor,\naccess material, recovery backup, snapshot);
+:Enter serialized session activation boundary;
+:Save vault lock task metadata;
 
-if (commit unlocked session succeeds?) then (yes)
+if (schedule lock task succeeds?) then (yes)
+  :Continue;
+else (no)
+  :Best effort remove matching lock task metadata;
+  :Best effort removePersistedLocalVault(vaultId);
+  :Throw schedule failure;
+  stop
+endif
+
+if (activate unlocked session succeeds?) then (yes)
   :Return recoveryMnemonicKey and vaultDisplayName;
   stop
 else (no)
+  :Best effort cancel scheduled lock task;
+  :Best effort remove matching lock task metadata;
   :Best effort removePersistedLocalVault(vaultId);
-  :Throw original session commit error;
+  :Throw original session activation error;
   stop
 endif
 @enduml

--- a/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
@@ -54,15 +54,16 @@ endif
 :Build device access material and recovery backup\nwith revision 1 and the same localAccessGenerationId;
 :Build local vault descriptor;
 :Build unlocked vault session object;
-:saveInitializedLocalVault(descriptor,\naccess material, recovery backup, snapshot);
 :Enter serialized session activation boundary;
+:saveInitializedLocalVault(descriptor,\naccess material, recovery backup, snapshot);
 :Save vault lock task metadata;
 
 if (schedule lock task succeeds?) then (yes)
   :Continue;
 else (no)
+  :Best effort cancel scheduled lock task;
   :Best effort remove matching lock task metadata;
-  :Best effort removePersistedLocalVault(vaultId);
+  :Best effort removePersistedLocalVaultIfSnapshotMatches(vaultId, snapshotDigest);
   :Throw schedule failure;
   stop
 endif
@@ -73,7 +74,7 @@ if (activate unlocked session succeeds?) then (yes)
 else (no)
   :Best effort cancel scheduled lock task;
   :Best effort remove matching lock task metadata;
-  :Best effort removePersistedLocalVault(vaultId);
+  :Best effort removePersistedLocalVaultIfSnapshotMatches(vaultId, snapshotDigest);
   :Throw original session activation error;
   stop
 endif

--- a/docs/v1/use-case/vault-lifecycle/lock-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/lock-vault.activity.puml
@@ -12,43 +12,33 @@ skinparam activity {
 start
 :Input:\noptional actionId;
 :Source:\npackages/core/src/use-cases/vault-lifecycle/lock-vault.ts;
-:Initialize executionError, sessionRemovalError,\nshouldRemoveSession = true;
-:Load pending vault lock task metadata;
+:Enter serialized session cleanup boundary;
+:Read active session material, preserving the first failure;
+:Load pending vault lock task metadata inside cleanup boundary;
 
-if (actionId provided and stored task actionId differs?) then (yes)
-  :Mark shouldRemoveSession = false;
-  :Skip cleanup body and continue to finally logic;
+if (scheduled action does not match current task or required vault?) then (yes)
+  :Return without cleanup as stale action;
+  stop
 else (no)
   :Load pending clipboard clear task;
-  :Try clipboardClear.clearTask(requireExpired = false);
+  :Attempt clipboardClear.clearTask(requireExpired = false);
   if (clipboard task existed?) then (yes)
-    :Try cancel scheduled clearClipboard task;
+    :Attempt cancellation of scheduled clearClipboard task;
   endif
-  :Remember clipboard cleanup error if any;
+  :Attempt clipboard task metadata removal after read/clear failure;
 
   if (vault lock task exists?) then (yes)
-    :Cancel scheduled lockVault task;
-    :Remove vault lock task metadata in finally;
+    :Attempt cancellation of scheduled lockVault task;
   endif
-
-  if (clipboard cleanup failed?) then (yes)
-    :Set executionError;
-  endif
+  :Attempt atomic vault lock task metadata removal\nonly if captured actionId is still active;
 endif
 
-if (shouldRemoveSession?) then (yes)
-  :Remove unlocked vault session;
-  if (session removal failed and no executionError?) then (yes)
-    :Set sessionRemovalError;
-  endif
-endif
+:Wipe known session material and remove both session records;
+:For manual lock with no stored session, invalidate any\nalready-authorized competing activation;
+:Continue every cleanup phase after failure;
 
-if (executionError exists?) then (yes)
-  :Throw executionError;
-  stop
-endif
-if (sessionRemovalError exists?) then (yes)
-  :Throw sessionRemovalError;
+if (any cleanup failed?) then (yes)
+  :Throw first meaningful failure;
   stop
 endif
 :Return void;

--- a/docs/v1/use-case/vault-lifecycle/unlock-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/unlock-vault.activity.puml
@@ -91,6 +91,7 @@ endif
 if (schedule lock task succeeds?) then (yes)
   :Continue;
 else (no)
+  :Best effort cancel scheduled lock task;
   :Best effort remove matching lock task metadata;
   :Throw schedule failure;
   stop

--- a/docs/v1/use-case/vault-lifecycle/unlock-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/unlock-vault.activity.puml
@@ -83,6 +83,7 @@ endif
 :Unwrap vaultMasterKey;
 :Decrypt snapshot content into vault;
 :Build unlocked vault session object;
+:Enter serialized session activation boundary;
 :Generate lock task actionId;
 :Compute lockScheduledAt = now + lockAfterMs;
 :Save vault lock task metadata;
@@ -90,7 +91,7 @@ endif
 if (schedule lock task succeeds?) then (yes)
   :Continue;
 else (no)
-  :Best effort remove lock task metadata;
+  :Best effort remove matching lock task metadata;
   :Throw schedule failure;
   stop
 endif
@@ -100,7 +101,7 @@ if (commit unlocked session succeeds?) then (yes)
   stop
 else (no)
   :Best effort cancel scheduled lock task;
-  :Best effort remove lock task metadata;
+  :Best effort remove matching lock task metadata;
   :Throw original session commit failure;
   stop
 endif

--- a/docs/v1/use-case/vault-lifecycle/unlock-vault.sequence.puml
+++ b/docs/v1/use-case/vault-lifecycle/unlock-vault.sequence.puml
@@ -45,6 +45,7 @@ UC -> Session : enter serialized auto-lock activation boundary
 UC -> LockRepo : save(actionId, vaultId, expiresAt)
 UC -> Tasks : scheduleTask(lockVault, runAt)
 alt scheduling fails
+  UC -> Tasks : cancelTask(lockVault)
   UC -> LockRepo : removeIfActionIsActive(actionId)
   UC --> Caller : throw schedule failure
 else scheduled

--- a/docs/v1/use-case/vault-lifecycle/unlock-vault.sequence.puml
+++ b/docs/v1/use-case/vault-lifecycle/unlock-vault.sequence.puml
@@ -41,16 +41,17 @@ UC -> Crypto : verifyDeviceSignKeyPair(material.publicSignKey, privateKey)
 UC -> Crypto : deriveDeviceSlotVaultMasterKeyProtectionKey(deviceSlotKey)
 UC -> Crypto : unwrapVaultMasterKey(protectedVaultMasterKey, protectionKey)
 UC -> Crypto : decryptVaultSnapshotContent(content, vaultMasterKey)
+UC -> Session : enter serialized auto-lock activation boundary
 UC -> LockRepo : save(actionId, vaultId, expiresAt)
 UC -> Tasks : scheduleTask(lockVault, runAt)
 alt scheduling fails
-  UC -> LockRepo : remove()
+  UC -> LockRepo : removeIfActionIsActive(actionId)
   UC --> Caller : throw schedule failure
 else scheduled
   UC -> Session : commit(unlockedVault, snapshotVersionVector)
   alt commit fails
     UC -> Tasks : cancelTask(lockVault)
-    UC -> LockRepo : remove()
+    UC -> LockRepo : removeIfActionIsActive(actionId)
     UC --> Caller : throw commit failure
   else committed
     UC --> Caller : visible vault projection, vaultId, deviceId,\nsnapshotVersionVector, revisionTimestamp

--- a/docs/v1/use-case/vault-lifecycle/vault-session.state-machine.puml
+++ b/docs/v1/use-case/vault-lifecycle/vault-session.state-machine.puml
@@ -29,7 +29,7 @@ Unlocked --> NoActiveSession : LockVaultUseCase runs shared lifecycle cleanup
 Unlocked --> Unlocked : stale lock actionId ignored
 Unlocked --> NoLocalVault : DeleteLocalVaultUseCase runs shared cleanup, then removes local vault
 Unlocked --> Unlocked : ChangeMasterPasswordUseCase rewraps local keys
-Unlocked --> Unlocked : Entry, sync, and trust mutations commit persisted snapshot
+Unlocked --> Unlocked : Entry, sync, and trust mutations commit persisted snapshot\nand advance activation generation
 
 NoLocalVault --> [*]
 
@@ -41,6 +41,7 @@ end note
 
 note right of Unlocked
 Hot secrets live in unlocked session material/payload.
+Each activation mints a fresh session ID and payload key.
 Use cases commit or remove session through UnlockedVaultSessionService.
 end note
 

--- a/docs/v1/use-case/vault-lifecycle/vault-session.state-machine.puml
+++ b/docs/v1/use-case/vault-lifecycle/vault-session.state-machine.puml
@@ -14,16 +14,20 @@ state "NoActiveSession" as NoActiveSession
 [*] --> NoActiveSession
 
 NoActiveSession --> Initializing : InitializeVaultUseCase
-Initializing --> Unlocked : save local vault + commit session
-Initializing --> NoActiveSession : commit fails / remove local vault
+Initializing --> Unlocked : save local vault + schedule lock + activate session
+Initializing --> NoActiveSession : schedule or activation fails / remove local vault
+
+NoActiveSession --> Enrolling : PerformDeviceEnrollmentUseCase
+Enrolling --> Unlocked : save local vault + schedule lock + activate session
+Enrolling --> NoActiveSession : schedule or activation fails / remove local vault
 
 NoActiveSession --> Unlocking : UnlockVaultUseCase
 Unlocking --> Unlocked : verify snapshot + decrypt + schedule lock + commit
 Unlocking --> NoActiveSession : validation, crypto, schedule, or commit failure
 
-Unlocked --> NoActiveSession : LockVaultUseCase removes unlocked session
+Unlocked --> NoActiveSession : LockVaultUseCase runs shared lifecycle cleanup
 Unlocked --> Unlocked : stale lock actionId ignored
-Unlocked --> NoLocalVault : DeleteLocalVaultUseCase removes session and local vault
+Unlocked --> NoLocalVault : DeleteLocalVaultUseCase runs shared cleanup, then removes local vault
 Unlocked --> Unlocked : ChangeMasterPasswordUseCase rewraps local keys
 Unlocked --> Unlocked : Entry, sync, and trust mutations commit persisted snapshot
 

--- a/packages/core/src/__tests__/fixtures/initialize-vault.ts
+++ b/packages/core/src/__tests__/fixtures/initialize-vault.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { InitializeVaultUseCase } from "../../use-cases/vault-lifecycle/initialize-vault";
 import { createCoreTestPorts } from "./ports";
 import { createCoreTestValues } from "./values";
@@ -13,7 +14,17 @@ export function createInitializeVaultTestContext() {
     ports.ids,
     ports.clock,
     ports.vaultDisplayName,
+    ports.scheduledTasks,
+    ports.vaultLockTasks,
   );
+
+  vi.mocked(ports.ids.generateId).mockReset();
+  vi.mocked(ports.ids.generateId)
+    .mockResolvedValueOnce(values.vaultId)
+    .mockResolvedValueOnce(values.deviceId)
+    .mockResolvedValueOnce(values.localAccessGenerationId)
+    .mockResolvedValueOnce(values.vaultLockActionId)
+    .mockResolvedValue(values.sessionId);
 
   return {
     values,

--- a/packages/core/src/__tests__/fixtures/ports.test.ts
+++ b/packages/core/src/__tests__/fixtures/ports.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { createCoreTestPorts } from "./ports";
+import { createCoreTestValues } from "./values";
+
+function expectFreshCopies(
+  first: ArrayBuffer,
+  second: ArrayBuffer,
+  source: ArrayBuffer,
+): void {
+  expect(first).not.toBe(second);
+  expect(first).not.toBe(source);
+  expect(second).not.toBe(source);
+  expect(new Uint8Array(first)).toEqual(new Uint8Array(source));
+  expect(new Uint8Array(second)).toEqual(new Uint8Array(source));
+}
+
+describe("createCoreTestPorts secret ownership", () => {
+  it("returns fresh caller-owned buffers from generators and derivations", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+
+    const [firstSignPair, secondSignPair] = await Promise.all([
+      ports.crypto.generateDeviceSignKeyPair(),
+      ports.crypto.generateDeviceSignKeyPair(),
+    ]);
+    expectFreshCopies(
+      firstSignPair.privateKey,
+      secondSignPair.privateKey,
+      values.devicePrivateSignKey,
+    );
+
+    const [firstVaultPair, secondVaultPair] = await Promise.all([
+      ports.crypto.generateDeviceVaultKeyPair(),
+      ports.crypto.generateDeviceVaultKeyPair(),
+    ]);
+    expectFreshCopies(
+      firstVaultPair.privateKey,
+      secondVaultPair.privateKey,
+      values.devicePrivateVaultKey,
+    );
+
+    const generationCases = await Promise.all([
+      Promise.all([
+        ports.crypto.generateDeviceLocalProtectionKey(),
+        ports.crypto.generateDeviceLocalProtectionKey(),
+      ]),
+      Promise.all([
+        ports.crypto.generateVaultMasterKey(),
+        ports.crypto.generateVaultMasterKey(),
+      ]),
+      Promise.all([
+        ports.crypto.generateRecoveryKey(),
+        ports.crypto.generateRecoveryKey(),
+      ]),
+      Promise.all([
+        ports.crypto.generateUnlockedVaultSessionPayloadKey(),
+        ports.crypto.generateUnlockedVaultSessionPayloadKey(),
+      ]),
+    ]);
+    const generationSources = [
+      values.deviceLocalProtectionKey,
+      values.vaultMasterKey,
+      values.recoverySecretKey,
+      values.unlockedVaultSessionPayloadKey,
+    ];
+
+    generationCases.forEach(([first, second], index) => {
+      expectFreshCopies(first, second, generationSources[index]!);
+    });
+
+    const [firstLocalRootKey, secondLocalRootKey] = await Promise.all([
+      ports.crypto.deriveLocalRootKey(
+        values.masterPassword,
+        values.masterPasswordSalt,
+      ),
+      ports.crypto.deriveLocalRootKey(
+        values.masterPassword,
+        values.masterPasswordSalt,
+      ),
+    ]);
+    expectFreshCopies(
+      firstLocalRootKey,
+      secondLocalRootKey,
+      values.localRootKey,
+    );
+
+    const [firstLocalProtectionKey, secondLocalProtectionKey] =
+      await Promise.all([
+        ports.crypto.deriveLocalKeysProtectionKey(
+          firstLocalRootKey,
+          values.localKeysProtectionSalt,
+        ),
+        ports.crypto.deriveLocalKeysProtectionKey(
+          secondLocalRootKey,
+          values.localKeysProtectionSalt,
+        ),
+      ]);
+    expectFreshCopies(
+      firstLocalProtectionKey,
+      secondLocalProtectionKey,
+      values.localKeysProtectionKey,
+    );
+
+    const [firstRecoveryProtectionKey, secondRecoveryProtectionKey] =
+      await Promise.all([
+        ports.crypto.deriveRecoveryLocalKeysProtectionKey(
+          values.recoverySecretKey,
+          values.recoveryLocalKeysProtectionSalt,
+        ),
+        ports.crypto.deriveRecoveryLocalKeysProtectionKey(
+          values.recoverySecretKey,
+          values.recoveryLocalKeysProtectionSalt,
+        ),
+      ]);
+    expectFreshCopies(
+      firstRecoveryProtectionKey,
+      secondRecoveryProtectionKey,
+      values.recoveryLocalKeysProtectionKey,
+    );
+
+    const [firstEnrollmentProtectionKey, secondEnrollmentProtectionKey] =
+      await Promise.all([
+        ports.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
+          firstLocalRootKey,
+          values.localKeysProtectionSalt,
+        ),
+        ports.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
+          secondLocalRootKey,
+          values.localKeysProtectionSalt,
+        ),
+      ]);
+    expectFreshCopies(
+      firstEnrollmentProtectionKey,
+      secondEnrollmentProtectionKey,
+      values.pendingEnrollmentProtectionKey,
+    );
+
+    const [firstRecoveryKey, secondRecoveryKey] = await Promise.all([
+      ports.bip39.mnemonicToRecoveryKey(values.recoveryMnemonicKey),
+      ports.bip39.mnemonicToRecoveryKey(values.recoveryMnemonicKey),
+    ]);
+    expectFreshCopies(
+      firstRecoveryKey,
+      secondRecoveryKey,
+      values.recoverySecretKey,
+    );
+  });
+});

--- a/packages/core/src/__tests__/fixtures/ports.test.ts
+++ b/packages/core/src/__tests__/fixtures/ports.test.ts
@@ -146,3 +146,27 @@ describe("createCoreTestPorts secret ownership", () => {
     );
   });
 });
+
+describe("createCoreTestPorts vault lock tasks", () => {
+  it("preserves the active task until its action ID matches removal", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const task = {
+      actionId: values.vaultLockActionId,
+      vaultId: values.vaultId,
+      expiresAt: values.timestamp + 60_000,
+    };
+
+    await ports.vaultLockTasks.save(task);
+
+    await expect(ports.vaultLockTasks.get()).resolves.toBe(task);
+    await expect(
+      ports.vaultLockTasks.removeIfActionIsActive("stale-action-id"),
+    ).resolves.toBe(false);
+    await expect(ports.vaultLockTasks.get()).resolves.toBe(task);
+    await expect(
+      ports.vaultLockTasks.removeIfActionIsActive(task.actionId),
+    ).resolves.toBe(true);
+    await expect(ports.vaultLockTasks.get()).resolves.toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -33,7 +33,10 @@ import type { IdPort } from "../../ports/system/id.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
-import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type {
+  VaultLockTask,
+  VaultLockTaskRepositoryPort,
+} from "../../ports/vault/vault-lock-task-repository.port";
 import type { UnlockedVaultSessionMaterialRepositoryPort } from "../../ports/session/unlocked-vault-session-material-repository.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
@@ -854,11 +857,17 @@ export function createCoreTestPorts(
     sessionServices.unlockedVaultSession,
     "cleanupActiveSession",
   ).mockImplementation(
-    async (requiredVaultId, invalidateWhenUnavailable, beforeRemoval) => {
+    async (
+      requiredVaultId,
+      invalidateWhenUnavailable,
+      beforeRemoval,
+      afterRemoval,
+    ) => {
       const result = await cleanupActiveSessionOriginal(
         requiredVaultId,
         invalidateWhenUnavailable,
         beforeRemoval,
+        afterRemoval,
       );
 
       if (result === "removed") {
@@ -891,10 +900,20 @@ export function createCoreTestPorts(
     checkVaultAccess: vi.fn(async () => "authentication_rejected" as const),
   };
 
+  let activeVaultLockTask: VaultLockTask | null = null;
   const vaultLockTasks: VaultLockTaskRepositoryPort = {
-    save: vi.fn(async () => undefined),
-    get: vi.fn(async () => null),
-    removeIfActionIsActive: vi.fn(async () => true),
+    save: vi.fn(async (task) => {
+      activeVaultLockTask = task;
+    }),
+    get: vi.fn(async () => activeVaultLockTask),
+    removeIfActionIsActive: vi.fn(async (actionId) => {
+      if (activeVaultLockTask?.actionId !== actionId) {
+        return false;
+      }
+
+      activeVaultLockTask = null;
+      return true;
+    }),
   };
 
   const vaultDisplayName: VaultDisplayNamePort = {

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -123,6 +123,13 @@ export function replaceVaultSnapshotAfterNextInitializedSave(
 export function createCoreTestPorts(
   values: CoreTestValues = createCoreTestValues(),
 ) {
+  const protectionKeyKinds = new WeakMap<
+    ArrayBuffer,
+    "local" | "new_local" | "recovery" | "rotated_recovery"
+  >();
+  const recoveryKeyKinds = new WeakMap<ArrayBuffer, "current" | "rotated">();
+  const freshBuffer = <T extends ArrayBuffer>(buffer: T): T =>
+    buffer.slice(0) as T;
   const saved: SavedCoreRecords = {
     vaultSnapshotDigest: values.vaultSnapshotDigest,
     deviceSyncCredentialState: values.encryptedDeviceSyncCredentialState,
@@ -178,15 +185,6 @@ export function createCoreTestPorts(
     },
   });
 
-  const deviceSignKeyPair: DeviceSignKeyPair = {
-    publicKey: values.devicePublicSignKey,
-    privateKey: values.devicePrivateSignKey,
-  };
-  const deviceVaultKeyPair: DeviceVaultKeyPair = {
-    publicKey: values.devicePublicVaultKey,
-    privateKey: values.devicePrivateVaultKey,
-  };
-
   const crypto: CryptoPort = {
     algorithmSuite: CURRENT_ALGORITHM_SUITE,
     generateRandomBytes: vi.fn(
@@ -194,15 +192,29 @@ export function createCoreTestPorts(
     ),
     hashSecretValue: vi.fn(async (value) => `hash:${value}`),
     compareSecretValueHash: vi.fn(async (left, right) => left === right),
-    generateDeviceSignKeyPair: vi.fn(async () => deviceSignKeyPair),
-    generateDeviceVaultKeyPair: vi.fn(async () => deviceVaultKeyPair),
-    generateDeviceLocalProtectionKey: vi.fn(
-      async () => values.deviceLocalProtectionKey,
+    generateDeviceSignKeyPair: vi.fn(
+      async (): Promise<DeviceSignKeyPair> => ({
+        publicKey: freshBuffer(values.devicePublicSignKey),
+        privateKey: freshBuffer(values.devicePrivateSignKey),
+      }),
     ),
-    generateVaultMasterKey: vi.fn(async () => values.vaultMasterKey),
-    generateRecoveryKey: vi.fn(async () => values.recoverySecretKey),
+    generateDeviceVaultKeyPair: vi.fn(
+      async (): Promise<DeviceVaultKeyPair> => ({
+        publicKey: freshBuffer(values.devicePublicVaultKey),
+        privateKey: freshBuffer(values.devicePrivateVaultKey),
+      }),
+    ),
+    generateDeviceLocalProtectionKey: vi.fn(
+      async () => freshBuffer(values.deviceLocalProtectionKey),
+    ),
+    generateVaultMasterKey: vi.fn(async () => freshBuffer(values.vaultMasterKey)),
+    generateRecoveryKey: vi.fn(async () => {
+      const recoveryKey = freshBuffer(values.recoverySecretKey);
+      recoveryKeyKinds.set(recoveryKey, "current");
+      return recoveryKey;
+    }),
     generateUnlockedVaultSessionPayloadKey: vi.fn(
-      async () => values.unlockedVaultSessionPayloadKey,
+      async () => freshBuffer(values.unlockedVaultSessionPayloadKey),
     ),
     generateMasterPasswordSalt: vi
       .fn()
@@ -215,50 +227,90 @@ export function createCoreTestPorts(
     generateRecoveryLocalKeysProtectionSalt: vi.fn(
       async () => values.recoveryLocalKeysProtectionSalt,
     ),
-    deriveLocalRootKey: vi
-      .fn()
-      .mockResolvedValueOnce(values.localRootKey)
-      .mockResolvedValue(values.newLocalRootKey),
-    deriveLocalKeysProtectionKey: vi.fn(async (_localRootKey, salt) =>
-      salt === values.newLocalKeysProtectionSalt
-        ? values.newLocalKeysProtectionKey
-        : values.localKeysProtectionKey,
+    deriveLocalRootKey: vi.fn(async (_masterPassword, salt) =>
+      freshBuffer(
+        salt === values.masterPasswordSalt
+          ? values.localRootKey
+          : values.newLocalRootKey,
+      ),
     ),
-    deriveRecoveryLocalKeysProtectionKey: vi.fn(async (_recoveryKey, salt) =>
-      salt === values.rotatedRecoveryLocalKeysProtectionSalt
-        ? values.rotatedRecoveryLocalKeysProtectionKey
-        : values.recoveryLocalKeysProtectionKey,
-    ),
+    deriveLocalKeysProtectionKey: vi.fn(async (_localRootKey, salt) => {
+      const isNew = salt === values.newLocalKeysProtectionSalt;
+      const protectionKey = freshBuffer(
+        isNew ? values.newLocalKeysProtectionKey : values.localKeysProtectionKey,
+      );
+      protectionKeyKinds.set(protectionKey, isNew ? "new_local" : "local");
+      return protectionKey;
+    }),
+    deriveRecoveryLocalKeysProtectionKey: vi.fn(async (_recoveryKey, salt) => {
+      const isRotated = salt === values.rotatedRecoveryLocalKeysProtectionSalt;
+      const protectionKey = freshBuffer(
+        isRotated
+          ? values.rotatedRecoveryLocalKeysProtectionKey
+          : values.recoveryLocalKeysProtectionKey,
+      );
+      protectionKeyKinds.set(
+        protectionKey,
+        isRotated ? "rotated_recovery" : "recovery",
+      );
+      return protectionKey;
+    }),
     deriveDeviceEnrollmentPrivateStateProtectionKey: vi.fn(
-      async () => values.pendingEnrollmentProtectionKey,
+      async () => freshBuffer(values.pendingEnrollmentProtectionKey),
     ),
     wrapLocalKeysPayload: vi.fn(async (_localKeysPayload, protectionKey) => {
-      if (protectionKey === values.newLocalKeysProtectionKey) {
+      const protectionKeyKind = protectionKeyKinds.get(protectionKey);
+
+      if (
+        protectionKey === values.newLocalKeysProtectionKey ||
+        protectionKeyKind === "new_local"
+      ) {
         return values.reprotectedLocalKeys;
       }
 
-      if (protectionKey === values.recoveryLocalKeysProtectionKey) {
+      if (
+        protectionKey === values.recoveryLocalKeysProtectionKey ||
+        protectionKeyKind === "recovery"
+      ) {
         return values.recoveryProtectedLocalKeys;
       }
 
-      if (protectionKey === values.rotatedRecoveryLocalKeysProtectionKey) {
+      if (
+        protectionKey === values.rotatedRecoveryLocalKeysProtectionKey ||
+        protectionKeyKind === "rotated_recovery"
+      ) {
         return values.rotatedRecoveryProtectedLocalKeys;
       }
 
       return values.protectedLocalKeys;
     }),
     unwrapLocalKeysPayload: vi.fn(async () => ({
-      devicePrivateSignKey: values.devicePrivateSignKey,
-      devicePrivateVaultKey: values.devicePrivateVaultKey,
-      deviceLocalProtectionKey: values.deviceLocalProtectionKey,
+      devicePrivateSignKey: values.devicePrivateSignKey.slice(
+        0,
+      ) as typeof values.devicePrivateSignKey,
+      devicePrivateVaultKey: values.devicePrivateVaultKey.slice(
+        0,
+      ) as typeof values.devicePrivateVaultKey,
+      deviceLocalProtectionKey: values.deviceLocalProtectionKey.slice(
+        0,
+      ) as typeof values.deviceLocalProtectionKey,
       vaultTrustAnchor: values.vaultTrustAnchor,
     })),
     wrapDeviceEnrollmentPrivateState: vi.fn(
       async () => values.protectedPendingDeviceEnrollment,
     ),
-    unwrapDeviceEnrollmentPrivateState: vi.fn(
-      async () => values.pendingDeviceEnrollmentPrivateState,
-    ),
+    unwrapDeviceEnrollmentPrivateState: vi.fn(async () => ({
+      ...values.pendingDeviceEnrollmentPrivateState,
+      devicePrivateSignKey: values.pendingDevicePrivateSignKey.slice(
+        0,
+      ) as typeof values.pendingDevicePrivateSignKey,
+      devicePrivateVaultKey: values.pendingDevicePrivateVaultKey.slice(
+        0,
+      ) as typeof values.pendingDevicePrivateVaultKey,
+      deviceLocalProtectionKey: values.pendingDeviceLocalProtectionKey.slice(
+        0,
+      ) as typeof values.pendingDeviceLocalProtectionKey,
+    })),
     createDeviceVaultKeyEnvelope: vi.fn(
       async (_vaultMasterKey, recipientPublicKey, context) =>
         recipientPublicKey === values.pendingDevicePublicVaultKey
@@ -273,7 +325,10 @@ export function createCoreTestPorts(
               vaultKeyGeneration: context.vaultKeyGeneration,
             },
     ),
-    openDeviceVaultKeyEnvelope: vi.fn(async () => values.vaultMasterKey),
+    openDeviceVaultKeyEnvelope: vi.fn(
+      async () =>
+        values.vaultMasterKey.slice(0) as typeof values.vaultMasterKey,
+    ),
     digestDevicePublicSignKey: vi.fn(async (publicKey) =>
       publicKey === values.pendingDevicePublicSignKey
         ? values.pendingDevicePublicSignKeyDigest
@@ -338,15 +393,19 @@ export function createCoreTestPorts(
 
   const bip39: Bip39Port = {
     recoveryKeyToMnemonic: vi.fn(async (recoveryKey) =>
-      recoveryKey === values.rotatedRecoverySecretKey
+      recoveryKey === values.rotatedRecoverySecretKey ||
+      recoveryKeyKinds.get(recoveryKey) === "rotated"
         ? values.rotatedRecoveryMnemonicKey
         : values.recoveryMnemonicKey,
     ),
-    mnemonicToRecoveryKey: vi.fn(async (recoveryMnemonicKey) =>
-      recoveryMnemonicKey === values.rotatedRecoveryMnemonicKey
-        ? values.rotatedRecoverySecretKey
-        : values.recoverySecretKey,
-    ),
+    mnemonicToRecoveryKey: vi.fn(async (recoveryMnemonicKey) => {
+      const isRotated = recoveryMnemonicKey === values.rotatedRecoveryMnemonicKey;
+      const recoveryKey = freshBuffer(
+        isRotated ? values.rotatedRecoverySecretKey : values.recoverySecretKey,
+      );
+      recoveryKeyKinds.set(recoveryKey, isRotated ? "rotated" : "current");
+      return recoveryKey;
+    }),
   };
 
   const vaultLocalRepository: VaultLocalRepositoryPort = {
@@ -693,6 +752,10 @@ export function createCoreTestPorts(
     sessionServices.unlockedVaultSession.activate.bind(
       sessionServices.unlockedVaultSession,
     );
+  const activateSessionWithAutoLockOriginal =
+    sessionServices.unlockedVaultSession.activateWithAutoLock.bind(
+      sessionServices.unlockedVaultSession,
+    );
   const getSessionOriginal = sessionServices.unlockedVaultSession.get.bind(
     sessionServices.unlockedVaultSession,
   );
@@ -702,6 +765,10 @@ export function createCoreTestPorts(
     );
   const removeSessionOriginal =
     sessionServices.unlockedVaultSession.remove.bind(
+      sessionServices.unlockedVaultSession,
+    );
+  const cleanupActiveSessionOriginal =
+    sessionServices.unlockedVaultSession.cleanupActiveSession.bind(
       sessionServices.unlockedVaultSession,
     );
 
@@ -723,6 +790,33 @@ export function createCoreTestPorts(
       };
 
       return sessionId;
+    },
+  );
+  vi.spyOn(
+    sessionServices.unlockedVaultSession,
+    "activateWithAutoLock",
+  ).mockImplementation(
+    async (
+      activationGeneration,
+      unlockedVault,
+      sourceSnapshotVersionVector,
+      installAutoLock,
+      rollbackAutoLock,
+    ) => {
+      const activatedSession = await activateSessionWithAutoLockOriginal(
+        activationGeneration,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+        installAutoLock,
+        rollbackAutoLock,
+      );
+      unlockedVaultSessionMirror = {
+        sessionId: activatedSession.sessionId,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      };
+
+      return activatedSession;
     },
   );
   vi.spyOn(
@@ -756,6 +850,24 @@ export function createCoreTestPorts(
       unlockedVaultSessionMirror = undefined;
     },
   );
+  vi.spyOn(
+    sessionServices.unlockedVaultSession,
+    "cleanupActiveSession",
+  ).mockImplementation(
+    async (requiredVaultId, invalidateWhenUnavailable, beforeRemoval) => {
+      const result = await cleanupActiveSessionOriginal(
+        requiredVaultId,
+        invalidateWhenUnavailable,
+        beforeRemoval,
+      );
+
+      if (result === "removed") {
+        unlockedVaultSessionMirror = undefined;
+      }
+
+      return result;
+    },
+  );
 
   const clock: ClockPort = {
     now: vi.fn(() => values.timestamp),
@@ -782,7 +894,7 @@ export function createCoreTestPorts(
   const vaultLockTasks: VaultLockTaskRepositoryPort = {
     save: vi.fn(async () => undefined),
     get: vi.fn(async () => null),
-    remove: vi.fn(async () => undefined),
+    removeIfActionIsActive: vi.fn(async () => true),
   };
 
   const vaultDisplayName: VaultDisplayNamePort = {

--- a/packages/core/src/__tests__/fixtures/values.ts
+++ b/packages/core/src/__tests__/fixtures/values.ts
@@ -44,7 +44,8 @@ import type {
 import type { Vault } from "../../domain/vault/vault";
 import type { Base64URLString } from "../../lib/base64Url.type";
 
-export const bytes = <T extends ArrayBuffer>() => new ArrayBuffer(1) as T;
+export const bytes = <T extends ArrayBuffer>() =>
+  new Uint8Array([2]).buffer as T;
 export const b64 = (value: string) => value as Base64URLString;
 
 export type CoreTestValues = ReturnType<typeof createCoreTestValues>;

--- a/packages/core/src/__tests__/fixtures/vault-entries.test.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createCoreTestPorts } from "./ports";
+import { createCoreTestValues } from "./values";
+import {
+  createUnlockedVaultWithEntries,
+  createVaultSnapshotServiceMock,
+} from "./vault-entries";
+
+describe("createVaultSnapshotServiceMock", () => {
+  it("directly restores a historical snapshot over its current replacement", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const service = createVaultSnapshotServiceMock(values, ports);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    const originalSnapshot = await service.requireLocalVaultSnapshot(
+      values.vaultId,
+    );
+    const persisted = await service.persistUnlockedVault(
+      values.vaultId,
+      unlockedVault,
+      originalSnapshot.metadata.snapshotVersionVector,
+    );
+
+    await service.restoreLocalVaultSnapshot(
+      originalSnapshot,
+      persisted.snapshot,
+      unlockedVault,
+    );
+
+    expect(ports.saved.vaultSnapshot).toBe(originalSnapshot);
+    expect(ports.saved.vaultSnapshotDigest).toBe(values.vaultSnapshotDigest);
+    expect(ports.saved.localVaultTrustCheckpoint).toBe(
+      values.localVaultTrustCheckpoint,
+    );
+  });
+
+  it("rejects a different snapshot with the current ID and vector", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const service = createVaultSnapshotServiceMock(values, ports);
+    const currentSnapshot = await service.requireLocalVaultSnapshot(
+      values.vaultId,
+    );
+    const sameVectorClone = {
+      ...currentSnapshot,
+      metadata: { ...currentSnapshot.metadata },
+    };
+
+    await expect(
+      service.prepareLocalVaultSnapshotRestore(
+        sameVectorClone,
+        createUnlockedVaultWithEntries(values, []),
+      ),
+    ).rejects.toThrow(
+      "Expected the prepared restore fixture state to match the current snapshot.",
+    );
+  });
+
+  it("creates a distinct coherent snapshot tuple for sequential persists", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const service = createVaultSnapshotServiceMock(values, ports);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+
+    const firstPersist = await service.persistUnlockedVault(
+      values.vaultId,
+      unlockedVault,
+      { [values.deviceId]: 1 },
+    );
+    const firstPreparedRestore = await service.prepareLocalVaultSnapshotRestore(
+      firstPersist.snapshot,
+      unlockedVault,
+    );
+    const secondPersist = await service.persistUnlockedVault(
+      values.vaultId,
+      unlockedVault,
+      firstPersist.snapshotVersionVector,
+    );
+
+    expect(secondPersist.trustedSnapshotContext.snapshotDigest).not.toBe(
+      firstPersist.trustedSnapshotContext.snapshotDigest,
+    );
+    expect(ports.saved.vaultSnapshotDigest).toBe(
+      secondPersist.trustedSnapshotContext.snapshotDigest,
+    );
+    expect(ports.saved.localVaultTrustCheckpoint?.payload).toMatchObject({
+      snapshotVersionVector: secondPersist.snapshotVersionVector,
+      snapshotDigest: secondPersist.trustedSnapshotContext.snapshotDigest,
+    });
+    expect(ports.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual(
+      secondPersist.snapshotVersionVector,
+    );
+
+    await service.restorePreparedLocalVaultSnapshot(
+      firstPreparedRestore,
+      secondPersist.trustedSnapshotContext.snapshotDigest,
+    );
+
+    expect(ports.saved.vaultSnapshot).toBe(firstPersist.snapshot);
+    expect(ports.saved.vaultSnapshotDigest).toBe(
+      firstPersist.trustedSnapshotContext.snapshotDigest,
+    );
+    expect(ports.saved.localVaultTrustCheckpoint).toBe(
+      firstPreparedRestore.checkpoint,
+    );
+    expect(ports.saved.localVaultTrustCheckpoint?.payload).toMatchObject({
+      snapshotVersionVector: firstPersist.snapshotVersionVector,
+      snapshotDigest: firstPersist.trustedSnapshotContext.snapshotDigest,
+    });
+  });
+});

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -4,9 +4,13 @@ import type { PasswordEntry } from "../../domain/entry/password-entry.type";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { Tag } from "../../domain/entry/tag.type";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
+import type { EncryptedDeviceSyncCredentialState } from "../../domain/sync";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import { incrementVersionVector } from "../../domain/versioning/version-vector.utils";
-import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
+import type {
+  PreparedLocalVaultSnapshotRestore,
+  VaultSnapshotService,
+} from "../../services/snapshot/vault-snapshot.service";
 import type { CoreTestPorts } from "./ports";
 import type { CoreTestValues } from "./values";
 
@@ -147,9 +151,11 @@ export function createVaultSnapshotServiceMock(
     signature: values.snapshotSignature,
   };
 
-  const restoreLocalVaultSnapshot = vi.fn(async (vaultSnapshot) => {
-    savedVaultSnapshot = vaultSnapshot;
-  });
+  const restoreLocalVaultSnapshot = vi.fn(
+    async (vaultSnapshot: VaultSnapshot) => {
+      savedVaultSnapshot = vaultSnapshot;
+    },
+  );
 
   return {
     requireCurrentSnapshotForUnlockedVault: vi.fn(
@@ -158,14 +164,19 @@ export function createVaultSnapshotServiceMock(
     requireLocalVaultSnapshot: vi.fn(async () => savedVaultSnapshot),
     restoreLocalVaultSnapshot,
     prepareLocalVaultSnapshotRestore: vi.fn(
-      async (vaultSnapshot, _unlockedVault, syncCredentialState) => ({
+      async (
+        vaultSnapshot: VaultSnapshot,
+        _unlockedVault: UnlockedVault,
+        syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
+      ) => ({
         snapshot: vaultSnapshot,
         checkpoint: values.localVaultTrustCheckpoint,
         ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
       }),
     ),
-    restorePreparedLocalVaultSnapshot: vi.fn(async (preparedRestore) =>
-      restoreLocalVaultSnapshot(preparedRestore.snapshot),
+    restorePreparedLocalVaultSnapshot: vi.fn(
+      async (preparedRestore: PreparedLocalVaultSnapshotRestore) =>
+        restoreLocalVaultSnapshot(preparedRestore.snapshot),
     ),
     persistUnlockedVault: vi.fn(
       async (

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -6,7 +6,10 @@ import type { Tag } from "../../domain/entry/tag.type";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
 import type { EncryptedDeviceSyncCredentialState } from "../../domain/sync";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
-import { incrementVersionVector } from "../../domain/versioning/version-vector.utils";
+import {
+  compareVersionVectors,
+  incrementVersionVector,
+} from "../../domain/versioning/version-vector.utils";
 import type {
   PreparedLocalVaultSnapshotRestore,
   VaultSnapshotService,
@@ -123,8 +126,9 @@ export function saveUnlockedVaultWithEntries(
 
 export function createVaultSnapshotServiceMock(
   values: CoreTestValues,
+  ports: CoreTestPorts,
 ): VaultSnapshotService {
-  let savedVaultSnapshot: VaultSnapshot = {
+  const initialVaultSnapshot: VaultSnapshot = {
     metadata: {
       id: values.vaultId,
       schemaVersion: 1,
@@ -150,34 +154,121 @@ export function createVaultSnapshotServiceMock(
     content: values.encryptedVault,
     signature: values.snapshotSignature,
   };
+  ports.saved.vaultSnapshot = initialVaultSnapshot;
+  ports.saved.localVaultTrustCheckpoint = values.localVaultTrustCheckpoint;
+  const snapshotRestoreStates = new WeakMap<
+    VaultSnapshot,
+    {
+      readonly snapshotDigest: string;
+      readonly checkpoint: PreparedLocalVaultSnapshotRestore["checkpoint"];
+    }
+  >();
+  snapshotRestoreStates.set(initialVaultSnapshot, {
+    snapshotDigest: values.vaultSnapshotDigest,
+    checkpoint: values.localVaultTrustCheckpoint,
+  });
+
+  const requireSavedVaultSnapshot = (): VaultSnapshot => {
+    const snapshot = ports.saved.vaultSnapshot;
+
+    if (snapshot === undefined) {
+      throw new Error("Expected the vault snapshot fixture to be initialized.");
+    }
+
+    return snapshot;
+  };
+
+  const prepareLocalVaultSnapshotRestore = vi.fn(
+    async (
+      vaultSnapshot: VaultSnapshot,
+      _unlockedVault: UnlockedVault,
+      syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
+    ): Promise<PreparedLocalVaultSnapshotRestore> => {
+      const checkpoint = ports.saved.localVaultTrustCheckpoint;
+
+      if (
+        ports.saved.vaultSnapshot !== vaultSnapshot ||
+        checkpoint === undefined ||
+        checkpoint.payload.vaultId !== vaultSnapshot.metadata.id ||
+        checkpoint.payload.snapshotDigest !== ports.saved.vaultSnapshotDigest ||
+        compareVersionVectors(
+          checkpoint.payload.snapshotVersionVector,
+          vaultSnapshot.metadata.snapshotVersionVector,
+        ) !== "equal"
+      ) {
+        throw new Error(
+          "Expected the prepared restore fixture state to match the current snapshot.",
+        );
+      }
+
+      return {
+        snapshot: vaultSnapshot,
+        checkpoint,
+        ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+      };
+    },
+  );
+
+  const restorePreparedLocalVaultSnapshot = vi.fn(
+    async (
+      preparedRestore: PreparedLocalVaultSnapshotRestore,
+      expectedSnapshotDigest: string,
+    ) => {
+      await ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest,
+        snapshot: preparedRestore.snapshot,
+        checkpoint: preparedRestore.checkpoint,
+        ...(preparedRestore.syncCredentialState === undefined
+          ? {}
+          : { syncCredentialState: preparedRestore.syncCredentialState }),
+      });
+      snapshotRestoreStates.set(preparedRestore.snapshot, {
+        snapshotDigest: preparedRestore.checkpoint.payload.snapshotDigest,
+        checkpoint: preparedRestore.checkpoint,
+      });
+    },
+  );
 
   const restoreLocalVaultSnapshot = vi.fn(
-    async (vaultSnapshot: VaultSnapshot) => {
-      savedVaultSnapshot = vaultSnapshot;
+    async (
+      vaultSnapshot: VaultSnapshot,
+      replacedSnapshot: VaultSnapshot,
+      _unlockedVault: UnlockedVault,
+      syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
+    ) => {
+      const restoreState = snapshotRestoreStates.get(vaultSnapshot);
+      const replacedState = snapshotRestoreStates.get(replacedSnapshot);
+
+      if (
+        restoreState === undefined ||
+        replacedState === undefined ||
+        ports.saved.vaultSnapshot !== replacedSnapshot ||
+        ports.saved.vaultSnapshotDigest !== replacedState.snapshotDigest
+      ) {
+        throw new Error(
+          "Expected the direct restore fixture state to match both snapshots.",
+        );
+      }
+
+      await restorePreparedLocalVaultSnapshot(
+        {
+          snapshot: vaultSnapshot,
+          checkpoint: restoreState.checkpoint,
+          ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+        },
+        replacedState.snapshotDigest,
+      );
     },
   );
 
   return {
-    requireCurrentSnapshotForUnlockedVault: vi.fn(
-      async () => savedVaultSnapshot,
+    requireCurrentSnapshotForUnlockedVault: vi.fn(async () =>
+      requireSavedVaultSnapshot(),
     ),
-    requireLocalVaultSnapshot: vi.fn(async () => savedVaultSnapshot),
+    requireLocalVaultSnapshot: vi.fn(async () => requireSavedVaultSnapshot()),
     restoreLocalVaultSnapshot,
-    prepareLocalVaultSnapshotRestore: vi.fn(
-      async (
-        vaultSnapshot: VaultSnapshot,
-        _unlockedVault: UnlockedVault,
-        syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
-      ) => ({
-        snapshot: vaultSnapshot,
-        checkpoint: values.localVaultTrustCheckpoint,
-        ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
-      }),
-    ),
-    restorePreparedLocalVaultSnapshot: vi.fn(
-      async (preparedRestore: PreparedLocalVaultSnapshotRestore) =>
-        restoreLocalVaultSnapshot(preparedRestore.snapshot),
-    ),
+    prepareLocalVaultSnapshotRestore,
+    restorePreparedLocalVaultSnapshot,
     persistUnlockedVault: vi.fn(
       async (
         _vaultId: string,
@@ -189,35 +280,63 @@ export function createVaultSnapshotServiceMock(
           readonly vaultKeyGeneration?: number;
         } = {},
       ) => {
-        savedVaultSnapshot = {
-          ...savedVaultSnapshot,
+        const currentVaultSnapshot = requireSavedVaultSnapshot();
+        const persistedVaultSnapshot = {
+          ...currentVaultSnapshot,
           metadata: {
-            ...savedVaultSnapshot.metadata,
+            ...currentVaultSnapshot.metadata,
             revisionTimestamp: values.timestamp + 1,
             snapshotVersionVector: incrementVersionVector(
               options.baseSnapshotVersionVector ??
-                savedVaultSnapshot.metadata.snapshotVersionVector,
+                currentVaultSnapshot.metadata.snapshotVersionVector,
               unlockedVault.deviceId,
             ),
             createdByDeviceId: unlockedVault.deviceId,
             vaultKeyGeneration:
               options.vaultKeyGeneration ??
-              savedVaultSnapshot.metadata.vaultKeyGeneration,
+              currentVaultSnapshot.metadata.vaultKeyGeneration,
           },
-          keySlots: options.keySlots ?? savedVaultSnapshot.keySlots,
+          keySlots: options.keySlots ?? currentVaultSnapshot.keySlots,
           content: values.encryptedVault,
           signature: values.snapshotSignature,
         };
+        const vectorDigestComponent = Object.entries(
+          persistedVaultSnapshot.metadata.snapshotVersionVector,
+        )
+          .sort(([leftDeviceId], [rightDeviceId]) =>
+            leftDeviceId.localeCompare(rightDeviceId),
+          )
+          .map(([deviceId, revision]) => `${deviceId}:${revision}`)
+          .join(",");
+        const persistedSnapshotDigest = `${values.vaultSnapshotDigest}:persisted:${persistedVaultSnapshot.metadata.revisionTimestamp}:${persistedVaultSnapshot.metadata.vaultKeyGeneration}:${vectorDigestComponent}`;
+        const persistedCheckpoint = {
+          ...values.localVaultTrustCheckpoint,
+          payload: {
+            ...values.localVaultTrustCheckpoint.payload,
+            vaultKeyGeneration:
+              persistedVaultSnapshot.metadata.vaultKeyGeneration,
+            snapshotVersionVector:
+              persistedVaultSnapshot.metadata.snapshotVersionVector,
+            snapshotDigest: persistedSnapshotDigest,
+          },
+        };
+        ports.saved.vaultSnapshot = persistedVaultSnapshot;
+        ports.saved.vaultSnapshotDigest = persistedSnapshotDigest;
+        ports.saved.localVaultTrustCheckpoint = persistedCheckpoint;
+        snapshotRestoreStates.set(persistedVaultSnapshot, {
+          snapshotDigest: persistedSnapshotDigest,
+          checkpoint: persistedCheckpoint,
+        });
 
         return {
           snapshotVersionVector:
-            savedVaultSnapshot.metadata.snapshotVersionVector,
-          revisionTimestamp: savedVaultSnapshot.metadata.revisionTimestamp,
+            persistedVaultSnapshot.metadata.snapshotVersionVector,
+          revisionTimestamp: persistedVaultSnapshot.metadata.revisionTimestamp,
           trustedSnapshotContext: {
-            snapshotDigest: values.vaultSnapshotDigest,
+            snapshotDigest: persistedSnapshotDigest,
             trust: values.verifiedVaultTrustState,
           },
-          snapshot: savedVaultSnapshot,
+          snapshot: persistedVaultSnapshot,
         };
       },
     ),

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -147,14 +147,26 @@ export function createVaultSnapshotServiceMock(
     signature: values.snapshotSignature,
   };
 
+  const restoreLocalVaultSnapshot = vi.fn(async (vaultSnapshot) => {
+    savedVaultSnapshot = vaultSnapshot;
+  });
+
   return {
     requireCurrentSnapshotForUnlockedVault: vi.fn(
       async () => savedVaultSnapshot,
     ),
     requireLocalVaultSnapshot: vi.fn(async () => savedVaultSnapshot),
-    restoreLocalVaultSnapshot: vi.fn(async (vaultSnapshot) => {
-      savedVaultSnapshot = vaultSnapshot;
-    }),
+    restoreLocalVaultSnapshot,
+    prepareLocalVaultSnapshotRestore: vi.fn(
+      async (vaultSnapshot, _unlockedVault, syncCredentialState) => ({
+        snapshot: vaultSnapshot,
+        checkpoint: values.localVaultTrustCheckpoint,
+        ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+      }),
+    ),
+    restorePreparedLocalVaultSnapshot: vi.fn(async (preparedRestore) =>
+      restoreLocalVaultSnapshot(preparedRestore.snapshot),
+    ),
     persistUnlockedVault: vi.fn(
       async (
         _vaultId: string,

--- a/packages/core/src/errors/vault-snapshot.errors.ts
+++ b/packages/core/src/errors/vault-snapshot.errors.ts
@@ -38,6 +38,16 @@ export class LocalVaultSnapshotChangedError extends Error {
   }
 }
 
+export class PersistedVaultRollbackIncompleteError extends Error {
+  override readonly name = "PersistedVaultRollbackIncompleteError";
+
+  constructor(vaultId: string, cause: unknown) {
+    super(`Vault "${vaultId}" persisted-state rollback did not complete.`, {
+      cause,
+    });
+  }
+}
+
 export class SnapshotSigningDeviceNotTrustedError extends Error {
   constructor(vaultId: string, deviceId: string) {
     super(`Device "${deviceId}" is not trusted to sign vault "${vaultId}".`);

--- a/packages/core/src/lib/secure-wipe.utils.test.ts
+++ b/packages/core/src/lib/secure-wipe.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { secureWipe } from "./secure-wipe.utils";
+import { bestEffortWipeArrayBuffers, secureWipe } from "./secure-wipe.utils";
 
 describe("secureWipe", () => {
   it("zeros a buffer filled with non-zero data", () => {
@@ -26,5 +26,18 @@ describe("secureWipe", () => {
     crypto.getRandomValues(buffer);
     secureWipe(buffer);
     expect(buffer.length).toBe(64);
+  });
+});
+
+describe("bestEffortWipeArrayBuffers", () => {
+  it("continues wiping after encountering a detached buffer", () => {
+    const detached = new Uint8Array([1]).buffer;
+    structuredClone(detached, { transfer: [detached] });
+    const remaining = new Uint8Array([7]).buffer;
+
+    expect(() =>
+      bestEffortWipeArrayBuffers([detached, remaining]),
+    ).not.toThrow();
+    expect(Array.from(new Uint8Array(remaining))).toEqual([0]);
   });
 });

--- a/packages/core/src/lib/secure-wipe.utils.ts
+++ b/packages/core/src/lib/secure-wipe.utils.ts
@@ -15,3 +15,19 @@
 export function secureWipe(buffer: Uint8Array): void {
   buffer.fill(0);
 }
+
+export function bestEffortWipeArrayBuffers(
+  buffers: readonly (ArrayBuffer | undefined)[],
+): void {
+  for (const buffer of buffers) {
+    if (buffer === undefined) {
+      continue;
+    }
+
+    try {
+      secureWipe(new Uint8Array(buffer));
+    } catch {
+      // Best-effort wiping must not prevent the owning cleanup from continuing.
+    }
+  }
+}

--- a/packages/core/src/ports/crypto/bip39.port.ts
+++ b/packages/core/src/ports/crypto/bip39.port.ts
@@ -2,6 +2,11 @@ import type { RecoveryKeyMnemonic } from "../../domain/recovery/bip39-mnemonic";
 import type { RecoverySecretKey } from "../../domain/recovery/brand-keys";
 
 export interface Bip39Port {
+  /**
+   * Implementations must not retain raw recovery-key inputs after resolution.
+   * Decoded recovery keys are fresh caller-owned buffers and must not alias
+   * adapter state or a value returned by an earlier call.
+   */
   recoveryKeyToMnemonic: (
     recoverySecretKey: RecoverySecretKey,
   ) => Promise<RecoveryKeyMnemonic>;

--- a/packages/core/src/ports/crypto/crypto.port.ts
+++ b/packages/core/src/ports/crypto/crypto.port.ts
@@ -49,12 +49,12 @@ import type {
 import type { Vault } from "../../domain/vault/vault";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 
+/**
+ * Raw buffers returned by generation, derivation, envelope opening, and
+ * unwrapping are fresh caller-owned values. Implementations must not retain
+ * or alias those returned buffers after the promise resolves.
+ */
 export interface CryptoPort {
-  /**
-   * Raw buffers returned by generation, derivation, envelope opening, and
-   * unwrapping are fresh caller-owned values. Implementations must not retain
-   * or alias those returned buffers after the promise resolves.
-   */
   // Suite
   algorithmSuite: AlgorithmSuite;
 

--- a/packages/core/src/ports/crypto/crypto.port.ts
+++ b/packages/core/src/ports/crypto/crypto.port.ts
@@ -50,6 +50,11 @@ import type { Vault } from "../../domain/vault/vault";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 
 export interface CryptoPort {
+  /**
+   * Raw buffers returned by generation, derivation, envelope opening, and
+   * unwrapping are fresh caller-owned values. Implementations must not retain
+   * or alias those returned buffers after the promise resolves.
+   */
   // Suite
   algorithmSuite: AlgorithmSuite;
 

--- a/packages/core/src/ports/session/unlocked-vault-session-material-repository.port.ts
+++ b/packages/core/src/ports/session/unlocked-vault-session-material-repository.port.ts
@@ -4,8 +4,15 @@ import type { UnlockedVaultSessionMaterial } from "../../domain/session/unlocked
  * Stores the active unlocked-vault session material.
  *
  * This record contains the hot secret material required to decrypt and operate
- * on the encrypted unlocked-vault session payload. Implementations should use
- * volatile, session-scoped storage and expose only the active record.
+ * on the encrypted unlocked-vault session payload. A successful save transfers
+ * custody of the material buffers to the repository while the serialized
+ * session service remains their wipe owner. Within one repository instance,
+ * subsequent reads must return the same material identity until it is replaced
+ * or removed. An implementation that restores serialized state must cache the
+ * first decoded material identity. This lets the session owner wipe every
+ * outstanding reference before repository removal.
+ * Implementations should use volatile, session-scoped storage and expose only
+ * the active record.
  */
 export interface UnlockedVaultSessionMaterialRepositoryPort {
   saveUnlockedVaultSessionMaterial: (

--- a/packages/core/src/ports/vault/vault-lock-task-repository.port.ts
+++ b/packages/core/src/ports/vault/vault-lock-task-repository.port.ts
@@ -7,5 +7,6 @@ export type VaultLockTask = {
 export interface VaultLockTaskRepositoryPort {
   save: (task: VaultLockTask) => Promise<void>;
   get: () => Promise<VaultLockTask | null>;
-  remove: () => Promise<void>;
+  /** Atomically removes only the task whose current action ID matches. */
+  removeIfActionIsActive: (actionId: string) => Promise<boolean>;
 }

--- a/packages/core/src/services/session/index.ts
+++ b/packages/core/src/services/session/index.ts
@@ -1,1 +1,3 @@
 export * from "./unlocked-vault-session.service";
+export * from "./vault-lifecycle-cleanup.service";
+export * from "./vault-session-activation.service";

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -461,9 +461,10 @@ describe("UnlockedVaultSessionService", () => {
     }
   });
 
-  it("commits an active session using the existing session id and payload key", async () => {
+  it("reactivates the active vault with a fresh session id and payload key", async () => {
     const ctx = createContext();
-    ctx.ports.saved.unlockedVaultSessionMaterial = createActiveMaterial(ctx);
+    const activeMaterial = createActiveMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = activeMaterial;
 
     await ctx.service.activate(
       0,
@@ -471,18 +472,18 @@ describe("UnlockedVaultSessionService", () => {
       ctx.sourceSnapshotVersionVector,
     );
 
-    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(ctx.ports.ids.generateId).toHaveBeenCalledOnce();
     expect(
       ctx.ports.crypto.generateUnlockedVaultSessionPayloadKey,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledOnce();
     expect(ctx.ports.saved.encryptedUnlockedVaultSessionPayload).toEqual({
-      sessionId: "active-session-id",
+      sessionId: ctx.values.sessionId,
       vaultId: ctx.values.vaultId,
       sourceSnapshotVersionVector: ctx.sourceSnapshotVersionVector,
       content: ctx.values.encryptedUnlockedVaultSessionPayload,
     });
     expect(ctx.ports.saved.unlockedVaultSessionMaterial).toEqual({
-      sessionId: "active-session-id",
+      sessionId: ctx.values.sessionId,
       vaultId: ctx.values.vaultId,
       sourceSnapshotVersionVector: ctx.sourceSnapshotVersionVector,
       deviceId: ctx.values.deviceId,
@@ -494,6 +495,56 @@ describe("UnlockedVaultSessionService", () => {
       trustedSnapshotContext: ctx.session.unlockedVault.trustedSnapshotContext,
       vaultTrustAnchor: ctx.session.unlockedVault.vaultTrustAnchor,
     });
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.payloadKey).not.toBe(
+      activeMaterial.payloadKey,
+    );
+  });
+
+  it("rejects work authorized before same-vault reactivation", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const staleContext = await ctx.service.requireUnlockedVaultContext(
+      ctx.values.vaultId,
+      "test operation",
+    );
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+    vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce(
+      "replacement-session-id",
+    );
+
+    await ctx.service.activate(
+      activationGeneration,
+      staleContext.unlockedVault,
+      staleContext.sourceSnapshotVersionVector,
+    );
+
+    const persist = vi.fn(async () => undefined);
+    await expect(
+      ctx.service.persistForActiveSession(
+        staleContext.sessionId,
+        ctx.values.vaultId,
+        persist,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+    await expect(
+      ctx.service.commitPersistedSnapshot(
+        staleContext.sessionId,
+        staleContext.unlockedVault,
+        staleContext.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.sessionId).toBe(
+      "replacement-session-id",
+    );
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload?.sessionId,
+    ).toBe("replacement-session-id");
   });
 
   it("rejects committing a different vault while another vault is active", async () => {
@@ -580,9 +631,7 @@ describe("UnlockedVaultSessionService", () => {
     ).mock.results[0]!.value;
     expect(Array.from(new Uint8Array(payloadKey))).toEqual([0]);
     expect(
-      Array.from(
-        new Uint8Array(ctx.values.unlockedVaultSessionPayloadKey),
-      ),
+      Array.from(new Uint8Array(ctx.values.unlockedVaultSessionPayloadKey)),
     ).toEqual([2]);
   });
 
@@ -686,7 +735,34 @@ describe("UnlockedVaultSessionService", () => {
     ).toBe("new-session-id");
   });
 
-  it("restores state for a stale session and invalidates its replacement", async () => {
+  it("invalidates an activation lease when the active session advances", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+
+    await ctx.service.commitPersistedSnapshot(
+      ctx.values.sessionId,
+      ctx.session.unlockedVault,
+      { [ctx.values.deviceId]: 8 },
+    );
+
+    await expect(
+      ctx.service.activate(
+        activationGeneration,
+        ctx.session.unlockedVault,
+        ctx.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toMatchObject({
+      sourceSnapshotVersionVector: { [ctx.values.deviceId]: 8 },
+    });
+  });
+
+  it("does not restore state or invalidate a replacement session", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
     ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
@@ -707,15 +783,100 @@ describe("UnlockedVaultSessionService", () => {
     const restored = await ctx.service.restorePersistedState(
       ctx.values.sessionId,
       ctx.values.vaultId,
+      ctx.sourceSnapshotVersionVector,
       restore,
     );
 
-    expect(restored).toBe(true);
+    expect(restored).toBe("session_advanced");
+    expect(restore).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.sessionId).toBe(
+      "new-session-id",
+    );
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload?.sessionId,
+    ).toBe("new-session-id");
+  });
+
+  it("does not restore state or invalidate an advanced session", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    await ctx.service.commitPersistedSnapshot(
+      ctx.values.sessionId,
+      ctx.session.unlockedVault,
+      { [ctx.values.deviceId]: 8 },
+    );
+
+    const restore = vi.fn();
+    const restored = await ctx.service.restorePersistedState(
+      ctx.values.sessionId,
+      ctx.values.vaultId,
+      ctx.sourceSnapshotVersionVector,
+      restore,
+    );
+
+    expect(restored).toBe("session_advanced");
+    expect(restore).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toMatchObject({
+      sessionId: ctx.values.sessionId,
+      sourceSnapshotVersionVector: { [ctx.values.deviceId]: 8 },
+    });
+  });
+
+  it("reports rollback failure without restoring when session ownership cannot be read", async () => {
+    const ctx = createContext();
+    const material = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const restore = vi.fn();
+
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(new Error("material read failed"));
+
+    await expect(
+      ctx.service.restorePersistedState(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        ctx.sourceSnapshotVersionVector,
+        restore,
+      ),
+    ).resolves.toBe("rollback_failed");
+
+    expect(restore).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBe(material);
+    expect(ctx.ports.saved.encryptedUnlockedVaultSessionPayload).toBeDefined();
+  });
+
+  it("invalidates a pending activation lease before restoring without active material", async () => {
+    const ctx = createContext();
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+    const restore = vi.fn(async () => undefined);
+
+    await expect(
+      ctx.service.restorePersistedState(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        ctx.sourceSnapshotVersionVector,
+        restore,
+      ),
+    ).resolves.toBe("restored");
+    await expect(
+      ctx.service.activate(
+        activationGeneration,
+        ctx.session.unlockedVault,
+        ctx.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+
     expect(restore).toHaveBeenCalledOnce();
     expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeUndefined();
-    expect(
-      ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
-    ).toBeUndefined();
   });
 
   it.each([
@@ -735,6 +896,7 @@ describe("UnlockedVaultSessionService", () => {
       await ctx.service.restorePersistedState(
         ctx.values.sessionId,
         ctx.values.vaultId,
+        ctx.sourceSnapshotVersionVector,
         restore,
       );
 
@@ -784,6 +946,49 @@ describe("UnlockedVaultSessionService", () => {
     expect(
       ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
     ).toBeUndefined();
+  });
+
+  it("invalidates a pending activation lease before active-session persistence starts", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const activationGeneration = await ctx.service.requireVaultCanBeActivated(
+      ctx.values.vaultId,
+    );
+    let continuePersistence!: () => void;
+    let markPersistenceStarted!: () => void;
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve;
+    });
+    const persistenceCanContinue = new Promise<void>((resolve) => {
+      continuePersistence = resolve;
+    });
+    const persist = vi.fn(async () => {
+      markPersistenceStarted();
+      await persistenceCanContinue;
+    });
+    const persistence = ctx.service.persistForActiveSession(
+      ctx.values.sessionId,
+      ctx.values.vaultId,
+      persist,
+    );
+    await persistenceStarted;
+    const staleActivation = ctx.service.activate(
+      activationGeneration,
+      ctx.session.unlockedVault,
+      ctx.sourceSnapshotVersionVector,
+    );
+    continuePersistence();
+    await persistence;
+
+    await expect(staleActivation).rejects.toBeInstanceOf(
+      UnlockedVaultSessionExpiredError,
+    );
+    expect(persist).toHaveBeenCalledOnce();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial?.sessionId).toBe(
+      ctx.values.sessionId,
+    );
   });
 
   it("keeps local enrollment state when session removal fails during discard", async () => {
@@ -859,6 +1064,70 @@ describe("UnlockedVaultSessionService", () => {
     expect(ctx.ports.saved.unlockedVaultSessionMaterial).toMatchObject({
       sourceSnapshotVersionVector: { [ctx.values.deviceId]: 8 },
     });
+  });
+
+  it("preserves an advanced session when its material cannot be read during discard", async () => {
+    const ctx = createContext();
+    const material = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const beforeRemoval = vi.fn(async () => undefined);
+    const discard = vi.fn(async () => true);
+
+    await ctx.service.commitPersistedSnapshot(
+      ctx.values.sessionId,
+      ctx.session.unlockedVault,
+      { [ctx.values.deviceId]: 8 },
+    );
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(new Error("material read failed"));
+
+    await expect(
+      ctx.service.discardIfSessionIsActive(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        0,
+        ctx.sourceSnapshotVersionVector,
+        beforeRemoval,
+        discard,
+      ),
+    ).resolves.toBe("session_advanced");
+
+    expect(beforeRemoval).not.toHaveBeenCalled();
+    expect(discard).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeDefined();
+  });
+
+  it("does not discard when current session ownership cannot be read", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const beforeRemoval = vi.fn(async () => undefined);
+    const discard = vi.fn(async () => true);
+
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(new Error("material read failed"));
+
+    await expect(
+      ctx.service.discardIfSessionIsActive(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        0,
+        ctx.sourceSnapshotVersionVector,
+        beforeRemoval,
+        discard,
+      ),
+    ).resolves.toBe("session_advanced");
+
+    expect(beforeRemoval).not.toHaveBeenCalled();
+    expect(discard).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeDefined();
   });
 
   it("distinguishes a removed session generation from an advanced snapshot", async () => {

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -267,11 +267,22 @@ describe("UnlockedVaultSessionService", () => {
 
   it("fails when session material exists without encrypted payload", async () => {
     const ctx = createContext();
-    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    const material = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
 
     await expect(ctx.service.get()).rejects.toBeInstanceOf(
       UnlockedVaultSessionInvalidError,
     );
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeUndefined();
+    for (const secret of [
+      material.vaultMasterKey,
+      material.devicePrivateSignKey,
+      material.devicePrivateVaultKey,
+      material.deviceLocalProtectionKey,
+      material.payloadKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).toEqual([0]);
+    }
   });
 
   it("rejects mismatched session material and encrypted payload", async () => {
@@ -351,6 +362,10 @@ describe("UnlockedVaultSessionService", () => {
 
     expect(caught).toBeInstanceOf(UnlockedVaultSessionInvalidError);
     expect((caught as Error).cause).toBe(decryptError);
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBeUndefined();
+    expect(
+      ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
+    ).toBeUndefined();
   });
 
   it("commits a new unlocked vault session as encrypted payload then material", async () => {
@@ -409,6 +424,41 @@ describe("UnlockedVaultSessionService", () => {
           .saveUnlockedVaultSessionMaterial,
       ).mock.invocationCallOrder[0],
     );
+  });
+
+  it("wipes the exact material identity retained after successful activation", async () => {
+    const ctx = createContext();
+
+    await ctx.service.activate(
+      0,
+      ctx.session.unlockedVault,
+      ctx.sourceSnapshotVersionVector,
+    );
+    const issuedSession = await ctx.service.get();
+    const ownedMaterial = ctx.ports.saved.unlockedVaultSessionMaterial;
+
+    if (issuedSession === null || ownedMaterial === undefined) {
+      throw new Error("Expected activated session material.");
+    }
+
+    expect(issuedSession.unlockedVault.vaultMasterKey).toBe(
+      ownedMaterial.vaultMasterKey,
+    );
+    expect(issuedSession.unlockedVault.devicePrivateSignKey).toBe(
+      ownedMaterial.devicePrivateSignKey,
+    );
+
+    await ctx.service.remove();
+
+    for (const secret of [
+      issuedSession.unlockedVault.vaultMasterKey,
+      issuedSession.unlockedVault.devicePrivateSignKey,
+      issuedSession.unlockedVault.devicePrivateVaultKey,
+      issuedSession.unlockedVault.deviceLocalProtectionKey,
+      ownedMaterial.payloadKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).toEqual([0]);
+    }
   });
 
   it("commits an active session using the existing session id and payload key", async () => {
@@ -525,6 +575,15 @@ describe("UnlockedVaultSessionService", () => {
       ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
         .removeEncryptedUnlockedVaultSessionPayload,
     ).not.toHaveBeenCalled();
+    const payloadKey = await vi.mocked(
+      ctx.ports.crypto.generateUnlockedVaultSessionPayloadKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(payloadKey))).toEqual([0]);
+    expect(
+      Array.from(
+        new Uint8Array(ctx.values.unlockedVaultSessionPayloadKey),
+      ),
+    ).toEqual([2]);
   });
 
   it("invalidates the session when persisted snapshot commit fails", async () => {
@@ -554,6 +613,10 @@ describe("UnlockedVaultSessionService", () => {
       ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
         .removeEncryptedUnlockedVaultSessionPayload,
     ).toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a persisted snapshot commit after the session was removed", async () => {
@@ -725,7 +788,8 @@ describe("UnlockedVaultSessionService", () => {
 
   it("keeps local enrollment state when session removal fails during discard", async () => {
     const ctx = createContext();
-    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    const material = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
     ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
       createEncryptedPayload(ctx);
     const removeError = new Error("material removal failed");
@@ -740,15 +804,28 @@ describe("UnlockedVaultSessionService", () => {
       ctx.service.discardIfSessionIsActive(
         ctx.values.sessionId,
         ctx.values.vaultId,
+        0,
         ctx.sourceSnapshotVersionVector,
+        async () => undefined,
         discard,
       ),
     ).resolves.toBe("rollback_failed");
 
     expect(discard).not.toHaveBeenCalled();
-    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toEqual(
-      createMaterial(ctx),
-    );
+    expect(ctx.ports.saved.unlockedVaultSessionMaterial).toBe(material);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    for (const secret of [
+      material.vaultMasterKey,
+      material.devicePrivateSignKey,
+      material.devicePrivateVaultKey,
+      material.deviceLocalProtectionKey,
+      material.payloadKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).toEqual([0]);
+    }
     expect(
       ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
     ).toBeUndefined();
@@ -771,7 +848,9 @@ describe("UnlockedVaultSessionService", () => {
       ctx.service.discardIfSessionIsActive(
         ctx.values.sessionId,
         ctx.values.vaultId,
+        0,
         ctx.sourceSnapshotVersionVector,
+        async () => undefined,
         discard,
       ),
     ).resolves.toBe("session_advanced");
@@ -780,6 +859,28 @@ describe("UnlockedVaultSessionService", () => {
     expect(ctx.ports.saved.unlockedVaultSessionMaterial).toMatchObject({
       sourceSnapshotVersionVector: { [ctx.values.deviceId]: 8 },
     });
+  });
+
+  it("distinguishes a removed session generation from an advanced snapshot", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const discard = vi.fn(async () => true);
+
+    await ctx.service.remove();
+
+    await expect(
+      ctx.service.discardIfSessionIsActive(
+        ctx.values.sessionId,
+        ctx.values.vaultId,
+        0,
+        ctx.sourceSnapshotVersionVector,
+        async () => undefined,
+        discard,
+      ),
+    ).resolves.toBe("session_replaced");
+    expect(discard).not.toHaveBeenCalled();
   });
 
   it("does not invalidate another active vault after persisted snapshot commit mismatch", async () => {
@@ -809,8 +910,9 @@ describe("UnlockedVaultSessionService", () => {
 
   it("removes session material and encrypted payload", async () => {
     const ctx = createContext();
+    const material = createMaterial(ctx);
 
-    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
     ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
       createEncryptedPayload(ctx);
 
@@ -820,13 +922,52 @@ describe("UnlockedVaultSessionService", () => {
     expect(
       ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
     ).toBeUndefined();
+    for (const buffer of [
+      material.vaultMasterKey,
+      material.devicePrivateSignKey,
+      material.devicePrivateVaultKey,
+      material.deviceLocalProtectionKey,
+      material.payloadKey,
+    ]) {
+      expect(Array.from(new Uint8Array(buffer))).toEqual([0]);
+    }
+  });
+
+  it("continues wiping and repository cleanup after a buffer cannot be wiped", async () => {
+    const ctx = createContext();
+    const detachedVaultMasterKey = new Uint8Array([2]).buffer;
+    structuredClone(detachedVaultMasterKey, {
+      transfer: [detachedVaultMasterKey],
+    });
+    const material = createMaterial(ctx, {
+      vaultMasterKey:
+        detachedVaultMasterKey as UnlockedVaultSessionMaterial["vaultMasterKey"],
+    });
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+
+    await expect(ctx.service.remove()).resolves.toBeUndefined();
+
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledTimes(1);
+    expect(Array.from(new Uint8Array(material.devicePrivateSignKey))).toEqual([
+      0,
+    ]);
   });
 
   it("removes encrypted payload when material removal fails", async () => {
     const ctx = createContext();
     const error = new Error("material remove failed");
+    const material = createMaterial(ctx);
 
-    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.unlockedVaultSessionMaterial = material;
     ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
       createEncryptedPayload(ctx);
     vi.mocked(
@@ -843,6 +984,15 @@ describe("UnlockedVaultSessionService", () => {
     expect(
       ctx.ports.saved.encryptedUnlockedVaultSessionPayload,
     ).toBeUndefined();
+    for (const buffer of [
+      material.vaultMasterKey,
+      material.devicePrivateSignKey,
+      material.devicePrivateVaultKey,
+      material.deviceLocalProtectionKey,
+      material.payloadKey,
+    ]) {
+      expect(Array.from(new Uint8Array(buffer))).toEqual([0]);
+    }
   });
 
   it("does not resurrect a session after material removal fails", async () => {

--- a/packages/core/src/services/session/unlocked-vault-session.service.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.ts
@@ -65,6 +65,18 @@ export class UnlockedVaultSessionService {
     vaultId: string,
     operation: string,
   ): Promise<UnlockedVaultSession> {
+    return this.runWithUnlockedVaultContext(
+      vaultId,
+      operation,
+      async (session) => session,
+    );
+  }
+
+  async runWithUnlockedVaultContext<T>(
+    vaultId: string,
+    operation: string,
+    run: (session: UnlockedVaultSession) => Promise<T>,
+  ): Promise<T> {
     return this.serializeSessionOperation(async () => {
       const unlockedVaultSession = await this.restoreSession();
 
@@ -75,7 +87,7 @@ export class UnlockedVaultSessionService {
         throw new VaultMustBeUnlockedError(vaultId, operation);
       }
 
-      return unlockedVaultSession;
+      return run(unlockedVaultSession);
     });
   }
 
@@ -90,6 +102,7 @@ export class UnlockedVaultSessionService {
         sessionId,
         vaultId,
       );
+      this.activationGeneration += 1;
 
       return operation();
     });
@@ -98,36 +111,50 @@ export class UnlockedVaultSessionService {
   async restorePersistedState(
     sessionId: string,
     vaultId: string,
+    sourceSnapshotVersionVector: VersionVector,
     restore: () => Promise<void>,
-  ): Promise<boolean> {
+  ): Promise<"restored" | "session_advanced" | "rollback_failed"> {
     return this.serializeSessionOperation(async () => {
+      let activeMaterial: UnlockedVaultSessionMaterial | null;
+
       try {
-        await restore();
-      } catch {
-        const activeMaterial = this.getActiveMaterial(
+        activeMaterial = this.getActiveMaterial(
           await this.materialRepository.getUnlockedVaultSessionMaterial(),
         );
-
-        if (activeMaterial?.vaultId === vaultId) {
-          await this.removeSessionRecordsPreservingRootCause(activeMaterial);
-        }
-
-        return false;
+      } catch {
+        return "rollback_failed";
       }
-
-      const activeMaterial = this.getActiveMaterial(
-        await this.materialRepository.getUnlockedVaultSessionMaterial(),
-      );
 
       if (
         activeMaterial !== null &&
         activeMaterial.vaultId === vaultId &&
-        !this.isActiveSession(activeMaterial, sessionId, vaultId)
+        (!this.isActiveSession(activeMaterial, sessionId, vaultId) ||
+          compareVersionVectors(
+            activeMaterial.sourceSnapshotVersionVector,
+            sourceSnapshotVersionVector,
+          ) !== "equal")
       ) {
-        await this.removeSessionRecordsPreservingRootCause(activeMaterial);
+        return "session_advanced";
       }
 
-      return true;
+      if (activeMaterial === null) {
+        this.activationGeneration += 1;
+      }
+
+      try {
+        await restore();
+      } catch {
+        if (
+          activeMaterial !== null &&
+          this.isActiveSession(activeMaterial, sessionId, vaultId)
+        ) {
+          await this.removeSessionRecordsPreservingRootCause(activeMaterial);
+        }
+
+        return "rollback_failed";
+      }
+
+      return "restored";
     });
   }
 
@@ -147,11 +174,27 @@ export class UnlockedVaultSessionService {
   > {
     return this.serializeSessionOperation(async () => {
       if (generation !== this.activationGeneration) {
-        return "session_replaced";
+        try {
+          const advancedMaterial =
+            await this.materialRepository.getUnlockedVaultSessionMaterial();
+
+          return advancedMaterial !== null &&
+            this.isActiveSession(advancedMaterial, sessionId, vaultId)
+            ? "session_advanced"
+            : "session_replaced";
+        } catch {
+          return "session_advanced";
+        }
       }
 
-      const activeMaterial =
-        await this.materialRepository.getUnlockedVaultSessionMaterial();
+      let activeMaterial: UnlockedVaultSessionMaterial | null;
+
+      try {
+        activeMaterial =
+          await this.materialRepository.getUnlockedVaultSessionMaterial();
+      } catch {
+        return "session_advanced";
+      }
 
       if (
         activeMaterial === null ||
@@ -219,7 +262,7 @@ export class UnlockedVaultSessionService {
     rollbackAutoLock: () => Promise<void>,
   ): Promise<{ readonly sessionId: string; readonly generation: number }> {
     return this.serializeSessionOperation(async () => {
-      let autoLockInstalled = false;
+      let activationPreparationStarted = false;
 
       try {
         return await this.activateWithinSessionOperation(
@@ -227,12 +270,12 @@ export class UnlockedVaultSessionService {
           unlockedVault,
           sourceSnapshotVersionVector,
           async () => {
+            activationPreparationStarted = true;
             await installAutoLock();
-            autoLockInstalled = true;
           },
         );
       } catch (error) {
-        if (autoLockInstalled) {
+        if (activationPreparationStarted) {
           try {
             await rollbackAutoLock();
           } catch {
@@ -272,13 +315,10 @@ export class UnlockedVaultSessionService {
     try {
       await beforeActivation?.();
 
-      const protectedSession = await this.protect(
-        {
-          unlockedVault,
-          sourceSnapshotVersionVector,
-        },
-        activeMaterial ?? undefined,
-      );
+      const protectedSession = await this.protect({
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      });
 
       try {
         await this.persistProtectedSession(protectedSession);
@@ -335,6 +375,7 @@ export class UnlockedVaultSessionService {
         );
         await this.persistProtectedSession(protectedSession);
         this.wipeReplacedMaterial(activeMaterial, protectedSession.material);
+        this.activationGeneration += 1;
       } catch (error) {
         if (protectedSession !== undefined) {
           this.wipeMaterial(protectedSession.material);
@@ -361,6 +402,7 @@ export class UnlockedVaultSessionService {
         readonly generation: number;
       } | null,
     ) => Promise<boolean>,
+    afterRemoval?: () => Promise<void>,
   ): Promise<"removed" | "session_unavailable" | "stale_action"> {
     return this.serializeSessionOperation(async () => {
       let firstError: unknown;
@@ -374,6 +416,10 @@ export class UnlockedVaultSessionService {
       } catch (error) {
         firstError = error;
         materialReadFailed = true;
+      }
+
+      if (materialReadFailed && requiredVaultId !== undefined) {
+        throw firstError;
       }
 
       if (
@@ -417,6 +463,14 @@ export class UnlockedVaultSessionService {
           await this.removeSessionRecords(material ?? undefined);
         } catch (error) {
           firstError ??= error;
+        }
+      }
+
+      if (firstError === undefined && material !== null) {
+        try {
+          await afterRemoval?.();
+        } catch (error) {
+          firstError = error;
         }
       }
 

--- a/packages/core/src/services/session/unlocked-vault-session.service.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.ts
@@ -17,6 +17,7 @@ import {
   UnlockedVaultSessionInvalidError,
   VaultMustBeUnlockedError,
 } from "../../errors/vault-session.errors";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export class UnlockedVaultSessionService {
   private readonly materialRepository: UnlockedVaultSessionMaterialRepositoryPort;
@@ -108,7 +109,7 @@ export class UnlockedVaultSessionService {
         );
 
         if (activeMaterial?.vaultId === vaultId) {
-          await this.removeSessionRecordsPreservingRootCause();
+          await this.removeSessionRecordsPreservingRootCause(activeMaterial);
         }
 
         return false;
@@ -123,7 +124,7 @@ export class UnlockedVaultSessionService {
         activeMaterial.vaultId === vaultId &&
         !this.isActiveSession(activeMaterial, sessionId, vaultId)
       ) {
-        await this.removeSessionRecordsPreservingRootCause();
+        await this.removeSessionRecordsPreservingRootCause(activeMaterial);
       }
 
       return true;
@@ -133,12 +134,22 @@ export class UnlockedVaultSessionService {
   async discardIfSessionIsActive(
     sessionId: string,
     vaultId: string,
+    generation: number,
     sourceSnapshotVersionVector: VersionVector,
+    beforeRemoval: () => Promise<void>,
     discard: () => Promise<boolean>,
   ): Promise<
-    "discarded" | "session_advanced" | "session_unavailable" | "rollback_failed"
+    | "discarded"
+    | "session_advanced"
+    | "session_replaced"
+    | "session_unavailable"
+    | "rollback_failed"
   > {
     return this.serializeSessionOperation(async () => {
+      if (generation !== this.activationGeneration) {
+        return "session_replaced";
+      }
+
       const activeMaterial =
         await this.materialRepository.getUnlockedVaultSessionMaterial();
 
@@ -158,9 +169,21 @@ export class UnlockedVaultSessionService {
         return "session_advanced";
       }
 
+      let cleanupFailed = false;
+
       try {
-        await this.removeSessionRecords();
+        await beforeRemoval();
       } catch {
+        cleanupFailed = true;
+      }
+
+      try {
+        await this.removeSessionRecords(activeMaterial);
+      } catch {
+        return "rollback_failed";
+      }
+
+      if (cleanupFailed) {
         return "rollback_failed";
       }
 
@@ -177,24 +200,77 @@ export class UnlockedVaultSessionService {
     unlockedVault: UnlockedVault,
     sourceSnapshotVersionVector: VersionVector,
   ): Promise<string> {
+    const activatedSession = await this.serializeSessionOperation(async () =>
+      this.activateWithinSessionOperation(
+        activationGeneration,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+      ),
+    );
+
+    return activatedSession.sessionId;
+  }
+
+  async activateWithAutoLock(
+    activationGeneration: number,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotVersionVector: VersionVector,
+    installAutoLock: () => Promise<void>,
+    rollbackAutoLock: () => Promise<void>,
+  ): Promise<{ readonly sessionId: string; readonly generation: number }> {
     return this.serializeSessionOperation(async () => {
-      if (activationGeneration !== this.activationGeneration) {
-        throw new UnlockedVaultSessionExpiredError(unlockedVault.vaultId);
-      }
+      let autoLockInstalled = false;
 
-      const storedMaterial =
-        await this.materialRepository.getUnlockedVaultSessionMaterial();
-      const activeMaterial = this.getActiveMaterial(storedMaterial);
-
-      if (
-        activeMaterial !== null &&
-        activeMaterial.vaultId !== unlockedVault.vaultId
-      ) {
-        throw new ActiveUnlockedVaultMismatchError(
-          activeMaterial.vaultId,
-          unlockedVault.vaultId,
+      try {
+        return await this.activateWithinSessionOperation(
+          activationGeneration,
+          unlockedVault,
+          sourceSnapshotVersionVector,
+          async () => {
+            await installAutoLock();
+            autoLockInstalled = true;
+          },
         );
+      } catch (error) {
+        if (autoLockInstalled) {
+          try {
+            await rollbackAutoLock();
+          } catch {
+            // The activation failure remains the root cause.
+          }
+        }
+
+        throw error;
       }
+    });
+  }
+
+  private async activateWithinSessionOperation(
+    activationGeneration: number,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotVersionVector: VersionVector,
+    beforeActivation?: () => Promise<void>,
+  ): Promise<{ readonly sessionId: string; readonly generation: number }> {
+    if (activationGeneration !== this.activationGeneration) {
+      throw new UnlockedVaultSessionExpiredError(unlockedVault.vaultId);
+    }
+
+    const storedMaterial =
+      await this.materialRepository.getUnlockedVaultSessionMaterial();
+    const activeMaterial = this.getActiveMaterial(storedMaterial);
+
+    if (
+      activeMaterial !== null &&
+      activeMaterial.vaultId !== unlockedVault.vaultId
+    ) {
+      throw new ActiveUnlockedVaultMismatchError(
+        activeMaterial.vaultId,
+        unlockedVault.vaultId,
+      );
+    }
+
+    try {
+      await beforeActivation?.();
 
       const protectedSession = await this.protect(
         {
@@ -207,14 +283,30 @@ export class UnlockedVaultSessionService {
       try {
         await this.persistProtectedSession(protectedSession);
       } catch (error) {
-        await this.removeSessionRecordsPreservingRootCause();
+        this.wipeMaterial(protectedSession.material);
+        await this.removeSessionRecordsPreservingRootCause(
+          activeMaterial ?? undefined,
+        );
         throw error;
+      }
+
+      if (activeMaterial !== null) {
+        this.wipeReplacedMaterial(activeMaterial, protectedSession.material);
       }
 
       this.sessionIsInvalidated = false;
       this.activationGeneration += 1;
-      return protectedSession.material.sessionId;
-    });
+      return {
+        sessionId: protectedSession.material.sessionId,
+        generation: this.activationGeneration,
+      };
+    } catch (error) {
+      if (activeMaterial !== null && !this.sessionIsInvalidated) {
+        await this.removeSessionRecordsPreservingRootCause(activeMaterial);
+      }
+
+      throw error;
+    }
   }
 
   async commitPersistedSnapshot(
@@ -229,8 +321,12 @@ export class UnlockedVaultSessionService {
         unlockedVault.vaultId,
       );
 
+      let protectedSession:
+        | Awaited<ReturnType<UnlockedVaultSessionService["protect"]>>
+        | undefined;
+
       try {
-        const protectedSession = await this.protect(
+        protectedSession = await this.protect(
           {
             unlockedVault,
             sourceSnapshotVersionVector,
@@ -238,8 +334,12 @@ export class UnlockedVaultSessionService {
           activeMaterial,
         );
         await this.persistProtectedSession(protectedSession);
+        this.wipeReplacedMaterial(activeMaterial, protectedSession.material);
       } catch (error) {
-        await this.removeSessionRecordsPreservingRootCause();
+        if (protectedSession !== undefined) {
+          this.wipeMaterial(protectedSession.material);
+        }
+        await this.removeSessionRecordsPreservingRootCause(activeMaterial);
         throw error;
       }
     });
@@ -248,6 +348,83 @@ export class UnlockedVaultSessionService {
   async remove(): Promise<void> {
     await this.serializeSessionOperation(async () => {
       await this.removeSessionRecords();
+    });
+  }
+
+  async cleanupActiveSession(
+    requiredVaultId: string | undefined,
+    invalidateWhenUnavailable: boolean,
+    beforeRemoval: (
+      activeSession: {
+        readonly sessionId: string;
+        readonly vaultId: string;
+        readonly generation: number;
+      } | null,
+    ) => Promise<boolean>,
+  ): Promise<"removed" | "session_unavailable" | "stale_action"> {
+    return this.serializeSessionOperation(async () => {
+      let firstError: unknown;
+      let material: UnlockedVaultSessionMaterial | null = null;
+      let materialReadFailed = false;
+
+      try {
+        material = this.getActiveMaterial(
+          await this.materialRepository.getUnlockedVaultSessionMaterial(),
+        );
+      } catch (error) {
+        firstError = error;
+        materialReadFailed = true;
+      }
+
+      if (
+        !materialReadFailed &&
+        requiredVaultId !== undefined &&
+        material?.vaultId !== requiredVaultId
+      ) {
+        return "session_unavailable";
+      }
+
+      const activeSession =
+        material === null
+          ? null
+          : {
+              sessionId: material.sessionId,
+              vaultId: material.vaultId,
+              generation: this.activationGeneration,
+            };
+      let shouldRemove = true;
+
+      try {
+        shouldRemove = await beforeRemoval(activeSession);
+      } catch (error) {
+        firstError ??= error;
+      }
+
+      if (!shouldRemove) {
+        if (firstError !== undefined) {
+          throw firstError;
+        }
+
+        return "stale_action";
+      }
+
+      if (
+        material !== null ||
+        materialReadFailed ||
+        invalidateWhenUnavailable
+      ) {
+        try {
+          await this.removeSessionRecords(material ?? undefined);
+        } catch (error) {
+          firstError ??= error;
+        }
+      }
+
+      if (firstError !== undefined) {
+        throw firstError;
+      }
+
+      return material === null ? "session_unavailable" : "removed";
     });
   }
 
@@ -260,23 +437,46 @@ export class UnlockedVaultSessionService {
       return null;
     }
 
-    const encryptedPayload =
-      await this.encryptedPayloadRepository.getEncryptedUnlockedVaultSessionPayload();
+    try {
+      const encryptedPayload =
+        await this.encryptedPayloadRepository.getEncryptedUnlockedVaultSessionPayload();
 
-    if (encryptedPayload === null) {
-      throw new UnlockedVaultSessionInvalidError(
-        "encrypted payload is missing",
-      );
+      if (encryptedPayload === null) {
+        throw new UnlockedVaultSessionInvalidError(
+          "encrypted payload is missing",
+        );
+      }
+
+      return await this.restore(material, encryptedPayload);
+    } catch (error) {
+      await this.removeSessionRecordsPreservingRootCause(material);
+      throw error;
     }
-
-    return this.restore(material, encryptedPayload);
   }
 
-  private async removeSessionRecords(): Promise<void> {
+  private async removeSessionRecords(
+    knownMaterial?: UnlockedVaultSessionMaterial,
+  ): Promise<void> {
     this.activationGeneration += 1;
     this.sessionIsInvalidated = true;
 
     let removalError: unknown;
+    let materialReadError: unknown;
+    let material = knownMaterial;
+
+    if (material === undefined) {
+      try {
+        material =
+          (await this.materialRepository.getUnlockedVaultSessionMaterial()) ??
+          undefined;
+      } catch (error) {
+        materialReadError = error;
+      }
+    }
+
+    if (material !== undefined) {
+      this.wipeMaterial(material);
+    }
 
     try {
       await this.materialRepository.removeUnlockedVaultSessionMaterial();
@@ -294,6 +494,10 @@ export class UnlockedVaultSessionService {
 
     if (removalError !== undefined) {
       throw removalError;
+    }
+
+    if (materialReadError !== undefined) {
+      throw materialReadError;
     }
   }
 
@@ -325,21 +529,31 @@ export class UnlockedVaultSessionService {
     const sessionId =
       activeMaterial?.sessionId ?? (await this.ids.generateId());
     const payloadKey =
-      activeMaterial?.payloadKey ??
-      (await this.crypto.generateUnlockedVaultSessionPayloadKey());
+      activeMaterial === undefined
+        ? await this.crypto.generateUnlockedVaultSessionPayloadKey()
+        : activeMaterial.payloadKey;
+    const generatedPayloadKey =
+      activeMaterial === undefined ? payloadKey : undefined;
     const { unlockedVault, sourceSnapshotVersionVector } = session;
     const context = {
       sessionId,
       vaultId: unlockedVault.vaultId,
       sourceSnapshotVersionVector,
     };
-    const content = await this.crypto.encryptUnlockedVaultSessionPayload(
-      {
-        vault: unlockedVault.vault,
-      },
-      payloadKey,
-      context,
-    );
+    let content: EncryptedUnlockedVaultSessionPayload["content"];
+
+    try {
+      content = await this.crypto.encryptUnlockedVaultSessionPayload(
+        {
+          vault: unlockedVault.vault,
+        },
+        payloadKey,
+        context,
+      );
+    } catch (error) {
+      bestEffortWipeArrayBuffers([generatedPayloadKey]);
+      throw error;
+    }
 
     return {
       material: {
@@ -406,12 +620,47 @@ export class UnlockedVaultSessionService {
     };
   }
 
-  private async removeSessionRecordsPreservingRootCause(): Promise<void> {
+  private async removeSessionRecordsPreservingRootCause(
+    knownMaterial?: UnlockedVaultSessionMaterial,
+  ): Promise<void> {
     try {
-      await this.removeSessionRecords();
+      await this.removeSessionRecords(knownMaterial);
     } catch {
       // Preserve the original failure as the root cause.
     }
+  }
+
+  private wipeMaterial(material: UnlockedVaultSessionMaterial): void {
+    bestEffortWipeArrayBuffers([
+      material.vaultMasterKey,
+      material.devicePrivateSignKey,
+      material.devicePrivateVaultKey,
+      material.deviceLocalProtectionKey,
+      material.payloadKey,
+    ]);
+  }
+
+  private wipeReplacedMaterial(
+    previous: UnlockedVaultSessionMaterial,
+    current: UnlockedVaultSessionMaterial,
+  ): void {
+    bestEffortWipeArrayBuffers([
+      previous.vaultMasterKey === current.vaultMasterKey
+        ? undefined
+        : previous.vaultMasterKey,
+      previous.devicePrivateSignKey === current.devicePrivateSignKey
+        ? undefined
+        : previous.devicePrivateSignKey,
+      previous.devicePrivateVaultKey === current.devicePrivateVaultKey
+        ? undefined
+        : previous.devicePrivateVaultKey,
+      previous.deviceLocalProtectionKey === current.deviceLocalProtectionKey
+        ? undefined
+        : previous.deviceLocalProtectionKey,
+      previous.payloadKey === current.payloadKey
+        ? undefined
+        : previous.payloadKey,
+    ]);
   }
 
   private async serializeSessionOperation<T>(

--- a/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
+++ b/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
@@ -1,0 +1,213 @@
+import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type { ClipboardClearService } from "../clipboard/clipboard-clear.service";
+import type { UnlockedVaultSessionService } from "./unlocked-vault-session.service";
+import type { VersionVector } from "../../domain/versioning/version-vector.type";
+
+export type VaultLifecycleCleanupParams = {
+  readonly actionId?: string;
+  readonly requiredVaultId?: string;
+};
+
+export class VaultLifecycleCleanupService {
+  private readonly clipboardClear: ClipboardClearService;
+  private readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
+  private readonly scheduledTasks: ScheduledTaskPort;
+  private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
+  private readonly unlockedVaultSession: UnlockedVaultSessionService;
+
+  constructor(
+    clipboardClear: ClipboardClearService,
+    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
+    scheduledTasks: ScheduledTaskPort,
+    vaultLockTasks: VaultLockTaskRepositoryPort,
+    unlockedVaultSession: UnlockedVaultSessionService,
+  ) {
+    this.clipboardClear = clipboardClear;
+    this.clipboardClearTasks = clipboardClearTasks;
+    this.scheduledTasks = scheduledTasks;
+    this.vaultLockTasks = vaultLockTasks;
+    this.unlockedVaultSession = unlockedVaultSession;
+  }
+
+  async cleanup(
+    params: VaultLifecycleCleanupParams = {},
+  ): Promise<"cleaned" | "session_unavailable" | "stale_action"> {
+    let staleAction = false;
+    let staleActionError: unknown;
+    const result = await this.unlockedVaultSession.cleanupActiveSession(
+      params.requiredVaultId,
+      params.actionId === undefined,
+      async (activeSession) => {
+        const taskCleanup = await this.cleanupTasks(
+          params.actionId,
+          activeSession?.vaultId ?? params.requiredVaultId,
+        );
+        if (taskCleanup.status === "stale_action") {
+          staleAction = true;
+          staleActionError = taskCleanup.error;
+        }
+        return !staleAction;
+      },
+    );
+
+    if (staleActionError !== undefined) {
+      throw staleActionError;
+    }
+
+    if (staleAction || result === "stale_action") {
+      return "stale_action";
+    }
+
+    return result === "session_unavailable" ? result : "cleaned";
+  }
+
+  async discardIfSessionIsActive(
+    params: {
+      readonly sessionId: string;
+      readonly vaultId: string;
+      readonly generation: number;
+      readonly sourceSnapshotVersionVector: VersionVector;
+    },
+    discard: () => Promise<boolean>,
+  ): Promise<
+    | "discarded"
+    | "session_advanced"
+    | "session_replaced"
+    | "session_unavailable"
+    | "rollback_failed"
+  > {
+    return this.unlockedVaultSession.discardIfSessionIsActive(
+      params.sessionId,
+      params.vaultId,
+      params.generation,
+      params.sourceSnapshotVersionVector,
+      async () => {
+        await this.cleanupTasks(undefined, params.vaultId);
+      },
+      discard,
+    );
+  }
+
+  private async cleanupTasks(
+    actionId: string | undefined,
+    expectedVaultId: string | undefined,
+  ): Promise<
+    | { readonly status: "cleaned" }
+    | { readonly status: "stale_action"; readonly error?: unknown }
+  > {
+    let firstError: unknown;
+    let vaultLockTask: Awaited<ReturnType<VaultLockTaskRepositoryPort["get"]>>;
+    let lockMetadataRemoved = false;
+
+    try {
+      vaultLockTask = await this.vaultLockTasks.get();
+    } catch (error) {
+      firstError = error;
+      vaultLockTask = null;
+
+      if (actionId !== undefined) {
+        try {
+          lockMetadataRemoved =
+            await this.vaultLockTasks.removeIfActionIsActive(actionId);
+        } catch {
+          return { status: "stale_action", error };
+        }
+
+        if (!lockMetadataRemoved) {
+          return { status: "stale_action" };
+        }
+      }
+    }
+
+    if (
+      actionId !== undefined &&
+      vaultLockTask !== null &&
+      (vaultLockTask.actionId !== actionId ||
+        (expectedVaultId !== undefined &&
+          vaultLockTask.vaultId !== expectedVaultId))
+    ) {
+      return { status: "stale_action" };
+    }
+
+    if (
+      actionId !== undefined &&
+      vaultLockTask === null &&
+      !lockMetadataRemoved
+    ) {
+      return { status: "stale_action" };
+    }
+
+    let clipboardClearTask: Awaited<
+      ReturnType<ClipboardClearTaskRepositoryPort["get"]>
+    >;
+    let clipboardTaskReadFailed = false;
+
+    try {
+      clipboardClearTask = await this.clipboardClearTasks.get();
+    } catch (error) {
+      firstError ??= error;
+      clipboardClearTask = null;
+      clipboardTaskReadFailed = true;
+    }
+
+    if (clipboardClearTask !== null) {
+      try {
+        await this.clipboardClear.clearTask({
+          task: clipboardClearTask,
+          requireExpired: false,
+        });
+      } catch (error) {
+        firstError ??= error;
+        clipboardTaskReadFailed = true;
+      }
+
+      try {
+        await this.scheduledTasks.cancelTask({
+          name: "clearClipboard",
+          actionId: clipboardClearTask.actionId,
+        });
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+
+    if (clipboardTaskReadFailed) {
+      try {
+        await this.clipboardClearTasks.remove();
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+
+    const lockActionId = vaultLockTask?.actionId ?? actionId;
+
+    if (lockActionId !== undefined) {
+      try {
+        await this.scheduledTasks.cancelTask({
+          name: "lockVault",
+          actionId: lockActionId,
+        });
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+
+    if (vaultLockTask !== null && !lockMetadataRemoved) {
+      try {
+        await this.vaultLockTasks.removeIfActionIsActive(
+          vaultLockTask.actionId,
+        );
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+
+    if (firstError !== undefined) {
+      throw firstError;
+    }
+
+    return { status: "cleaned" };
+  }
+}

--- a/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
+++ b/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
@@ -7,6 +7,7 @@ import type { VersionVector } from "../../domain/versioning/version-vector.type"
 
 export type VaultLifecycleCleanupParams = {
   readonly actionId?: string;
+  readonly afterSessionRemoval?: () => Promise<void>;
   readonly requiredVaultId?: string;
 };
 
@@ -50,6 +51,7 @@ export class VaultLifecycleCleanupService {
         }
         return !staleAction;
       },
+      params.afterSessionRemoval,
     );
 
     if (staleActionError !== undefined) {
@@ -142,14 +144,14 @@ export class VaultLifecycleCleanupService {
     let clipboardClearTask: Awaited<
       ReturnType<ClipboardClearTaskRepositoryPort["get"]>
     >;
-    let clipboardTaskReadFailed = false;
+    let clipboardTaskStateUnknown = false;
 
     try {
       clipboardClearTask = await this.clipboardClearTasks.get();
     } catch (error) {
       firstError ??= error;
       clipboardClearTask = null;
-      clipboardTaskReadFailed = true;
+      clipboardTaskStateUnknown = true;
     }
 
     if (clipboardClearTask !== null) {
@@ -160,7 +162,7 @@ export class VaultLifecycleCleanupService {
         });
       } catch (error) {
         firstError ??= error;
-        clipboardTaskReadFailed = true;
+        clipboardTaskStateUnknown = true;
       }
 
       try {
@@ -173,7 +175,7 @@ export class VaultLifecycleCleanupService {
       }
     }
 
-    if (clipboardTaskReadFailed) {
+    if (clipboardTaskStateUnknown) {
       try {
         await this.clipboardClearTasks.remove();
       } catch (error) {
@@ -196,9 +198,16 @@ export class VaultLifecycleCleanupService {
 
     if (vaultLockTask !== null && !lockMetadataRemoved) {
       try {
-        await this.vaultLockTasks.removeIfActionIsActive(
+        const removed = await this.vaultLockTasks.removeIfActionIsActive(
           vaultLockTask.actionId,
         );
+
+        if (actionId !== undefined && !removed) {
+          return {
+            status: "stale_action",
+            ...(firstError === undefined ? {} : { error: firstError }),
+          };
+        }
       } catch (error) {
         firstError ??= error;
       }

--- a/packages/core/src/services/session/vault-session-activation.service.test.ts
+++ b/packages/core/src/services/session/vault-session-activation.service.test.ts
@@ -75,9 +75,13 @@ describe("VaultSessionActivationService", () => {
       activationGeneration: firstGeneration,
     });
     await scheduleStarted;
+    const competingPrepare = vi.fn(async () => undefined);
+    const competingRollback = vi.fn(async () => undefined);
     const competingActivation = service.activate({
       ...params,
       activationGeneration: competingGeneration,
+      prepareActivation: competingPrepare,
+      rollbackPreparedActivation: competingRollback,
     });
     releaseSchedule();
 
@@ -90,6 +94,8 @@ describe("VaultSessionActivationService", () => {
     );
     expect(vaultLockTasks.save).toHaveBeenCalledTimes(1);
     expect(scheduledTasks.scheduleTask).toHaveBeenCalledTimes(1);
+    expect(competingPrepare).not.toHaveBeenCalled();
+    expect(competingRollback).not.toHaveBeenCalled();
     expect(activeLockTask).toMatchObject({
       actionId: values.vaultLockActionId,
       vaultId: values.vaultId,
@@ -132,12 +138,57 @@ describe("VaultSessionActivationService", () => {
       }),
       cancelTask: vi.fn(async () => undefined),
     };
-    vi.mocked(ports.ids.generateId).mockReset().mockResolvedValue("new-action-id");
+    vi.mocked(ports.ids.generateId)
+      .mockReset()
+      .mockResolvedValue("new-action-id");
     const service = new VaultSessionActivationService(
       ports.clock,
       ports.ids,
       scheduledTasks,
       vaultLockTasks,
+      ports.sessionServices.unlockedVaultSession,
+    );
+    const generation =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+    const prepareActivation = vi.fn(async () => undefined);
+    const rollbackPreparedActivation = vi.fn(async () => undefined);
+
+    await expect(
+      service.activate({
+        activationGeneration: generation,
+        unlockedVault,
+        sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+        lockAfterMs: 60_000,
+        prepareActivation,
+        rollbackPreparedActivation,
+      }),
+    ).rejects.toBe(scheduleError);
+
+    expect(activeLockTask).toBeNull();
+    expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: "new-action-id",
+    });
+    expect(rollbackPreparedActivation).toHaveBeenCalledOnce();
+    expect(ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("does not roll back persistence when activation preparation fails", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    const prepareError = new Error("prepare failed");
+    const prepareActivation = vi.fn(async () => {
+      throw prepareError;
+    });
+    const rollbackPreparedActivation = vi.fn(async () => undefined);
+    const service = new VaultSessionActivationService(
+      ports.clock,
+      ports.ids,
+      ports.scheduledTasks,
+      ports.vaultLockTasks,
       ports.sessionServices.unlockedVaultSession,
     );
     const generation =
@@ -151,14 +202,14 @@ describe("VaultSessionActivationService", () => {
         unlockedVault,
         sourceSnapshotVersionVector: { [values.deviceId]: 1 },
         lockAfterMs: 60_000,
+        prepareActivation,
+        rollbackPreparedActivation,
       }),
-    ).rejects.toBe(scheduleError);
+    ).rejects.toBe(prepareError);
 
-    expect(activeLockTask).toBeNull();
-    expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "lockVault",
-      actionId: "new-action-id",
-    });
+    expect(rollbackPreparedActivation).not.toHaveBeenCalled();
+    expect(ports.vaultLockTasks.save).not.toHaveBeenCalled();
+    expect(ports.scheduledTasks.scheduleTask).not.toHaveBeenCalled();
     expect(ports.saved.unlockedVaultSession).toBeUndefined();
   });
 
@@ -198,7 +249,9 @@ describe("VaultSessionActivationService", () => {
     vi.mocked(
       ports.crypto.encryptUnlockedVaultSessionPayload,
     ).mockRejectedValueOnce(protectionError);
-    vi.mocked(ports.ids.generateId).mockReset().mockResolvedValue("new-action-id");
+    vi.mocked(ports.ids.generateId)
+      .mockReset()
+      .mockResolvedValue("new-action-id");
     const service = new VaultSessionActivationService(
       ports.clock,
       ports.ids,
@@ -224,6 +277,78 @@ describe("VaultSessionActivationService", () => {
     expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
       name: "lockVault",
       actionId: "new-action-id",
+    });
+    expect(ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("preserves a newer lock action when activation rollback runs", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    const failedActionId = "failed-action-id";
+    const newerLockTask: VaultLockTask = {
+      actionId: "newer-action-id",
+      vaultId: values.vaultId,
+      expiresAt: values.timestamp + 120_000,
+    };
+    let activeLockTask: VaultLockTask | null = null;
+    const vaultLockTasks: VaultLockTaskRepositoryPort = {
+      save: vi.fn(async (task) => {
+        activeLockTask = task;
+      }),
+      get: vi.fn(async () => activeLockTask),
+      removeIfActionIsActive: vi.fn(async (actionId) => {
+        if (activeLockTask?.actionId !== actionId) {
+          return false;
+        }
+
+        activeLockTask = null;
+        return true;
+      }),
+    };
+    const scheduledTasks: ScheduledTaskPort = {
+      scheduleTask: vi.fn(async () => undefined),
+      cancelTask: vi.fn(async () => undefined),
+    };
+    const protectionError = new Error("protection failed");
+    vi.mocked(
+      ports.crypto.encryptUnlockedVaultSessionPayload,
+    ).mockImplementationOnce(async () => {
+      activeLockTask = newerLockTask;
+      throw protectionError;
+    });
+    vi.mocked(ports.ids.generateId)
+      .mockReset()
+      .mockResolvedValueOnce(failedActionId)
+      .mockResolvedValueOnce(values.sessionId);
+    const service = new VaultSessionActivationService(
+      ports.clock,
+      ports.ids,
+      scheduledTasks,
+      vaultLockTasks,
+      ports.sessionServices.unlockedVaultSession,
+    );
+    const generation =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+
+    await expect(
+      service.activate({
+        activationGeneration: generation,
+        unlockedVault,
+        sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+        lockAfterMs: 60_000,
+      }),
+    ).rejects.toBe(protectionError);
+
+    expect(vaultLockTasks.removeIfActionIsActive).toHaveBeenCalledWith(
+      failedActionId,
+    );
+    expect(activeLockTask).toBe(newerLockTask);
+    expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: failedActionId,
     });
     expect(ports.saved.unlockedVaultSession).toBeUndefined();
   });

--- a/packages/core/src/services/session/vault-session-activation.service.test.ts
+++ b/packages/core/src/services/session/vault-session-activation.service.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import { createCoreTestValues } from "../../__tests__/fixtures/values";
+import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
+import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type {
+  VaultLockTask,
+  VaultLockTaskRepositoryPort,
+} from "../../ports/vault/vault-lock-task-repository.port";
+import { VaultSessionActivationService } from "./vault-session-activation.service";
+
+describe("VaultSessionActivationService", () => {
+  it("serializes competing auto-lock installation and session activation", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    let activeLockTask: VaultLockTask | null = null;
+    const vaultLockTasks: VaultLockTaskRepositoryPort = {
+      save: vi.fn(async (task) => {
+        activeLockTask = task;
+      }),
+      get: vi.fn(async () => activeLockTask),
+      removeIfActionIsActive: vi.fn(async (actionId) => {
+        if (activeLockTask?.actionId !== actionId) {
+          return false;
+        }
+
+        activeLockTask = null;
+        return true;
+      }),
+    };
+    let releaseSchedule = (): void => undefined;
+    let markScheduleStarted = (): void => undefined;
+    const scheduleStarted = new Promise<void>((resolve) => {
+      markScheduleStarted = resolve;
+    });
+    const scheduleCanFinish = new Promise<void>((resolve) => {
+      releaseSchedule = resolve;
+    });
+    const scheduledTasks: ScheduledTaskPort = {
+      scheduleTask: vi.fn(async () => {
+        markScheduleStarted();
+        await scheduleCanFinish;
+      }),
+      cancelTask: vi.fn(async () => undefined),
+    };
+    vi.mocked(ports.ids.generateId)
+      .mockReset()
+      .mockResolvedValueOnce(values.vaultLockActionId)
+      .mockResolvedValueOnce(values.sessionId);
+    const service = new VaultSessionActivationService(
+      ports.clock,
+      ports.ids,
+      scheduledTasks,
+      vaultLockTasks,
+      ports.sessionServices.unlockedVaultSession,
+    );
+    const firstGeneration =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+    const competingGeneration =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+    const params = {
+      unlockedVault,
+      sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+      lockAfterMs: 60_000,
+    } as const;
+
+    const firstActivation = service.activate({
+      ...params,
+      activationGeneration: firstGeneration,
+    });
+    await scheduleStarted;
+    const competingActivation = service.activate({
+      ...params,
+      activationGeneration: competingGeneration,
+    });
+    releaseSchedule();
+
+    await expect(firstActivation).resolves.toEqual({
+      sessionId: values.sessionId,
+      generation: 1,
+    });
+    await expect(competingActivation).rejects.toBeInstanceOf(
+      UnlockedVaultSessionExpiredError,
+    );
+    expect(vaultLockTasks.save).toHaveBeenCalledTimes(1);
+    expect(scheduledTasks.scheduleTask).toHaveBeenCalledTimes(1);
+    expect(activeLockTask).toMatchObject({
+      actionId: values.vaultLockActionId,
+      vaultId: values.vaultId,
+    });
+    expect(ports.saved.unlockedVaultSession).toBeDefined();
+  });
+
+  it("invalidates an existing session when replacement scheduling fails", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    ports.saved.unlockedVaultSession = {
+      sessionId: values.sessionId,
+      unlockedVault,
+      sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+    };
+    let activeLockTask: VaultLockTask | null = {
+      actionId: "existing-lock-action-id",
+      vaultId: values.vaultId,
+      expiresAt: values.timestamp + 30_000,
+    };
+    const vaultLockTasks: VaultLockTaskRepositoryPort = {
+      save: vi.fn(async (task) => {
+        activeLockTask = task;
+      }),
+      get: vi.fn(async () => activeLockTask),
+      removeIfActionIsActive: vi.fn(async (actionId) => {
+        if (activeLockTask?.actionId !== actionId) {
+          return false;
+        }
+
+        activeLockTask = null;
+        return true;
+      }),
+    };
+    const scheduleError = new Error("schedule failed");
+    const scheduledTasks: ScheduledTaskPort = {
+      scheduleTask: vi.fn(async () => {
+        throw scheduleError;
+      }),
+      cancelTask: vi.fn(async () => undefined),
+    };
+    vi.mocked(ports.ids.generateId).mockReset().mockResolvedValue("new-action-id");
+    const service = new VaultSessionActivationService(
+      ports.clock,
+      ports.ids,
+      scheduledTasks,
+      vaultLockTasks,
+      ports.sessionServices.unlockedVaultSession,
+    );
+    const generation =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+
+    await expect(
+      service.activate({
+        activationGeneration: generation,
+        unlockedVault,
+        sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+        lockAfterMs: 60_000,
+      }),
+    ).rejects.toBe(scheduleError);
+
+    expect(activeLockTask).toBeNull();
+    expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: "new-action-id",
+    });
+    expect(ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("invalidates an existing session when replacement protection fails", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const unlockedVault = createUnlockedVaultWithEntries(values, []);
+    ports.saved.unlockedVaultSession = {
+      sessionId: values.sessionId,
+      unlockedVault,
+      sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+    };
+    let activeLockTask: VaultLockTask | null = {
+      actionId: "existing-lock-action-id",
+      vaultId: values.vaultId,
+      expiresAt: values.timestamp + 30_000,
+    };
+    const vaultLockTasks: VaultLockTaskRepositoryPort = {
+      save: vi.fn(async (task) => {
+        activeLockTask = task;
+      }),
+      get: vi.fn(async () => activeLockTask),
+      removeIfActionIsActive: vi.fn(async (actionId) => {
+        if (activeLockTask?.actionId !== actionId) {
+          return false;
+        }
+
+        activeLockTask = null;
+        return true;
+      }),
+    };
+    const scheduledTasks: ScheduledTaskPort = {
+      scheduleTask: vi.fn(async () => undefined),
+      cancelTask: vi.fn(async () => undefined),
+    };
+    const protectionError = new Error("protection failed");
+    vi.mocked(
+      ports.crypto.encryptUnlockedVaultSessionPayload,
+    ).mockRejectedValueOnce(protectionError);
+    vi.mocked(ports.ids.generateId).mockReset().mockResolvedValue("new-action-id");
+    const service = new VaultSessionActivationService(
+      ports.clock,
+      ports.ids,
+      scheduledTasks,
+      vaultLockTasks,
+      ports.sessionServices.unlockedVaultSession,
+    );
+    const generation =
+      await ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        values.vaultId,
+      );
+
+    await expect(
+      service.activate({
+        activationGeneration: generation,
+        unlockedVault,
+        sourceSnapshotVersionVector: { [values.deviceId]: 1 },
+        lockAfterMs: 60_000,
+      }),
+    ).rejects.toBe(protectionError);
+
+    expect(activeLockTask).toBeNull();
+    expect(scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: "new-action-id",
+    });
+    expect(ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+});

--- a/packages/core/src/services/session/vault-session-activation.service.ts
+++ b/packages/core/src/services/session/vault-session-activation.service.ts
@@ -1,0 +1,112 @@
+import type { UnlockedVault } from "../../domain/session/unlocked-vault";
+import { vaultLockDelayMsSchema } from "../../domain/scheduled-task/scheduled-task-delay.schema";
+import type { VaultLockDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
+import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
+import type { ClockPort } from "../../ports/system/clock.port";
+import type { IdPort } from "../../ports/system/id.port";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type { UnlockedVaultSessionService } from "./unlocked-vault-session.service";
+
+export class VaultSessionActivationService {
+  private readonly clock: ClockPort;
+  private readonly ids: IdPort;
+  private readonly scheduledTasks: ScheduledTaskPort;
+  private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
+  private readonly unlockedVaultSession: UnlockedVaultSessionService;
+
+  constructor(
+    clock: ClockPort,
+    ids: IdPort,
+    scheduledTasks: ScheduledTaskPort,
+    vaultLockTasks: VaultLockTaskRepositoryPort,
+    unlockedVaultSession: UnlockedVaultSessionService,
+  ) {
+    this.clock = clock;
+    this.ids = ids;
+    this.scheduledTasks = scheduledTasks;
+    this.vaultLockTasks = vaultLockTasks;
+    this.unlockedVaultSession = unlockedVaultSession;
+  }
+
+  requireValidLockDelay(lockAfterMs: VaultLockDelayMs): VaultLockDelayMs {
+    const result = vaultLockDelayMsSchema.safeParse(lockAfterMs);
+
+    if (!result.success) {
+      throw new InvalidVaultLockDelayError(result.error);
+    }
+
+    return result.data;
+  }
+
+  async activate(params: {
+    readonly activationGeneration: number;
+    readonly unlockedVault: UnlockedVault;
+    readonly sourceSnapshotVersionVector: VersionVector;
+    readonly lockAfterMs: VaultLockDelayMs;
+  }): Promise<{ readonly sessionId: string; readonly generation: number }> {
+    let actionId: string | undefined;
+
+    return this.unlockedVaultSession.activateWithAutoLock(
+      params.activationGeneration,
+      params.unlockedVault,
+      params.sourceSnapshotVersionVector,
+      async () => {
+        actionId = await this.ids.generateId();
+        const expiresAt = this.clock.now() + params.lockAfterMs;
+
+        try {
+          await this.vaultLockTasks.save({
+            actionId,
+            vaultId: params.unlockedVault.vaultId,
+            expiresAt,
+          });
+          await this.scheduledTasks.scheduleTask({
+            task: {
+              name: "lockVault",
+              actionId,
+            },
+            runAt: expiresAt,
+          });
+        } catch (error) {
+          try {
+            await this.scheduledTasks.cancelTask({
+              name: "lockVault",
+              actionId,
+            });
+          } catch {
+            // Matching metadata cleanup still must run.
+          }
+
+          try {
+            await this.vaultLockTasks.removeIfActionIsActive(actionId);
+          } catch {
+            // The scheduling failure remains the root cause.
+          }
+          throw error;
+        }
+      },
+      async () => {
+        if (actionId === undefined) {
+          return;
+        }
+
+        try {
+          await this.scheduledTasks.cancelTask({
+            name: "lockVault",
+            actionId,
+          });
+        } catch {
+          // Metadata cleanup still must run.
+        }
+
+        try {
+          await this.vaultLockTasks.removeIfActionIsActive(actionId);
+        } catch {
+          // Session activation remains the root cause.
+        }
+      },
+    );
+  }
+}

--- a/packages/core/src/services/session/vault-session-activation.service.ts
+++ b/packages/core/src/services/session/vault-session-activation.service.ts
@@ -30,7 +30,7 @@ export class VaultSessionActivationService {
     this.unlockedVaultSession = unlockedVaultSession;
   }
 
-  requireValidLockDelay(lockAfterMs: VaultLockDelayMs): VaultLockDelayMs {
+  requireValidLockDelay(lockAfterMs: unknown): VaultLockDelayMs {
     const result = vaultLockDelayMsSchema.safeParse(lockAfterMs);
 
     if (!result.success) {
@@ -45,66 +45,58 @@ export class VaultSessionActivationService {
     readonly unlockedVault: UnlockedVault;
     readonly sourceSnapshotVersionVector: VersionVector;
     readonly lockAfterMs: VaultLockDelayMs;
+    readonly prepareActivation?: () => Promise<void>;
+    readonly rollbackPreparedActivation?: () => Promise<void>;
   }): Promise<{ readonly sessionId: string; readonly generation: number }> {
     let actionId: string | undefined;
+    let activationPrepared = false;
 
     return this.unlockedVaultSession.activateWithAutoLock(
       params.activationGeneration,
       params.unlockedVault,
       params.sourceSnapshotVersionVector,
       async () => {
+        await params.prepareActivation?.();
+        activationPrepared = true;
         actionId = await this.ids.generateId();
         const expiresAt = this.clock.now() + params.lockAfterMs;
-
-        try {
-          await this.vaultLockTasks.save({
+        await this.vaultLockTasks.save({
+          actionId,
+          vaultId: params.unlockedVault.vaultId,
+          expiresAt,
+        });
+        await this.scheduledTasks.scheduleTask({
+          task: {
+            name: "lockVault",
             actionId,
-            vaultId: params.unlockedVault.vaultId,
-            expiresAt,
-          });
-          await this.scheduledTasks.scheduleTask({
-            task: {
-              name: "lockVault",
-              actionId,
-            },
-            runAt: expiresAt,
-          });
-        } catch (error) {
+          },
+          runAt: expiresAt,
+        });
+      },
+      async () => {
+        if (actionId !== undefined) {
           try {
             await this.scheduledTasks.cancelTask({
               name: "lockVault",
               actionId,
             });
           } catch {
-            // Matching metadata cleanup still must run.
+            // Matching metadata and prepared-state cleanup still must run.
           }
 
           try {
             await this.vaultLockTasks.removeIfActionIsActive(actionId);
           } catch {
-            // The scheduling failure remains the root cause.
+            // Prepared-state cleanup still must run.
           }
-          throw error;
-        }
-      },
-      async () => {
-        if (actionId === undefined) {
-          return;
         }
 
-        try {
-          await this.scheduledTasks.cancelTask({
-            name: "lockVault",
-            actionId,
-          });
-        } catch {
-          // Metadata cleanup still must run.
-        }
-
-        try {
-          await this.vaultLockTasks.removeIfActionIsActive(actionId);
-        } catch {
-          // Session activation remains the root cause.
+        if (activationPrepared) {
+          try {
+            await params.rollbackPreparedActivation?.();
+          } catch {
+            // Session activation remains the root cause.
+          }
         }
       },
     );

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -99,6 +99,37 @@ describe("VaultSnapshotService", () => {
     ).rejects.toBeInstanceOf(VaultSnapshotDigestMismatchError);
   });
 
+  it("restores from a checkpoint prepared before private session material is wiped", async () => {
+    const ctx = createContext();
+    const preparedRestore = await ctx.service.prepareLocalVaultSnapshotRestore(
+      ctx.vaultSnapshot,
+      ctx.unlockedVault,
+      null,
+    );
+    const signCallCount = vi.mocked(
+      ctx.ports.crypto.signLocalVaultTrustCheckpoint,
+    ).mock.calls.length;
+    new Uint8Array(ctx.unlockedVault.devicePrivateSignKey).fill(0);
+    ctx.ports.saved.vaultSnapshotDigest = "replacement-snapshot-digest";
+
+    await ctx.service.restorePreparedLocalVaultSnapshot(
+      preparedRestore,
+      "replacement-snapshot-digest",
+    );
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenLastCalledWith({
+      expectedSnapshotDigest: "replacement-snapshot-digest",
+      snapshot: ctx.vaultSnapshot,
+      checkpoint: preparedRestore.checkpoint,
+      syncCredentialState: null,
+    });
+    expect(
+      ctx.ports.crypto.signLocalVaultTrustCheckpoint,
+    ).toHaveBeenCalledTimes(signCallCount);
+  });
+
   it("does not save when encryption fails", async () => {
     const ctx = createContext();
     vi.mocked(ctx.ports.crypto.encryptVaultSnapshotContent).mockRejectedValue(

--- a/packages/core/src/services/snapshot/vault-snapshot.service.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.ts
@@ -1,4 +1,5 @@
 import type {
+  LocalVaultTrustCheckpoint,
   VaultTrustChain,
   VerifiedVaultTrustState,
 } from "../../domain/device-trust";
@@ -28,6 +29,12 @@ import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { VaultTrustService } from "../trust/vault-trust.service";
+
+export type PreparedLocalVaultSnapshotRestore = {
+  readonly snapshot: VaultSnapshot;
+  readonly checkpoint: LocalVaultTrustCheckpoint;
+  readonly syncCredentialState?: EncryptedDeviceSyncCredentialState | null;
+};
 
 export class VaultSnapshotService {
   private readonly crypto: CryptoPort;
@@ -197,17 +204,47 @@ export class VaultSnapshotService {
     unlockedVault: UnlockedVault,
     syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
   ): Promise<void> {
-    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
-      expectedSnapshotDigest:
-        await this.crypto.digestVaultSnapshot(replacedSnapshot),
+    const preparedRestore = await this.prepareLocalVaultSnapshotRestore(
       snapshot,
-      checkpoint: await this.vaultTrust.createCheckpoint(
-        snapshot,
-        unlockedVault.trustedSnapshotContext.trust,
-        unlockedVault.deviceId,
-        unlockedVault.devicePrivateSignKey,
-      ),
+      unlockedVault,
+      syncCredentialState,
+    );
+    await this.restorePreparedLocalVaultSnapshot(
+      preparedRestore,
+      await this.crypto.digestVaultSnapshot(replacedSnapshot),
+    );
+  }
+
+  async prepareLocalVaultSnapshotRestore(
+    snapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
+    syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
+  ): Promise<PreparedLocalVaultSnapshotRestore> {
+    const checkpoint = await this.vaultTrust.createCheckpoint(
+      snapshot,
+      unlockedVault.trustedSnapshotContext.trust,
+      unlockedVault.deviceId,
+      unlockedVault.devicePrivateSignKey,
+    );
+
+    return {
+      snapshot,
+      checkpoint,
       ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+    };
+  }
+
+  async restorePreparedLocalVaultSnapshot(
+    preparedRestore: PreparedLocalVaultSnapshotRestore,
+    expectedSnapshotDigest: string,
+  ): Promise<void> {
+    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest,
+      snapshot: preparedRestore.snapshot,
+      checkpoint: preparedRestore.checkpoint,
+      ...(preparedRestore.syncCredentialState === undefined
+        ? {}
+        : { syncCredentialState: preparedRestore.syncCredentialState }),
     });
   }
 

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -19,11 +19,27 @@ import {
   ProviderCredentialRevocationPendingError,
   SyncRemovalPendingError,
 } from "../../errors/sync.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../session/unlocked-vault-session.service";
-import type { VaultSnapshotService } from "../snapshot/vault-snapshot.service";
+import type {
+  PreparedLocalVaultSnapshotRestore,
+  VaultSnapshotService,
+} from "../snapshot/vault-snapshot.service";
+
+type LocalMutationSyncState =
+  | {
+      readonly localSnapshot: VaultSnapshot;
+      readonly syncAccess?: undefined;
+      readonly remoteSnapshotDescriptor?: undefined;
+    }
+  | {
+      readonly localSnapshot: VaultSnapshot;
+      readonly syncAccess: SyncAccess;
+      readonly remoteSnapshotDescriptor: VaultSnapshotDescriptor;
+    };
 
 export class VaultSyncGuardService {
   private readonly syncProvider: SyncProviderPort;
@@ -64,11 +80,7 @@ export class VaultSyncGuardService {
     vaultId: string,
     unlockedVault: UnlockedVault,
     sourceSnapshotVersionVector: VersionVector,
-  ): Promise<{
-    readonly localSnapshot: VaultSnapshot;
-    readonly syncAccess?: SyncAccess;
-    readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
-  }> {
+  ): Promise<LocalMutationSyncState> {
     const localSnapshot =
       await this.vaultSnapshot.requireCurrentSnapshotForUnlockedVault(
         vaultId,
@@ -220,7 +232,8 @@ export class VaultSyncGuardService {
       readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
     },
     persistedSnapshot: VaultSnapshot,
-    unlockedVault: UnlockedVault,
+    persistedSnapshotDigest: string,
+    preparedRestore: PreparedLocalVaultSnapshotRestore,
     sessionId: string,
   ): Promise<void> {
     if (
@@ -237,17 +250,21 @@ export class VaultSyncGuardService {
         syncState.remoteSnapshotDescriptor,
       );
     } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        sessionId,
-        vaultId,
-        async () => {
-          await this.vaultSnapshot.restoreLocalVaultSnapshot(
-            syncState.localSnapshot,
-            persistedSnapshot,
-            unlockedVault,
-          );
-        },
-      );
+      const rollbackResult =
+        await this.unlockedVaultSession.restorePersistedState(
+          sessionId,
+          vaultId,
+          syncState.localSnapshot.metadata.snapshotVersionVector,
+          async () =>
+            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+              preparedRestore,
+              persistedSnapshotDigest,
+            ),
+        );
+
+      if (rollbackResult === "rollback_failed") {
+        throw new PersistedVaultRollbackIncompleteError(vaultId, error);
+      }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(vaultId);
@@ -262,7 +279,8 @@ export class VaultSyncGuardService {
     syncAccess: SyncAccess,
     localSnapshot: VaultSnapshot,
     persistedSnapshot: VaultSnapshot,
-    unlockedVault: UnlockedVault,
+    persistedSnapshotDigest: string,
+    preparedRestore: PreparedLocalVaultSnapshotRestore,
     sessionId: string,
   ): Promise<void> {
     try {
@@ -272,18 +290,21 @@ export class VaultSyncGuardService {
         null,
       );
     } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        sessionId,
-        vaultId,
-        async () => {
-          await this.vaultSnapshot.restoreLocalVaultSnapshot(
-            localSnapshot,
-            persistedSnapshot,
-            unlockedVault,
-            null,
-          );
-        },
-      );
+      const rollbackResult =
+        await this.unlockedVaultSession.restorePersistedState(
+          sessionId,
+          vaultId,
+          localSnapshot.metadata.snapshotVersionVector,
+          async () =>
+            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+              preparedRestore,
+              persistedSnapshotDigest,
+            ),
+        );
+
+      if (rollbackResult === "rollback_failed") {
+        throw new PersistedVaultRollbackIncompleteError(vaultId, error);
+      }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(vaultId);

--- a/packages/core/src/services/trust/device-revocation-consumption.service.ts
+++ b/packages/core/src/services/trust/device-revocation-consumption.service.ts
@@ -35,6 +35,7 @@ import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.erro
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import type { VaultSnapshotService } from "../snapshot/vault-snapshot.service";
 import { VaultTrustService } from "./vault-trust.service";
 
@@ -260,102 +261,115 @@ export class DeviceRevocationConsumptionService {
         algorithmSuiteId: remoteSnapshot.metadata.algorithmSuiteId,
       },
     );
-    const remoteVault = await this.crypto.decryptVaultSnapshotContent(
-      remoteSnapshot.content,
-      vaultMasterKey,
-    );
-
-    if (
-      !areJsonEqual(remoteVault.syncTarget, syncTarget) ||
-      !areJsonEqual(
-        remoteVault.syncRemovalPending,
-        params.unlockedVault.vault.syncRemovalPending,
-      )
-    ) {
-      throw new InvalidDeviceRevocationTransitionError(
-        params.vaultId,
-        "the revocation snapshot changed the sync target or removal state",
-      );
-    }
-
-    const providerCredentialRevocationPending =
-      remoteVault.providerCredentialRevocationPending;
-    const finalTransition = transitions.at(-1);
-
-    if (
-      providerCredentialRevocationPending !== undefined &&
-      (finalTransition?.type !== "revocation" ||
-        providerCredentialRevocationPending.vaultKeyGeneration !==
-          remoteSnapshot.metadata.vaultKeyGeneration ||
-        providerCredentialRevocationPending.revokedDeviceIds.length !== 1 ||
-        providerCredentialRevocationPending.revokedDeviceIds[0] !==
-          finalTransition.revokedDeviceId)
-    ) {
-      throw new InvalidDeviceRevocationTransitionError(
-        params.vaultId,
-        "the provider credential revocation marker does not match the final trust transition",
-      );
-    }
+    let vaultMasterKeyTransferred = false;
 
     try {
-      requireDeviceProfilesMatchTrust(
-        params.unlockedVault.vault,
-        new Set(
-          params.unlockedVault.trustedSnapshotContext.trust.trustedDevices.map(
-            (device) => device.deviceId,
-          ),
-        ),
-        new Set(
-          localSnapshot.trustChain.certificates.flatMap((certificate) =>
-            certificate.payload.trustedDevices.map((device) => device.deviceId),
-          ),
-        ),
+      const remoteVault = await this.crypto.decryptVaultSnapshotContent(
+        remoteSnapshot.content,
+        vaultMasterKey,
       );
-      requireDeviceProfilesMatchTrust(
+
+      if (
+        !areJsonEqual(remoteVault.syncTarget, syncTarget) ||
+        !areJsonEqual(
+          remoteVault.syncRemovalPending,
+          params.unlockedVault.vault.syncRemovalPending,
+        )
+      ) {
+        throw new InvalidDeviceRevocationTransitionError(
+          params.vaultId,
+          "the revocation snapshot changed the sync target or removal state",
+        );
+      }
+
+      const providerCredentialRevocationPending =
+        remoteVault.providerCredentialRevocationPending;
+      const finalTransition = transitions.at(-1);
+
+      if (
+        providerCredentialRevocationPending !== undefined &&
+        (finalTransition?.type !== "revocation" ||
+          providerCredentialRevocationPending.vaultKeyGeneration !==
+            remoteSnapshot.metadata.vaultKeyGeneration ||
+          providerCredentialRevocationPending.revokedDeviceIds.length !== 1 ||
+          providerCredentialRevocationPending.revokedDeviceIds[0] !==
+            finalTransition.revokedDeviceId)
+      ) {
+        throw new InvalidDeviceRevocationTransitionError(
+          params.vaultId,
+          "the provider credential revocation marker does not match the final trust transition",
+        );
+      }
+
+      try {
+        requireDeviceProfilesMatchTrust(
+          params.unlockedVault.vault,
+          new Set(
+            params.unlockedVault.trustedSnapshotContext.trust.trustedDevices.map(
+              (device) => device.deviceId,
+            ),
+          ),
+          new Set(
+            localSnapshot.trustChain.certificates.flatMap((certificate) =>
+              certificate.payload.trustedDevices.map(
+                (device) => device.deviceId,
+              ),
+            ),
+          ),
+        );
+        requireDeviceProfilesMatchTrust(
+          remoteVault,
+          new Set(
+            remoteTrust.state.trustedDevices.map((device) => device.deviceId),
+          ),
+          new Set(
+            remoteTrust.chain.certificates.flatMap((certificate) =>
+              certificate.payload.trustedDevices.map(
+                (device) => device.deviceId,
+              ),
+            ),
+          ),
+        );
+      } catch (error) {
+        throw new InvalidDeviceRevocationTransitionError(
+          params.vaultId,
+          "device profiles do not match the trusted identities",
+          { cause: error },
+        );
+      }
+
+      const trustTransitionBaseline = this.buildTrustTransitionBaseline(
+        params.vaultId,
+        params.unlockedVault.vault,
         remoteVault,
+        transitions,
         new Set(
           remoteTrust.state.trustedDevices.map((device) => device.deviceId),
         ),
-        new Set(
-          remoteTrust.chain.certificates.flatMap((certificate) =>
-            certificate.payload.trustedDevices.map((device) => device.deviceId),
-          ),
-        ),
       );
-    } catch (error) {
-      throw new InvalidDeviceRevocationTransitionError(
-        params.vaultId,
-        "device profiles do not match the trusted identities",
-        { cause: error },
-      );
+
+      vaultMasterKeyTransferred = true;
+      return {
+        replacementAccess,
+        previousEncryptedState,
+        previousState,
+        credentialContext,
+        localSnapshot,
+        remoteSnapshotDescriptor,
+        remoteSnapshot,
+        remoteTrust,
+        transitions,
+        revocations,
+        enrollments,
+        remoteVault,
+        trustTransitionBaseline,
+        vaultMasterKey,
+      };
+    } finally {
+      if (!vaultMasterKeyTransferred) {
+        bestEffortWipeArrayBuffers([vaultMasterKey]);
+      }
     }
-
-    const trustTransitionBaseline = this.buildTrustTransitionBaseline(
-      params.vaultId,
-      params.unlockedVault.vault,
-      remoteVault,
-      transitions,
-      new Set(
-        remoteTrust.state.trustedDevices.map((device) => device.deviceId),
-      ),
-    );
-
-    return {
-      replacementAccess,
-      previousEncryptedState,
-      previousState,
-      credentialContext,
-      localSnapshot,
-      remoteSnapshotDescriptor,
-      remoteSnapshot,
-      remoteTrust,
-      transitions,
-      revocations,
-      enrollments,
-      remoteVault,
-      trustTransitionBaseline,
-      vaultMasterKey,
-    };
   }
 
   private buildTrustTransitionBaseline(

--- a/packages/core/src/use-cases/clipboard/copy-entry-password.test.ts
+++ b/packages/core/src/use-cases/clipboard/copy-entry-password.test.ts
@@ -6,12 +6,17 @@ import {
   singlePasswordEntry,
 } from "../../__tests__/fixtures/vault-entries";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
-import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type {
+  ClipboardClearTask,
+  ClipboardClearTaskRepositoryPort,
+} from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { InvalidClipboardClearDelayError } from "../../errors/clipboard.errors";
 import { PasswordEntryNotFoundError } from "../../errors/vault-entry.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import { LockVaultUseCase } from "../vault-lifecycle/lock-vault";
 import {
   CopyEntryPasswordUseCase,
   type CopyEntryPasswordCommandParams,
@@ -25,14 +30,22 @@ function createContext() {
   vi.mocked(ports.ids.generateId).mockReset();
   vi.mocked(ports.ids.generateId).mockResolvedValue("clipboard-action-id");
 
+  let clipboardText = "";
   const clipboard: ClipboardPort = {
-    readText: vi.fn(async () => ""),
-    writeText: vi.fn(async () => undefined),
+    readText: vi.fn(async () => clipboardText),
+    writeText: vi.fn(async (value) => {
+      clipboardText = value;
+    }),
   };
+  let activeClipboardClearTask: ClipboardClearTask | null = null;
   const clipboardClearTasks: ClipboardClearTaskRepositoryPort = {
-    save: vi.fn(async () => undefined),
-    get: vi.fn(async () => null),
-    remove: vi.fn(async () => undefined),
+    save: vi.fn(async (task) => {
+      activeClipboardClearTask = task;
+    }),
+    get: vi.fn(async () => activeClipboardClearTask),
+    remove: vi.fn(async () => {
+      activeClipboardClearTask = null;
+    }),
   };
   const scheduledTasks: ScheduledTaskPort = {
     scheduleTask: vi.fn(async () => undefined),
@@ -52,7 +65,9 @@ function createContext() {
     values,
     ports,
     clipboard,
+    clipboardClear,
     clipboardClearTasks,
+    getClipboardText: () => clipboardText,
     scheduledTasks,
     clock,
     useCase: new CopyEntryPasswordUseCase(
@@ -66,6 +81,18 @@ function createContext() {
       ports.sessionServices.unlockedVaultSession,
     ),
   };
+}
+
+function createLockVaultUseCase(ctx: ReturnType<typeof createContext>) {
+  const lifecycleCleanup = new VaultLifecycleCleanupService(
+    ctx.clipboardClear,
+    ctx.clipboardClearTasks,
+    ctx.scheduledTasks,
+    ctx.ports.vaultLockTasks,
+    ctx.ports.sessionServices.unlockedVaultSession,
+  );
+
+  return new LockVaultUseCase(lifecycleCleanup);
 }
 
 describe("CopyEntryPasswordUseCase", () => {
@@ -113,6 +140,149 @@ describe("CopyEntryPasswordUseCase", () => {
     expect(ctx.clipboardClearTasks.save).not.toHaveBeenCalled();
     expect(ctx.scheduledTasks.scheduleTask).not.toHaveBeenCalled();
     expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("does not copy a password after a concurrent lock wins", async () => {
+    const ctx = createContext();
+    let continueLock!: () => void;
+    let markLockStarted!: () => void;
+    const lockStarted = new Promise<void>((resolve) => {
+      markLockStarted = resolve;
+    });
+    const lockCanContinue = new Promise<void>((resolve) => {
+      continueLock = resolve;
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockImplementationOnce(async () => {
+      markLockStarted();
+      await lockCanContinue;
+      return null;
+    });
+
+    const lock = createLockVaultUseCase(ctx).execute();
+    await lockStarted;
+    const copy = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entryId: singlePasswordEntry.id,
+      clearAfterMs: 60_000,
+    });
+    continueLock();
+
+    await expect(lock).resolves.toBeUndefined();
+    await expect(copy).rejects.toBeInstanceOf(VaultMustBeUnlockedError);
+    expect(ctx.clipboardClearTasks.save).not.toHaveBeenCalled();
+    expect(ctx.scheduledTasks.scheduleTask).not.toHaveBeenCalled();
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalledWith(
+      singlePasswordEntry.password,
+    );
+    expect(ctx.getClipboardText()).toBe("");
+  });
+
+  it("waits for a concurrent copy and then clears it while locking", async () => {
+    const ctx = createContext();
+    let continueCopy!: () => void;
+    let markCopyStarted!: () => void;
+    const copyStarted = new Promise<void>((resolve) => {
+      markCopyStarted = resolve;
+    });
+    const copyCanContinue = new Promise<void>((resolve) => {
+      continueCopy = resolve;
+    });
+    vi.mocked(ctx.ports.ids.generateId).mockImplementationOnce(async () => {
+      markCopyStarted();
+      await copyCanContinue;
+      return "clipboard-action-id";
+    });
+
+    const copy = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entryId: singlePasswordEntry.id,
+      clearAfterMs: 60_000,
+    });
+    await copyStarted;
+    let lockCompleted = false;
+    const lock = createLockVaultUseCase(ctx)
+      .execute()
+      .then(() => {
+        lockCompleted = true;
+      });
+    await Promise.resolve();
+    expect(lockCompleted).toBe(false);
+    continueCopy();
+
+    await expect(copy).resolves.toEqual({ copied: true });
+    await expect(lock).resolves.toBeUndefined();
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith(
+      singlePasswordEntry.password,
+    );
+    expect(ctx.clipboard.writeText).toHaveBeenLastCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    await expect(ctx.clipboardClearTasks.get()).resolves.toBeNull();
+    expect(ctx.getClipboardText()).toBe("");
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("reads the current entry after a queued snapshot commit", async () => {
+    const ctx = createContext();
+    const activeSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("Expected an active test session.");
+    }
+
+    const saveEncryptedPayload = vi.mocked(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .saveEncryptedUnlockedVaultSessionPayload,
+    );
+    const saveEncryptedPayloadOriginal =
+      saveEncryptedPayload.getMockImplementation();
+
+    if (saveEncryptedPayloadOriginal === undefined) {
+      throw new Error("Expected a session-payload save implementation.");
+    }
+
+    let continueCommit!: () => void;
+    let markCommitStarted!: () => void;
+    const commitStarted = new Promise<void>((resolve) => {
+      markCommitStarted = resolve;
+    });
+    const commitCanContinue = new Promise<void>((resolve) => {
+      continueCommit = resolve;
+    });
+    saveEncryptedPayload.mockImplementationOnce(async (payload) => {
+      markCommitStarted();
+      await commitCanContinue;
+      await saveEncryptedPayloadOriginal(payload);
+    });
+    const commit =
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot(
+        activeSession.sessionId,
+        {
+          ...activeSession.unlockedVault,
+          vault: {
+            ...activeSession.unlockedVault.vault,
+            entries: [],
+          },
+        },
+        { [ctx.values.deviceId]: 2 },
+      );
+    await commitStarted;
+
+    const copy = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entryId: singlePasswordEntry.id,
+      clearAfterMs: 60_000,
+    });
+    continueCommit();
+
+    await expect(commit).resolves.toBeUndefined();
+    await expect(copy).rejects.toBeInstanceOf(PasswordEntryNotFoundError);
+    expect(ctx.clipboardClearTasks.save).not.toHaveBeenCalled();
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalledWith(
+      singlePasswordEntry.password,
+    );
   });
 
   it("does not write to the clipboard when requested entry does not exist", async () => {

--- a/packages/core/src/use-cases/clipboard/copy-entry-password.ts
+++ b/packages/core/src/use-cases/clipboard/copy-entry-password.ts
@@ -62,99 +62,101 @@ export class CopyEntryPasswordUseCase {
       throw new InvalidClipboardClearDelayError(clearDelayResult.error);
     }
 
-    const { unlockedVault } =
-      await this.unlockedVaultSession.requireUnlockedVaultContext(
-        params.vaultId,
-        "copy entry password",
-      );
+    return this.unlockedVaultSession.runWithUnlockedVaultContext(
+      params.vaultId,
+      "copy entry password",
+      async ({ unlockedVault }) => {
+        const entry = unlockedVault.vault.entries.find(
+          (candidate) => candidate.id === params.entryId,
+        );
 
-    const entry = unlockedVault.vault.entries.find(
-      (candidate) => candidate.id === params.entryId,
-    );
+        if (entry === undefined) {
+          throw new PasswordEntryNotFoundError(params.vaultId, params.entryId);
+        }
 
-    if (entry === undefined) {
-      throw new PasswordEntryNotFoundError(params.vaultId, params.entryId);
-    }
+        const clearScheduledAt = this.clock.now() + params.clearAfterMs;
+        const previousClipboardClearTask = await this.clipboardClearTasks.get();
 
-    const clearScheduledAt = this.clock.now() + params.clearAfterMs;
-    const previousClipboardClearTask = await this.clipboardClearTasks.get();
+        if (previousClipboardClearTask !== null) {
+          let previousClearError: unknown;
 
-    if (previousClipboardClearTask !== null) {
-      let previousClearError: unknown;
+          try {
+            await this.clipboardClear.clearTask({
+              task: previousClipboardClearTask,
+              requireExpired: false,
+            });
+          } catch (error) {
+            previousClearError = error;
+          }
 
-      try {
-        await this.clipboardClear.clearTask({
-          task: previousClipboardClearTask,
-          requireExpired: false,
+          try {
+            await this.scheduledTasks.cancelTask({
+              name: "clearClipboard",
+              actionId: previousClipboardClearTask.actionId,
+            });
+          } catch (error) {
+            if (previousClearError === undefined) {
+              throw error;
+            }
+          }
+
+          if (previousClearError !== undefined) {
+            throw previousClearError;
+          }
+        }
+
+        const actionId = await this.ids.generateId();
+        const copiedValueHash = await this.crypto.hashSecretValue(
+          entry.password,
+        );
+
+        await this.clipboardClearTasks.save({
+          actionId,
+          copiedValueHash,
+          expiresAt: clearScheduledAt,
         });
-      } catch (error) {
-        previousClearError = error;
-      }
 
-      try {
-        await this.scheduledTasks.cancelTask({
-          name: "clearClipboard",
-          actionId: previousClipboardClearTask.actionId,
-        });
-      } catch (error) {
-        if (previousClearError === undefined) {
+        try {
+          await this.scheduledTasks.scheduleTask({
+            task: {
+              name: "clearClipboard",
+              actionId,
+            },
+            runAt: clearScheduledAt,
+          });
+        } catch (error) {
+          try {
+            await this.clipboardClearTasks.remove();
+          } catch {
+            // Preserve the schedule failure as the root cause.
+          }
+
           throw error;
         }
-      }
 
-      if (previousClearError !== undefined) {
-        throw previousClearError;
-      }
-    }
+        try {
+          await this.clipboard.writeText(entry.password);
+        } catch (error) {
+          try {
+            await this.scheduledTasks.cancelTask({
+              name: "clearClipboard",
+              actionId,
+            });
+          } catch {
+            // Preserve the clipboard write failure; repository cleanup still needs to run.
+          }
+          try {
+            await this.clipboardClearTasks.remove();
+          } catch {
+            // Preserve the clipboard write failure.
+          }
+          throw error;
+        }
 
-    const actionId = await this.ids.generateId();
-    const copiedValueHash = await this.crypto.hashSecretValue(entry.password);
-
-    await this.clipboardClearTasks.save({
-      actionId,
-      copiedValueHash,
-      expiresAt: clearScheduledAt,
-    });
-
-    try {
-      await this.scheduledTasks.scheduleTask({
-        task: {
-          name: "clearClipboard",
-          actionId,
-        },
-        runAt: clearScheduledAt,
-      });
-    } catch (error) {
-      try {
-        await this.clipboardClearTasks.remove();
-      } catch {
-        // Preserve the schedule failure as the root cause.
-      }
-
-      throw error;
-    }
-
-    try {
-      await this.clipboard.writeText(entry.password);
-    } catch (error) {
-      try {
-        await this.scheduledTasks.cancelTask({
-          name: "clearClipboard",
-          actionId,
-        });
-      } catch {
-        // Preserve the clipboard write failure; repository cleanup still needs to run.
-      }
-      try {
-        await this.clipboardClearTasks.remove();
-      } catch {
-        // Preserve the clipboard write failure.
-      }
-      throw error;
-    }
-
-    return {
-      copied: true,
-    };
+        return {
+          copied: true,
+        };
+      },
+    );
   }
 }

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
@@ -160,26 +160,35 @@ export class ConsumeDeviceEnrollmentUseCase {
         ...unlockedVault,
         vault: resolvedVault,
       };
-      const persistedSnapshot =
+      const { persistedSnapshot, preparedRestore } =
         await this.unlockedVaultSession.persistForActiveSession(
           sessionId,
           params.vaultId,
-          async () =>
-            this.vaultSnapshot.persistUnlockedVault(
-              params.vaultId,
-              updatedUnlockedVault,
-              sourceSnapshotVersionVector,
-              {
-                baseSnapshotVersionVector: mergeVersionVectors(
-                  candidate.localSnapshot.metadata.snapshotVersionVector,
-                  candidate.remoteSnapshot.metadata.snapshotVersionVector,
-                ),
-                keySlots: candidate.remoteSnapshot.keySlots,
-                vaultKeyGeneration:
-                  candidate.remoteSnapshot.metadata.vaultKeyGeneration,
-                nextTrust: candidate.remoteTrust,
-              },
-            ),
+          async () => {
+            const preparedRestore =
+              await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+                candidate.localSnapshot,
+                unlockedVault,
+              );
+            const persistedSnapshot =
+              await this.vaultSnapshot.persistUnlockedVault(
+                params.vaultId,
+                updatedUnlockedVault,
+                sourceSnapshotVersionVector,
+                {
+                  baseSnapshotVersionVector: mergeVersionVectors(
+                    candidate.localSnapshot.metadata.snapshotVersionVector,
+                    candidate.remoteSnapshot.metadata.snapshotVersionVector,
+                  ),
+                  keySlots: candidate.remoteSnapshot.keySlots,
+                  vaultKeyGeneration:
+                    candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+                  nextTrust: candidate.remoteTrust,
+                },
+              );
+
+            return { persistedSnapshot, preparedRestore };
+          },
         );
 
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
@@ -192,7 +201,8 @@ export class ConsumeDeviceEnrollmentUseCase {
           ),
         },
         persistedSnapshot.snapshot,
-        unlockedVault,
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        preparedRestore,
         sessionId,
       );
 

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
@@ -309,6 +309,9 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
       ctx.ports.crypto.encryptDeviceSyncCredentialState,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      Array.from(new Uint8Array(ctx.values.rotatedVaultMasterKey)),
+    ).toEqual([0]);
   });
 
   it("rejects a revocation chain that diverges from the local trust baseline", async () => {
@@ -614,6 +617,9 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
+    expect(
+      Array.from(new Uint8Array(ctx.values.rotatedVaultMasterKey)),
+    ).toEqual([0]);
   });
 
   it("rejects a provider marker bound to another vault-key generation", async () => {

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
@@ -43,6 +43,7 @@ import type { UnlockedVaultSessionService } from "../../services/session/unlocke
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { DeviceRevocationConsumptionService } from "../../services/trust/device-revocation-consumption.service";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type ConsumeDeviceRevocationCommandParams = {
   readonly vaultId: string;
@@ -117,104 +118,115 @@ export class ConsumeDeviceRevocationUseCase {
       sourceSnapshotVersionVector,
       reviewedSnapshotDescriptors,
     });
-    const entryReviews = findChangedEntries(
-      candidate.trustTransitionBaseline,
-      candidate.remoteVault,
-    );
-    const tagReviews = findChangedTags(
-      candidate.trustTransitionBaseline,
-      candidate.remoteVault,
-    );
-    const deviceProfileReviews = findChangedDeviceProfiles(
-      candidate.trustTransitionBaseline,
-      candidate.remoteVault,
-    );
+    let vaultMasterKeyTransferred = false;
 
-    if (
-      entryReviews.length !== resolution.entryResolutions.length ||
-      tagReviews.length !== resolution.tagResolutions.length ||
-      deviceProfileReviews.length !== resolution.deviceProfileResolutions.length
-    ) {
-      throw new SyncResolutionIncompleteError(params.vaultId);
-    }
-
-    const revokedDeviceIds = candidate.revocations.map(
-      (transition) => transition.revokedDeviceId,
-    );
-    const enrolledDeviceIds = candidate.enrollments.map(
-      (transition) => transition.enrolledDeviceId,
-    );
-    const encryptedCredentialState =
-      await this.crypto.encryptDeviceSyncCredentialState(
-        {
-          currentCredentials: candidate.replacementAccess.credentials,
-          previousCredentials: {
-            credentials: candidate.previousState.currentCredentials,
-            revokedDeviceIds,
-            vaultKeyGeneration:
-              candidate.remoteSnapshot.metadata.vaultKeyGeneration,
-          },
-        },
-        unlockedVault.deviceLocalProtectionKey,
-        candidate.credentialContext,
-      );
-    const hasContentChanges =
-      entryReviews.length > 0 ||
-      tagReviews.length > 0 ||
-      deviceProfileReviews.length > 0;
-
-    if (!hasContentChanges) {
-      await this.persistRemoteSnapshot(
-        sessionId,
-        unlockedVault,
-        candidate.remoteSnapshot,
-        candidate.remoteTrust.state,
+    try {
+      const entryReviews = findChangedEntries(
+        candidate.trustTransitionBaseline,
         candidate.remoteVault,
-        candidate.vaultMasterKey,
-        encryptedCredentialState,
       );
-    } else {
-      let resolvedVault: Vault;
+      const tagReviews = findChangedTags(
+        candidate.trustTransitionBaseline,
+        candidate.remoteVault,
+      );
+      const deviceProfileReviews = findChangedDeviceProfiles(
+        candidate.trustTransitionBaseline,
+        candidate.remoteVault,
+      );
 
-      try {
-        resolvedVault = applyVaultSyncResolution(
-          candidate.trustTransitionBaseline,
-          candidate.remoteVault,
-          { entryReviews, tagReviews, deviceProfileReviews },
-          resolution,
-          unlockedVault.deviceId,
-        );
-      } catch (error) {
-        if (error instanceof InvalidVaultSyncResolutionError) {
-          throw new InvalidSyncResolutionError(params.vaultId, error);
-        }
-
-        throw error;
+      if (
+        entryReviews.length !== resolution.entryResolutions.length ||
+        tagReviews.length !== resolution.tagResolutions.length ||
+        deviceProfileReviews.length !==
+          resolution.deviceProfileResolutions.length
+      ) {
+        throw new SyncResolutionIncompleteError(params.vaultId);
       }
 
-      await this.persistResolvedSnapshot({
-        vaultId: params.vaultId,
-        sessionId,
-        sourceSnapshotVersionVector,
-        unlockedVault,
-        localSnapshot: candidate.localSnapshot,
-        remoteSnapshot: candidate.remoteSnapshot,
-        remoteSnapshotDescriptor: candidate.remoteSnapshotDescriptor,
-        remoteTrust: candidate.remoteTrust,
-        replacementAccess: candidate.replacementAccess,
-        vaultMasterKey: candidate.vaultMasterKey,
-        resolvedVault,
-        previousEncryptedState: candidate.previousEncryptedState,
-        encryptedCredentialState,
-      });
-    }
+      const revokedDeviceIds = candidate.revocations.map(
+        (transition) => transition.revokedDeviceId,
+      );
+      const enrolledDeviceIds = candidate.enrollments.map(
+        (transition) => transition.enrolledDeviceId,
+      );
+      const encryptedCredentialState =
+        await this.crypto.encryptDeviceSyncCredentialState(
+          {
+            currentCredentials: candidate.replacementAccess.credentials,
+            previousCredentials: {
+              credentials: candidate.previousState.currentCredentials,
+              revokedDeviceIds,
+              vaultKeyGeneration:
+                candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+            },
+          },
+          unlockedVault.deviceLocalProtectionKey,
+          candidate.credentialContext,
+        );
+      const hasContentChanges =
+        entryReviews.length > 0 ||
+        tagReviews.length > 0 ||
+        deviceProfileReviews.length > 0;
 
-    return {
-      revokedDeviceIds,
-      enrolledDeviceIds,
-      vaultKeyGeneration: candidate.remoteSnapshot.metadata.vaultKeyGeneration,
-      providerCredentialRevocation: "pending_external_disable",
-    };
+      if (!hasContentChanges) {
+        await this.persistRemoteSnapshot(
+          sessionId,
+          unlockedVault,
+          candidate.remoteSnapshot,
+          candidate.remoteTrust.state,
+          candidate.remoteVault,
+          candidate.vaultMasterKey,
+          encryptedCredentialState,
+        );
+      } else {
+        let resolvedVault: Vault;
+
+        try {
+          resolvedVault = applyVaultSyncResolution(
+            candidate.trustTransitionBaseline,
+            candidate.remoteVault,
+            { entryReviews, tagReviews, deviceProfileReviews },
+            resolution,
+            unlockedVault.deviceId,
+          );
+        } catch (error) {
+          if (error instanceof InvalidVaultSyncResolutionError) {
+            throw new InvalidSyncResolutionError(params.vaultId, error);
+          }
+
+          throw error;
+        }
+
+        await this.persistResolvedSnapshot({
+          vaultId: params.vaultId,
+          sessionId,
+          sourceSnapshotVersionVector,
+          unlockedVault,
+          localSnapshot: candidate.localSnapshot,
+          remoteSnapshot: candidate.remoteSnapshot,
+          remoteSnapshotDescriptor: candidate.remoteSnapshotDescriptor,
+          remoteTrust: candidate.remoteTrust,
+          replacementAccess: candidate.replacementAccess,
+          vaultMasterKey: candidate.vaultMasterKey,
+          resolvedVault,
+          previousEncryptedState: candidate.previousEncryptedState,
+          encryptedCredentialState,
+        });
+      }
+      vaultMasterKeyTransferred = true;
+
+      return {
+        revokedDeviceIds,
+        enrolledDeviceIds,
+        vaultKeyGeneration:
+          candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+        providerCredentialRevocation: "pending_external_disable",
+      };
+    } finally {
+      if (!vaultMasterKeyTransferred) {
+        bestEffortWipeArrayBuffers([candidate.vaultMasterKey]);
+      }
+    }
   }
 
   private async persistRemoteSnapshot(

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
@@ -36,6 +36,7 @@ import {
   SyncConflictDetectedError,
   SyncResolutionIncompleteError,
 } from "../../errors/sync.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
@@ -298,27 +299,37 @@ export class ConsumeDeviceRevocationUseCase {
       vault: params.resolvedVault,
       vaultMasterKey: params.vaultMasterKey,
     };
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         params.sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            rotatedUnlockedVault,
-            params.sourceSnapshotVersionVector,
-            {
-              baseSnapshotVersionVector: mergeVersionVectors(
-                params.localSnapshot.metadata.snapshotVersionVector,
-                params.remoteSnapshot.metadata.snapshotVersionVector,
-              ),
-              keySlots: params.remoteSnapshot.keySlots,
-              vaultKeyGeneration:
-                params.remoteSnapshot.metadata.vaultKeyGeneration,
-              nextTrust: params.remoteTrust,
-              syncCredentialState: params.encryptedCredentialState,
-            },
-          ),
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              params.localSnapshot,
+              params.unlockedVault,
+              params.previousEncryptedState,
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              rotatedUnlockedVault,
+              params.sourceSnapshotVersionVector,
+              {
+                baseSnapshotVersionVector: mergeVersionVectors(
+                  params.localSnapshot.metadata.snapshotVersionVector,
+                  params.remoteSnapshot.metadata.snapshotVersionVector,
+                ),
+                keySlots: params.remoteSnapshot.keySlots,
+                vaultKeyGeneration:
+                  params.remoteSnapshot.metadata.vaultKeyGeneration,
+                nextTrust: params.remoteTrust,
+                syncCredentialState: params.encryptedCredentialState,
+              },
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     try {
@@ -328,17 +339,21 @@ export class ConsumeDeviceRevocationUseCase {
         cloneVaultSnapshotDescriptor(params.remoteSnapshotDescriptor),
       );
     } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        params.sessionId,
-        params.vaultId,
-        async () =>
-          this.vaultSnapshot.restoreLocalVaultSnapshot(
-            params.localSnapshot,
-            persistedSnapshot.snapshot,
-            params.unlockedVault,
-            params.previousEncryptedState,
-          ),
-      );
+      const rollbackResult =
+        await this.unlockedVaultSession.restorePersistedState(
+          params.sessionId,
+          params.vaultId,
+          params.sourceSnapshotVersionVector,
+          async () =>
+            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+              preparedRestore,
+              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+            ),
+        );
+
+      if (rollbackResult === "rollback_failed") {
+        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
+      }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(params.vaultId);

--- a/packages/core/src/use-cases/device-trust/create-device-enrollment-request.test.ts
+++ b/packages/core/src/use-cases/device-trust/create-device-enrollment-request.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import type { RawMasterPassword } from "../../domain/master-password";
@@ -83,5 +83,28 @@ describe("CreateDeviceEnrollmentRequestUseCase", () => {
     expect(request).not.toHaveProperty("devicePrivateSignKey");
     expect(request).not.toHaveProperty("devicePrivateVaultKey");
     expect(request).not.toHaveProperty("deviceLocalProtectionKey");
+    const signKeyPair = await vi.mocked(ports.crypto.generateDeviceSignKeyPair)
+      .mock.results[0]!.value;
+    const vaultKeyPair = await vi.mocked(
+      ports.crypto.generateDeviceVaultKeyPair,
+    ).mock.results[0]!.value;
+    const deviceLocalProtectionKey = await vi.mocked(
+      ports.crypto.generateDeviceLocalProtectionKey,
+    ).mock.results[0]!.value;
+    const localRootKey = await vi.mocked(ports.crypto.deriveLocalRootKey).mock
+      .results[0]!.value;
+    const pendingEnrollmentProtectionKey = await vi.mocked(
+      ports.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey,
+    ).mock.results[0]!.value;
+    for (const buffer of [
+      signKeyPair.privateKey,
+      vaultKeyPair.privateKey,
+      deviceLocalProtectionKey,
+      localRootKey,
+      pendingEnrollmentProtectionKey,
+    ]) {
+      expect(Array.from(new Uint8Array(buffer))).toEqual([0]);
+    }
+    expect(Array.from(new Uint8Array(values.localRootKey))).toEqual([2]);
   });
 });

--- a/packages/core/src/use-cases/device-trust/create-device-enrollment-request.ts
+++ b/packages/core/src/use-cases/device-trust/create-device-enrollment-request.ts
@@ -8,6 +8,7 @@ import { assertNewMasterPasswordMeetsPolicy } from "../../domain/master-password
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { IdPort } from "../../ports/system/id.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type CreateDeviceEnrollmentRequestCommandParams = {
   readonly vaultId: string;
@@ -37,62 +38,75 @@ export class CreateDeviceEnrollmentRequestUseCase {
 
     const requestId = await this.ids.generateId();
     const deviceId = await this.ids.generateId();
-    const signKeyPair = await this.crypto.generateDeviceSignKeyPair();
-    const vaultKeyPair = await this.crypto.generateDeviceVaultKeyPair();
-    const deviceLocalProtectionKey =
-      await this.crypto.generateDeviceLocalProtectionKey();
-    const payload = {
-      version: 1,
-      requestId,
-      vaultId: params.vaultId,
-      expectedGenesisCertificateDigest: params.expectedGenesisCertificateDigest,
-      deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      publicSignKey: signKeyPair.publicKey,
-      publicVaultKey: vaultKeyPair.publicKey,
-    } as const;
-    const request: DeviceEnrollmentRequest = {
-      payload,
-      signature: await this.crypto.signDeviceEnrollmentRequest(
+    const ownedSecrets: ArrayBuffer[] = [];
+
+    try {
+      const signKeyPair = await this.crypto.generateDeviceSignKeyPair();
+      ownedSecrets.push(signKeyPair.privateKey);
+      const vaultKeyPair = await this.crypto.generateDeviceVaultKeyPair();
+      ownedSecrets.push(vaultKeyPair.privateKey);
+      const deviceLocalProtectionKey =
+        await this.crypto.generateDeviceLocalProtectionKey();
+      ownedSecrets.push(deviceLocalProtectionKey);
+      const payload = {
+        version: 1,
+        requestId,
+        vaultId: params.vaultId,
+        expectedGenesisCertificateDigest:
+          params.expectedGenesisCertificateDigest,
+        deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        publicSignKey: signKeyPair.publicKey,
+        publicVaultKey: vaultKeyPair.publicKey,
+      } as const;
+      const request: DeviceEnrollmentRequest = {
         payload,
-        signKeyPair.privateKey,
-      ),
-    };
-    const privateState: DeviceEnrollmentPrivateState = {
-      request,
-      devicePrivateSignKey: signKeyPair.privateKey,
-      devicePrivateVaultKey: vaultKeyPair.privateKey,
-      deviceLocalProtectionKey,
-    };
-    const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
-    const localRootKey = await this.crypto.deriveLocalRootKey(
-      params.masterPassword,
-      masterPasswordSalt,
-    );
-    const localKeysProtectionSalt =
-      await this.crypto.generateLocalKeysProtectionSalt();
-    const protectionKey =
-      await this.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
-        localRootKey,
-        localKeysProtectionSalt,
+        signature: await this.crypto.signDeviceEnrollmentRequest(
+          payload,
+          signKeyPair.privateKey,
+        ),
+      };
+      const privateState: DeviceEnrollmentPrivateState = {
+        request,
+        devicePrivateSignKey: signKeyPair.privateKey,
+        devicePrivateVaultKey: vaultKeyPair.privateKey,
+        deviceLocalProtectionKey,
+      };
+      const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
+      const localRootKey = await this.crypto.deriveLocalRootKey(
+        params.masterPassword,
+        masterPasswordSalt,
       );
-    const pendingEnrollment: PendingDeviceEnrollment = {
-      requestId,
-      vaultId: params.vaultId,
-      deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      masterPasswordSalt,
-      localKeysProtectionSalt,
-      protectedPrivateState: await this.crypto.wrapDeviceEnrollmentPrivateState(
-        privateState,
-        protectionKey,
-      ),
-    };
+      ownedSecrets.push(localRootKey);
+      const localKeysProtectionSalt =
+        await this.crypto.generateLocalKeysProtectionSalt();
+      const protectionKey =
+        await this.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
+          localRootKey,
+          localKeysProtectionSalt,
+        );
+      ownedSecrets.push(protectionKey);
+      const pendingEnrollment: PendingDeviceEnrollment = {
+        requestId,
+        vaultId: params.vaultId,
+        deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        masterPasswordSalt,
+        localKeysProtectionSalt,
+        protectedPrivateState:
+          await this.crypto.wrapDeviceEnrollmentPrivateState(
+            privateState,
+            protectionKey,
+          ),
+      };
 
-    await this.vaultLocalRepository.savePendingDeviceEnrollment(
-      pendingEnrollment,
-    );
+      await this.vaultLocalRepository.savePendingDeviceEnrollment(
+        pendingEnrollment,
+      );
 
-    return request;
+      return request;
+    } finally {
+      bestEffortWipeArrayBuffers(ownedSecrets);
+    }
   }
 }

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -191,35 +191,45 @@ export class InitializeDeviceEnrollmentUseCase {
         },
       ),
     };
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            unlockedVault,
-            sourceSnapshotVersionVector,
-            {
-              keySlots: {
-                deviceSlots: [
-                  ...currentSnapshot.keySlots.deviceSlots,
-                  targetSlot,
-                ],
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              currentSnapshot,
+              unlockedVault,
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              unlockedVault,
+              sourceSnapshotVersionVector,
+              {
+                keySlots: {
+                  deviceSlots: [
+                    ...currentSnapshot.keySlots.deviceSlots,
+                    targetSlot,
+                  ],
+                },
+                nextTrust: {
+                  chain: nextTrust.chain,
+                  state: nextTrust.trust,
+                },
               },
-              nextTrust: {
-                chain: nextTrust.chain,
-                state: nextTrust.trust,
-              },
-            },
-          ),
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     await this.vaultSyncGuard.uploadPersistedLocalMutation(
       params.vaultId,
       syncState,
       persistedSnapshot.snapshot,
-      unlockedVault,
+      persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      preparedRestore,
       sessionId,
     );
 

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -31,6 +31,7 @@ import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 import { LockVaultUseCase } from "../vault-lifecycle/lock-vault";
 import { PerformDeviceEnrollmentUseCase } from "./perform-device-enrollment";
 
@@ -133,6 +134,13 @@ function createContext(synced = false) {
     ports.clock,
     ports.crypto,
   );
+  const lifecycleCleanup = new VaultLifecycleCleanupService(
+    clipboardClear,
+    clipboardClearTasks,
+    ports.scheduledTasks,
+    ports.vaultLockTasks,
+    ports.sessionServices.unlockedVaultSession,
+  );
   const useCase = new PerformDeviceEnrollmentUseCase(
     ports.clock,
     ports.crypto,
@@ -142,8 +150,7 @@ function createContext(synced = false) {
     ports.sessionServices.unlockedVaultSession,
     ports.vaultDisplayName,
     ports.vaultLocalRepository,
-    clipboardClear,
-    clipboardClearTasks,
+    lifecycleCleanup,
     ports.scheduledTasks,
     ports.vaultLockTasks,
   );
@@ -161,8 +168,50 @@ function createContext(synced = false) {
     clipboard,
     clipboardClear,
     clipboardClearTasks,
+    lifecycleCleanup,
     useCase,
   };
+}
+
+async function expectEnrollmentOwnedBuffersWiped(
+  ctx: ReturnType<typeof createContext>,
+): Promise<void> {
+  const pendingRootKey = await vi.mocked(ctx.ports.crypto.deriveLocalRootKey)
+    .mock.results[0]!.value;
+  const nextRootKey = await vi.mocked(ctx.ports.crypto.deriveLocalRootKey).mock
+    .results[1]!.value;
+  const pendingProtectionKey = await vi.mocked(
+    ctx.ports.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey,
+  ).mock.results[0]!.value;
+  const localProtectionKey = await vi.mocked(
+    ctx.ports.crypto.deriveLocalKeysProtectionKey,
+  ).mock.results[0]!.value;
+  const recoveryKey = await vi.mocked(ctx.ports.crypto.generateRecoveryKey).mock
+    .results[0]!.value;
+  const recoveryProtectionKey = await vi.mocked(
+    ctx.ports.crypto.deriveRecoveryLocalKeysProtectionKey,
+  ).mock.results[0]!.value;
+  const privateState = await vi.mocked(
+    ctx.ports.crypto.unwrapDeviceEnrollmentPrivateState,
+  ).mock.results[0]!.value;
+  const vaultMasterKey = await vi.mocked(
+    ctx.ports.crypto.openDeviceVaultKeyEnvelope,
+  ).mock.results[0]!.value;
+
+  for (const buffer of [
+    pendingRootKey,
+    nextRootKey,
+    pendingProtectionKey,
+    localProtectionKey,
+    recoveryKey,
+    recoveryProtectionKey,
+    privateState.devicePrivateSignKey,
+    privateState.devicePrivateVaultKey,
+    privateState.deviceLocalProtectionKey,
+    vaultMasterKey,
+  ]) {
+    expect(Array.from(new Uint8Array(buffer))).toEqual([0]);
+  }
 }
 
 describe("PerformDeviceEnrollmentUseCase", () => {
@@ -355,6 +404,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     ).not.toHaveBeenCalled();
     expect(ctx.ports.saved.localVaultDescriptor).toBeUndefined();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    await expectEnrollmentOwnedBuffersWiped(ctx);
   });
 
   it("encrypts manually supplied sync credentials only in local storage", async () => {
@@ -475,8 +525,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
     expect(ctx.ports.saved.localVaultDescriptor).toBeUndefined();
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
-    ).toHaveBeenCalledWith(ctx.values.vaultId);
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+    ).toHaveBeenCalledWith(ctx.values.vaultId, ctx.values.vaultSnapshotDigest);
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
     expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
       name: "lockVault",
@@ -485,6 +535,11 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(
       ctx.ports.vaultLockTasks.removeIfActionIsActive,
     ).toHaveBeenCalledTimes(1);
+    await expectEnrollmentOwnedBuffersWiped(ctx);
+    const payloadKey = await vi.mocked(
+      ctx.ports.crypto.generateUnlockedVaultSessionPayloadKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(payloadKey))).toEqual([0]);
   });
 
   it("preserves the activation error when local cleanup also fails", async () => {
@@ -495,7 +550,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         .saveUnlockedVaultSessionMaterial,
     ).mockRejectedValueOnce(activationError);
     vi.mocked(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
     ).mockRejectedValueOnce(new Error("local cleanup failed"));
 
     await expect(
@@ -573,6 +628,129 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
+  it("preserves advanced session keys when rejected-upload rollback cannot read material", async () => {
+    const ctx = createContext(true);
+    let rejectUpload: (error: Error) => void = () => undefined;
+    let uploadStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      uploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectUpload = reject;
+          uploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      enrollmentResponse: ctx.response,
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "New laptop",
+      lockAfterMs: 60_000,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    await started;
+    const activeSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("expected enrollment session to be active");
+    }
+
+    await ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot(
+      activeSession.sessionId,
+      activeSession.unlockedVault,
+      { [ctx.values.deviceId]: 3 },
+    );
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(new Error("material read failed"));
+    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+
+    await expect(execution).rejects.toBeInstanceOf(
+      DeviceEnrollmentRollbackIncompleteError,
+    );
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    for (const secret of [
+      activeSession.unlockedVault.vaultMasterKey,
+      activeSession.unlockedVault.devicePrivateSignKey,
+      activeSession.unlockedVault.devicePrivateVaultKey,
+      activeSession.unlockedVault.deviceLocalProtectionKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).not.toEqual([0]);
+    }
+  });
+
+  it("preserves shared keys owned by a replacement same-vault session", async () => {
+    const ctx = createContext(true);
+    let rejectUpload: (error: Error) => void = () => undefined;
+    let uploadStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      uploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectUpload = reject;
+          uploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      enrollmentResponse: ctx.response,
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "New laptop",
+      lockAfterMs: 60_000,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    await started;
+    const activeSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("expected enrollment session to be active");
+    }
+
+    vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce(
+      "replacement-session-id",
+    );
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+    await ctx.ports.sessionServices.unlockedVaultSession.activate(
+      activationGeneration,
+      activeSession.unlockedVault,
+      activeSession.sourceSnapshotVersionVector,
+    );
+    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+
+    await expect(execution).rejects.toBeInstanceOf(
+      DeviceEnrollmentRollbackIncompleteError,
+    );
+    expect(ctx.ports.saved.unlockedVaultSession?.sessionId).toBe(
+      "replacement-session-id",
+    );
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    for (const secret of [
+      activeSession.unlockedVault.vaultMasterKey,
+      activeSession.unlockedVault.devicePrivateSignKey,
+      activeSession.unlockedVault.devicePrivateVaultKey,
+      activeSession.unlockedVault.deviceLocalProtectionKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).not.toEqual([0]);
+    }
+  });
+
   it("does not report rejected enrollment upload as complete after concurrent lock", async () => {
     const ctx = createContext(true);
     let rejectUpload: (error: Error) => void = () => undefined;
@@ -589,13 +767,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
           uploadStarted();
         }),
     );
-    const lockVault = new LockVaultUseCase(
-      ctx.clipboardClear,
-      ctx.clipboardClearTasks,
-      ctx.ports.scheduledTasks,
-      ctx.ports.vaultLockTasks,
-      ctx.ports.sessionServices.unlockedVaultSession,
-    );
+    const lockVault = new LockVaultUseCase(ctx.lifecycleCleanup);
 
     const execution = ctx.useCase.execute({
       enrollmentResponse: ctx.response,

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -27,15 +27,16 @@ import {
   SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import { LocalVaultAlreadyInitializedError } from "../../errors/vault-lifecycle.errors";
+import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
+import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
+import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { LockVaultUseCase } from "../vault-lifecycle/lock-vault";
 import { PerformDeviceEnrollmentUseCase } from "./perform-device-enrollment";
 
 function createContext(synced = false) {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
-  vi.mocked(ports.ids.generateId).mockReset();
-  vi.mocked(ports.ids.generateId)
-    .mockResolvedValueOnce(values.localAccessGenerationId)
-    .mockResolvedValue(values.sessionId);
   const targetIdentity = {
     deviceId: values.pendingDeviceId,
     publicSignKey: values.pendingDevicePublicSignKey,
@@ -117,6 +118,21 @@ function createContext(synced = false) {
   ).mockResolvedValue(
     toVaultSnapshotDescriptor(values.vaultId, authorizedSnapshot),
   );
+  const clipboard: ClipboardPort = {
+    readText: vi.fn(async () => singlePasswordEntry.password),
+    writeText: vi.fn(async () => undefined),
+  };
+  const clipboardClearTasks: ClipboardClearTaskRepositoryPort = {
+    save: vi.fn(async () => undefined),
+    get: vi.fn(async () => null),
+    remove: vi.fn(async () => undefined),
+  };
+  const clipboardClear = new ClipboardClearService(
+    clipboard,
+    clipboardClearTasks,
+    ports.clock,
+    ports.crypto,
+  );
   const useCase = new PerformDeviceEnrollmentUseCase(
     ports.clock,
     ports.crypto,
@@ -126,9 +142,27 @@ function createContext(synced = false) {
     ports.sessionServices.unlockedVaultSession,
     ports.vaultDisplayName,
     ports.vaultLocalRepository,
+    clipboardClear,
+    clipboardClearTasks,
+    ports.scheduledTasks,
+    ports.vaultLockTasks,
   );
 
-  return { values, ports, response, useCase };
+  vi.mocked(ports.ids.generateId).mockReset();
+  vi.mocked(ports.ids.generateId)
+    .mockResolvedValueOnce(values.localAccessGenerationId)
+    .mockResolvedValueOnce(values.vaultLockActionId)
+    .mockResolvedValue(values.sessionId);
+
+  return {
+    values,
+    ports,
+    response,
+    clipboard,
+    clipboardClear,
+    clipboardClearTasks,
+    useCase,
+  };
 }
 
 describe("PerformDeviceEnrollmentUseCase", () => {
@@ -140,6 +174,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: "correcthorsebatterystaple" as RawMasterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(InvalidNewMasterPasswordError);
 
@@ -157,6 +192,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
     });
 
     expect(ctx.ports.crypto.deriveLocalRootKey).toHaveBeenNthCalledWith(
@@ -175,6 +211,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(DeviceAccessMaterialChangedError);
 
@@ -195,6 +232,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
       syncConfig: ctx.values.syncConfigInput,
+      lockAfterMs: 60_000,
     });
 
     const uploadedSnapshot = vi.mocked(
@@ -212,6 +250,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
     });
 
     expect(ctx.ports.crypto.openDeviceVaultKeyEnvelope).toHaveBeenCalledWith(
@@ -260,6 +299,62 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       [ctx.values.deviceId]: 2,
       [ctx.values.pendingDeviceId]: 1,
     });
+    expect(ctx.ports.vaultLockTasks.save).toHaveBeenCalledWith({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    expect(ctx.ports.scheduledTasks.scheduleTask).toHaveBeenCalledWith({
+      task: {
+        name: "lockVault",
+        actionId: ctx.values.vaultLockActionId,
+      },
+      runAt: ctx.values.timestamp + 60_000,
+    });
+  });
+
+  it("rejects an invalid lock delay before reading pending enrollment", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.useCase.execute({
+        enrollmentResponse: ctx.response,
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "New laptop",
+        lockAfterMs: 1 as never,
+      }),
+    ).rejects.toBeInstanceOf(InvalidVaultLockDelayError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.getPendingDeviceEnrollment,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.deriveLocalRootKey).not.toHaveBeenCalled();
+  });
+
+  it("rolls back local enrollment when lock scheduling fails", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.scheduledTasks.scheduleTask).mockRejectedValueOnce(
+      new Error("schedule failed"),
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        enrollmentResponse: ctx.response,
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "New laptop",
+        lockAfterMs: 60_000,
+      }),
+    ).rejects.toThrow("schedule failed");
+
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.localVaultDescriptor).toBeUndefined();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
   it("encrypts manually supplied sync credentials only in local storage", async () => {
@@ -269,6 +364,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
       syncConfig: ctx.values.syncConfigInput,
     });
 
@@ -310,6 +406,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
         syncConfig: ctx.values.syncConfigInput,
       }),
     ).rejects.toBeInstanceOf(SyncRemovalPendingError);
@@ -330,6 +427,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(PendingDeviceEnrollmentMismatchError);
 
@@ -351,6 +449,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         },
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(DeviceEnrollmentIntegrityError);
 
@@ -370,6 +469,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toThrow("session activation failed");
 
@@ -378,6 +478,13 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).toHaveBeenCalledWith(ctx.values.vaultId);
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("preserves the activation error when local cleanup also fails", async () => {
@@ -396,6 +503,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBe(activationError);
 
@@ -406,13 +514,14 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(LocalVaultAlreadyInitializedError);
 
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
-  it("preserves newer local state after enrollment upload is rejected", async () => {
+  it("preserves newer local state without reporting a rejected upload as complete", async () => {
     const ctx = createContext(true);
     let rejectUpload: (error: Error) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
@@ -433,6 +542,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
       syncConfig: ctx.values.syncConfigInput,
     });
 
@@ -450,10 +560,9 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     );
     rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
 
-    await expect(execution).resolves.toMatchObject({
-      recoveryMnemonicKey: ctx.values.recoveryMnemonicKey,
-      syncUpload: "complete",
-    });
+    await expect(execution).rejects.toBeInstanceOf(
+      DeviceEnrollmentRollbackIncompleteError,
+    );
     expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
     expect(ctx.ports.saved.unlockedVaultSession).toMatchObject({
       sourceSnapshotVersionVector: { [ctx.values.deviceId]: 3 },
@@ -461,7 +570,54 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
     ).not.toHaveBeenCalled();
-    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeUndefined();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+  });
+
+  it("does not report rejected enrollment upload as complete after concurrent lock", async () => {
+    const ctx = createContext(true);
+    let rejectUpload: (error: Error) => void = () => undefined;
+    let uploadStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      uploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectUpload = reject;
+          uploadStarted();
+        }),
+    );
+    const lockVault = new LockVaultUseCase(
+      ctx.clipboardClear,
+      ctx.clipboardClearTasks,
+      ctx.ports.scheduledTasks,
+      ctx.ports.vaultLockTasks,
+      ctx.ports.sessionServices.unlockedVaultSession,
+    );
+
+    const execution = ctx.useCase.execute({
+      enrollmentResponse: ctx.response,
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "New laptop",
+      lockAfterMs: 60_000,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    await started;
+    await lockVault.execute();
+    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+
+    await expect(execution).rejects.toBeInstanceOf(
+      DeviceEnrollmentRollbackIncompleteError,
+    );
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
   it("does not remove a locally replaced enrollment snapshot", async () => {
@@ -485,6 +641,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
       syncConfig: ctx.values.syncConfigInput,
     });
 
@@ -516,6 +673,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
       syncConfig: ctx.values.syncConfigInput,
     });
 
@@ -544,6 +702,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
         syncConfig: ctx.values.syncConfigInput,
       }),
     ).rejects.toBeInstanceOf(DeviceEnrollmentRollbackIncompleteError);
@@ -568,6 +727,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       enrollmentResponse: ctx.response,
       masterPassword: ctx.values.masterPassword,
       deviceName: "New laptop",
+      lockAfterMs: 60_000,
       syncConfig: ctx.values.syncConfigInput,
     });
 
@@ -584,6 +744,16 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("rolls back local state after a definitive compare-and-set rejection", async () => {
     const ctx = createContext(true);
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValue({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValue({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
     vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
@@ -593,6 +763,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
         syncConfig: ctx.values.syncConfigInput,
       }),
     ).rejects.toBeInstanceOf(DeviceEnrollmentRemoteSnapshotChangedError);
@@ -600,6 +771,33 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(ctx.ports.saved.localVaultDescriptor).toBeUndefined();
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+
+    const privateState = await vi.mocked(
+      ctx.ports.crypto.unwrapDeviceEnrollmentPrivateState,
+    ).mock.results[0]!.value;
+    const vaultMasterKey = await vi.mocked(
+      ctx.ports.crypto.openDeviceVaultKeyEnvelope,
+    ).mock.results[0]!.value;
+    for (const secret of [
+      privateState.devicePrivateSignKey,
+      privateState.devicePrivateVaultKey,
+      privateState.deviceLocalProtectionKey,
+      vaultMasterKey,
+    ]) {
+      expect(Array.from(new Uint8Array(secret))).toEqual([0]);
+    }
   });
 
   it("reports success when completed pending-state cleanup fails", async () => {
@@ -613,6 +811,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).resolves.toMatchObject({
       deviceId: ctx.values.pendingDeviceId,
@@ -651,6 +850,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         enrollmentResponse: ctx.response,
         masterPassword: ctx.values.masterPassword,
         deviceName: "New laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(LocalVaultAlreadyInitializedError);
 

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -54,10 +54,8 @@ import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-rep
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
-import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { VaultLockDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
-import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
-import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import type { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 import { VaultSessionActivationService } from "../../services/session/vault-session-activation.service";
 import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
@@ -101,8 +99,7 @@ export class PerformDeviceEnrollmentUseCase {
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultDisplayName: VaultDisplayNamePort,
     vaultLocalRepository: VaultLocalRepositoryPort,
-    clipboardClear: ClipboardClearService,
-    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
+    lifecycleCleanup: VaultLifecycleCleanupService,
     scheduledTasks: ScheduledTaskPort,
     vaultLockTasks: VaultLockTaskRepositoryPort,
   ) {
@@ -122,13 +119,7 @@ export class PerformDeviceEnrollmentUseCase {
       vaultLockTasks,
       unlockedVaultSession,
     );
-    this.lifecycleCleanup = new VaultLifecycleCleanupService(
-      clipboardClear,
-      clipboardClearTasks,
-      scheduledTasks,
-      vaultLockTasks,
-      unlockedVaultSession,
-    );
+    this.lifecycleCleanup = lifecycleCleanup;
   }
 
   async execute(
@@ -450,41 +441,31 @@ export class PerformDeviceEnrollmentUseCase {
         vaultTrustAnchor: response.vaultTrustAnchor,
       };
 
-      await this.vaultLocalRepository.saveInitializedLocalVault({
-        descriptor,
-        deviceAccessMaterial,
-        deviceAccessRecoveryBackup,
-        snapshot,
-        checkpoint,
-        ...(encryptedSyncCredentialState === undefined
-          ? {}
-          : { syncCredentialState: encryptedSyncCredentialState }),
-      });
-
-      let sessionId: string;
-      let sessionGeneration: number;
-
-      try {
-        const activatedSession = await this.sessionActivation.activate({
-          activationGeneration,
-          unlockedVault,
-          sourceSnapshotVersionVector: snapshot.metadata.snapshotVersionVector,
-          lockAfterMs,
-        });
-        sessionId = activatedSession.sessionId;
-        sessionGeneration = activatedSession.generation;
-        sessionActivated = true;
-      } catch (error) {
-        try {
-          await this.vaultLocalRepository.removePersistedLocalVault(
+      const activatedSession = await this.sessionActivation.activate({
+        activationGeneration,
+        unlockedVault,
+        sourceSnapshotVersionVector: snapshot.metadata.snapshotVersionVector,
+        lockAfterMs,
+        prepareActivation: async () =>
+          this.vaultLocalRepository.saveInitializedLocalVault({
+            descriptor,
+            deviceAccessMaterial,
+            deviceAccessRecoveryBackup,
+            snapshot,
+            checkpoint,
+            ...(encryptedSyncCredentialState === undefined
+              ? {}
+              : { syncCredentialState: encryptedSyncCredentialState }),
+          }),
+        rollbackPreparedActivation: async () => {
+          await this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
             response.vaultId,
+            snapshotDigest,
           );
-        } catch {
-          // Preserve the activation failure as the root cause.
-        }
-
-        throw error;
-      }
+        },
+      });
+      const { sessionId, generation: sessionGeneration } = activatedSession;
+      sessionActivated = true;
 
       let syncUpload: "complete" | "pending" = "complete";
 
@@ -519,7 +500,10 @@ export class PerformDeviceEnrollmentUseCase {
                   ),
               );
 
-            if (rollbackResult !== "session_advanced") {
+            if (
+              rollbackResult !== "session_advanced" &&
+              rollbackResult !== "session_replaced"
+            ) {
               sessionActivated = false;
             }
 

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -52,6 +52,14 @@ import type { IdPort } from "../../ports/system/id.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { VaultLockDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
+import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import { VaultSessionActivationService } from "../../services/session/vault-session-activation.service";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
 
 export type PerformDeviceEnrollmentCommandParams = {
@@ -59,6 +67,7 @@ export type PerformDeviceEnrollmentCommandParams = {
   readonly masterPassword: RawMasterPassword;
   readonly deviceName: string;
   readonly syncConfig?: SyncSetupInput;
+  readonly lockAfterMs: VaultLockDelayMs;
 };
 
 export type PerformDeviceEnrollmentResult = {
@@ -80,6 +89,8 @@ export class PerformDeviceEnrollmentUseCase {
   private readonly vaultDisplayName: VaultDisplayNamePort;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
   private readonly vaultTrust: VaultTrustService;
+  private readonly sessionActivation: VaultSessionActivationService;
+  private readonly lifecycleCleanup: VaultLifecycleCleanupService;
 
   constructor(
     clock: ClockPort,
@@ -90,6 +101,10 @@ export class PerformDeviceEnrollmentUseCase {
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultDisplayName: VaultDisplayNamePort,
     vaultLocalRepository: VaultLocalRepositoryPort,
+    clipboardClear: ClipboardClearService,
+    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
+    scheduledTasks: ScheduledTaskPort,
+    vaultLockTasks: VaultLockTaskRepositoryPort,
   ) {
     this.bip39 = bip39;
     this.clock = clock;
@@ -100,13 +115,29 @@ export class PerformDeviceEnrollmentUseCase {
     this.vaultDisplayName = vaultDisplayName;
     this.vaultLocalRepository = vaultLocalRepository;
     this.vaultTrust = new VaultTrustService(crypto);
+    this.sessionActivation = new VaultSessionActivationService(
+      clock,
+      ids,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
+    this.lifecycleCleanup = new VaultLifecycleCleanupService(
+      clipboardClear,
+      clipboardClearTasks,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
   }
 
   async execute(
     params: PerformDeviceEnrollmentCommandParams,
   ): Promise<PerformDeviceEnrollmentResult> {
+    const lockAfterMs = this.sessionActivation.requireValidLockDelay(
+      params.lockAfterMs,
+    );
     assertNewMasterPasswordMeetsPolicy(params.masterPassword);
-
     const response = params.enrollmentResponse;
     const pending = await this.vaultLocalRepository.getPendingDeviceEnrollment(
       response.requestId,
@@ -138,362 +169,397 @@ export class PerformDeviceEnrollmentUseCase {
       await this.unlockedVaultSession.requireVaultCanBeActivated(
         response.vaultId,
       );
-    const localRootKey = await this.crypto.deriveLocalRootKey(
-      params.masterPassword,
-      pending.masterPasswordSalt,
-    );
-    const pendingProtectionKey =
-      await this.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
-        localRootKey,
-        pending.localKeysProtectionSalt,
-      );
-    const privateState = await this.crypto.unwrapDeviceEnrollmentPrivateState(
-      pending.protectedPrivateState,
-      pendingProtectionKey,
-    );
-    const request = privateState.request;
-
-    if (
-      request.payload.requestId !== response.requestId ||
-      request.payload.vaultId !== response.vaultId ||
-      request.payload.deviceId !== pending.deviceId ||
-      !(await this.crypto.verifyDeviceEnrollmentRequestSignature(request)) ||
-      !(await this.crypto.verifyDeviceSignKeyPair(
-        request.payload.publicSignKey,
-        privateState.devicePrivateSignKey,
-      )) ||
-      !(await this.crypto.verifyDeviceVaultKeyPair(
-        request.payload.publicVaultKey,
-        privateState.devicePrivateVaultKey,
-      ))
-    ) {
-      throw new PendingDeviceEnrollmentMismatchError(response.requestId);
-    }
-
-    const authorizedSnapshot = response.snapshot;
-
-    if (authorizedSnapshot.metadata.id !== response.vaultId) {
-      throw new DeviceEnrollmentSnapshotMismatchError(
-        response.vaultId,
-        authorizedSnapshot.metadata.id,
-      );
-    }
-
-    if (
-      authorizedSnapshot.metadata.schemaVersion !== 1 ||
-      authorizedSnapshot.metadata.algorithmSuiteId !==
-        this.crypto.algorithmSuite.id
-    ) {
-      throw new UnsupportedAlgorithmSuiteError({
-        vaultId: response.vaultId,
-        artifact: "device enrollment snapshot",
-        expectedAlgorithmSuiteId: this.crypto.algorithmSuite.id,
-        actualAlgorithmSuiteId: authorizedSnapshot.metadata.algorithmSuiteId,
-      });
-    }
-
-    if (
-      response.vaultTrustAnchor.genesisCertificateDigest !==
-      request.payload.expectedGenesisCertificateDigest
-    ) {
-      throw new DeviceEnrollmentIntegrityError(
-        response.vaultId,
-        "response trust anchor does not match the enrollment request",
-      );
-    }
-
-    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
-      response.vaultId,
-      response.vaultTrustAnchor,
-      authorizedSnapshot.trustChain,
-    );
-    await this.vaultTrust.verifySnapshot(
-      response.vaultId,
-      authorizedSnapshot,
-      verifiedTrust,
-    );
-
-    const targetIdentity = verifiedTrust.trustedDevices.find(
-      (device) => device.deviceId === request.payload.deviceId,
-    );
-    const targetSlots = authorizedSnapshot.keySlots.deviceSlots.filter(
-      (slot) => slot.deviceId === request.payload.deviceId,
-    );
-
-    if (
-      targetIdentity === undefined ||
-      targetSlots.length !== 1 ||
-      (await this.crypto.digestDevicePublicSignKey(
-        targetIdentity.publicSignKey,
-      )) !==
-        (await this.crypto.digestDevicePublicSignKey(
-          request.payload.publicSignKey,
-        )) ||
-      (await this.crypto.digestDevicePublicVaultKey(
-        targetIdentity.publicVaultKey,
-      )) !==
-        (await this.crypto.digestDevicePublicVaultKey(
-          request.payload.publicVaultKey,
-        ))
-    ) {
-      throw new DeviceEnrollmentIntegrityError(
-        response.vaultId,
-        "target identity or vault key envelope does not match the request",
-      );
-    }
-
-    const targetSlot = targetSlots[0];
-    const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
-      targetSlot.envelope,
-      privateState.devicePrivateVaultKey,
-      {
-        vaultId: response.vaultId,
-        deviceId: request.payload.deviceId,
-        vaultKeyGeneration: authorizedSnapshot.metadata.vaultKeyGeneration,
-        algorithmSuiteId: authorizedSnapshot.metadata.algorithmSuiteId,
-      },
-    );
-    const authorizedVault = await this.crypto.decryptVaultSnapshotContent(
-      authorizedSnapshot.content,
-      vaultMasterKey,
-    );
-    const timestamp = this.clock.now();
-    const vault = addDeviceProfileToVault(
-      authorizedVault,
-      request.payload.deviceId,
-      params.deviceName,
-      timestamp,
-    );
-    const syncAccess = await this.prepareSyncAccess(
-      response.vaultId,
-      vault,
-      params.syncConfig,
-      authorizedSnapshot,
-    );
-    const unsignedSnapshot: UnsignedVaultSnapshot = {
-      metadata: {
-        ...authorizedSnapshot.metadata,
-        revisionTimestamp: timestamp,
-        snapshotVersionVector: incrementVersionVector(
-          authorizedSnapshot.metadata.snapshotVersionVector,
-          request.payload.deviceId,
-        ),
-        createdByDeviceId: request.payload.deviceId,
-      },
-      trustChain: authorizedSnapshot.trustChain,
-      keySlots: authorizedSnapshot.keySlots,
-      content: await this.crypto.encryptVaultSnapshotContent(
-        vault,
-        vaultMasterKey,
-      ),
-    };
-    const snapshot: VaultSnapshot = {
-      ...unsignedSnapshot,
-      signature: await this.crypto.signVaultSnapshot(
-        unsignedSnapshot,
-        privateState.devicePrivateSignKey,
-      ),
-    };
-    await this.vaultTrust.verifySnapshot(
-      response.vaultId,
-      snapshot,
-      verifiedTrust,
-    );
-
-    const recoverySecretKey = await this.crypto.generateRecoveryKey();
-    const recoveryMnemonicKey =
-      await this.bip39.recoveryKeyToMnemonic(recoverySecretKey);
-    const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
-    const nextLocalRootKey = await this.crypto.deriveLocalRootKey(
-      params.masterPassword,
-      masterPasswordSalt,
-    );
-    const localKeysProtectionSalt =
-      await this.crypto.generateLocalKeysProtectionSalt();
-    const localKeysProtectionKey =
-      await this.crypto.deriveLocalKeysProtectionKey(
-        nextLocalRootKey,
-        localKeysProtectionSalt,
-      );
-    const localKeysPayload: LocalKeysPayload = {
-      devicePrivateSignKey: privateState.devicePrivateSignKey,
-      devicePrivateVaultKey: privateState.devicePrivateVaultKey,
-      deviceLocalProtectionKey: privateState.deviceLocalProtectionKey,
-      vaultTrustAnchor: response.vaultTrustAnchor,
-    };
-    const recoveryLocalKeysProtectionSalt =
-      await this.crypto.generateRecoveryLocalKeysProtectionSalt();
-    const recoveryLocalKeysProtectionKey =
-      await this.crypto.deriveRecoveryLocalKeysProtectionKey(
-        recoverySecretKey,
-        recoveryLocalKeysProtectionSalt,
-      );
-    const localAccessGenerationId = await this.ids.generateId();
-
-    if (!isValidLocalAccessGenerationId(localAccessGenerationId)) {
-      throw new DeviceAccessMaterialChangedError(response.vaultId);
-    }
-    const deviceAccessMaterial: DeviceAccessMaterial = {
-      revision: INITIAL_DEVICE_ACCESS_REVISION,
-      localAccessGenerationId,
-      vaultId: response.vaultId,
-      deviceId: request.payload.deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      masterPasswordSalt,
-      localKeysProtectionSalt,
-      devicePublicSignKey: request.payload.publicSignKey,
-      devicePublicVaultKey: request.payload.publicVaultKey,
-      protectedLocalKeys: await this.crypto.wrapLocalKeysPayload(
-        localKeysPayload,
-        localKeysProtectionKey,
-      ),
-    };
-    const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
-      revision: INITIAL_DEVICE_ACCESS_REVISION,
-      localAccessGenerationId,
-      vaultId: response.vaultId,
-      deviceId: request.payload.deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      recoveryLocalKeysProtectionSalt,
-      devicePublicSignKey: request.payload.publicSignKey,
-      devicePublicVaultKey: request.payload.publicVaultKey,
-      protectedLocalKeys: await this.crypto.wrapLocalKeysPayload(
-        localKeysPayload,
-        recoveryLocalKeysProtectionKey,
-      ),
-    };
-    const descriptor: LocalVaultDescriptor = {
-      vaultId: response.vaultId,
-      displayName: await this.vaultDisplayName.generateVaultDisplayName(),
-      createdAt: authorizedSnapshot.metadata.vaultCreationTimestamp,
-    };
-    const snapshotDigest = await this.crypto.digestVaultSnapshot(snapshot);
-    const checkpoint = await this.vaultTrust.createCheckpoint(
-      snapshot,
-      verifiedTrust,
-      request.payload.deviceId,
-      privateState.devicePrivateSignKey,
-    );
-    const encryptedSyncCredentialState =
-      syncAccess === undefined
-        ? undefined
-        : await this.crypto.encryptDeviceSyncCredentialState(
-            { currentCredentials: syncAccess.credentials },
-            privateState.deviceLocalProtectionKey,
-            {
-              vaultId: response.vaultId,
-              deviceId: request.payload.deviceId,
-              provider: syncAccess.target.provider,
-              target: syncAccess.target,
-            },
-          );
-    const unlockedVault: UnlockedVault = {
-      vaultId: response.vaultId,
-      deviceId: request.payload.deviceId,
-      vault,
-      vaultMasterKey,
-      devicePrivateSignKey: privateState.devicePrivateSignKey,
-      devicePrivateVaultKey: privateState.devicePrivateVaultKey,
-      deviceLocalProtectionKey: privateState.deviceLocalProtectionKey,
-      trustedSnapshotContext: {
-        snapshotDigest,
-        trust: verifiedTrust,
-      },
-      vaultTrustAnchor: response.vaultTrustAnchor,
-    };
-
-    await this.vaultLocalRepository.saveInitializedLocalVault({
-      descriptor,
-      deviceAccessMaterial,
-      deviceAccessRecoveryBackup,
-      snapshot,
-      checkpoint,
-      ...(encryptedSyncCredentialState === undefined
-        ? {}
-        : { syncCredentialState: encryptedSyncCredentialState }),
-    });
-
-    let sessionId: string;
+    const ephemeralSecrets: ArrayBuffer[] = [];
+    const sessionSecrets: ArrayBuffer[] = [];
+    let sessionActivated = false;
 
     try {
-      sessionId = await this.unlockedVaultSession.activate(
-        activationGeneration,
-        unlockedVault,
-        snapshot.metadata.snapshotVersionVector,
+      const localRootKey = await this.crypto.deriveLocalRootKey(
+        params.masterPassword,
+        pending.masterPasswordSalt,
       );
-    } catch (error) {
-      try {
-        await this.vaultLocalRepository.removePersistedLocalVault(
-          response.vaultId,
+      ephemeralSecrets.push(localRootKey);
+      const pendingProtectionKey =
+        await this.crypto.deriveDeviceEnrollmentPrivateStateProtectionKey(
+          localRootKey,
+          pending.localKeysProtectionSalt,
         );
-      } catch {
-        // Preserve the activation failure as the root cause.
+      ephemeralSecrets.push(pendingProtectionKey);
+      const privateState = await this.crypto.unwrapDeviceEnrollmentPrivateState(
+        pending.protectedPrivateState,
+        pendingProtectionKey,
+      );
+      sessionSecrets.push(
+        privateState.devicePrivateSignKey,
+        privateState.devicePrivateVaultKey,
+        privateState.deviceLocalProtectionKey,
+      );
+      const request = privateState.request;
+
+      if (
+        request.payload.requestId !== response.requestId ||
+        request.payload.vaultId !== response.vaultId ||
+        request.payload.deviceId !== pending.deviceId ||
+        !(await this.crypto.verifyDeviceEnrollmentRequestSignature(request)) ||
+        !(await this.crypto.verifyDeviceSignKeyPair(
+          request.payload.publicSignKey,
+          privateState.devicePrivateSignKey,
+        )) ||
+        !(await this.crypto.verifyDeviceVaultKeyPair(
+          request.payload.publicVaultKey,
+          privateState.devicePrivateVaultKey,
+        ))
+      ) {
+        throw new PendingDeviceEnrollmentMismatchError(response.requestId);
       }
 
-      throw error;
-    }
+      const authorizedSnapshot = response.snapshot;
 
-    let syncUpload: "complete" | "pending" = "complete";
-
-    if (syncAccess !== undefined) {
-      try {
-        await this.syncProvider.uploadVaultSnapshot(
-          syncAccess,
-          snapshot,
-          toVaultSnapshotDescriptor(response.vaultId, authorizedSnapshot),
+      if (authorizedSnapshot.metadata.id !== response.vaultId) {
+        throw new DeviceEnrollmentSnapshotMismatchError(
+          response.vaultId,
+          authorizedSnapshot.metadata.id,
         );
-      } catch (error) {
-        if (!(error instanceof RemoteVaultSnapshotChangedError)) {
-          syncUpload = "pending";
-        } else {
-          const remoteSnapshotChanged =
-            new DeviceEnrollmentRemoteSnapshotChangedError(response.vaultId, {
-              cause: error,
-            });
-          const rollbackResult =
-            await this.unlockedVaultSession.discardIfSessionIsActive(
-              sessionId,
-              response.vaultId,
-              snapshot.metadata.snapshotVersionVector,
-              async () =>
-                this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
-                  response.vaultId,
-                  snapshotDigest,
-                ),
-            );
+      }
 
-          if (rollbackResult === "session_advanced") {
-            syncUpload = "complete";
-          } else if (rollbackResult !== "discarded") {
-            throw new DeviceEnrollmentRollbackIncompleteError(
-              response.vaultId,
-              remoteSnapshotChanged,
+      if (
+        authorizedSnapshot.metadata.schemaVersion !== 1 ||
+        authorizedSnapshot.metadata.algorithmSuiteId !==
+          this.crypto.algorithmSuite.id
+      ) {
+        throw new UnsupportedAlgorithmSuiteError({
+          vaultId: response.vaultId,
+          artifact: "device enrollment snapshot",
+          expectedAlgorithmSuiteId: this.crypto.algorithmSuite.id,
+          actualAlgorithmSuiteId: authorizedSnapshot.metadata.algorithmSuiteId,
+        });
+      }
+
+      if (
+        response.vaultTrustAnchor.genesisCertificateDigest !==
+        request.payload.expectedGenesisCertificateDigest
+      ) {
+        throw new DeviceEnrollmentIntegrityError(
+          response.vaultId,
+          "response trust anchor does not match the enrollment request",
+        );
+      }
+
+      const verifiedTrust = await this.vaultTrust.verifyTrustChain(
+        response.vaultId,
+        response.vaultTrustAnchor,
+        authorizedSnapshot.trustChain,
+      );
+      await this.vaultTrust.verifySnapshot(
+        response.vaultId,
+        authorizedSnapshot,
+        verifiedTrust,
+      );
+
+      const targetIdentity = verifiedTrust.trustedDevices.find(
+        (device) => device.deviceId === request.payload.deviceId,
+      );
+      const targetSlots = authorizedSnapshot.keySlots.deviceSlots.filter(
+        (slot) => slot.deviceId === request.payload.deviceId,
+      );
+
+      if (
+        targetIdentity === undefined ||
+        targetSlots.length !== 1 ||
+        (await this.crypto.digestDevicePublicSignKey(
+          targetIdentity.publicSignKey,
+        )) !==
+          (await this.crypto.digestDevicePublicSignKey(
+            request.payload.publicSignKey,
+          )) ||
+        (await this.crypto.digestDevicePublicVaultKey(
+          targetIdentity.publicVaultKey,
+        )) !==
+          (await this.crypto.digestDevicePublicVaultKey(
+            request.payload.publicVaultKey,
+          ))
+      ) {
+        throw new DeviceEnrollmentIntegrityError(
+          response.vaultId,
+          "target identity or vault key envelope does not match the request",
+        );
+      }
+
+      const targetSlot = targetSlots[0];
+      const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
+        targetSlot.envelope,
+        privateState.devicePrivateVaultKey,
+        {
+          vaultId: response.vaultId,
+          deviceId: request.payload.deviceId,
+          vaultKeyGeneration: authorizedSnapshot.metadata.vaultKeyGeneration,
+          algorithmSuiteId: authorizedSnapshot.metadata.algorithmSuiteId,
+        },
+      );
+      sessionSecrets.push(vaultMasterKey);
+      const authorizedVault = await this.crypto.decryptVaultSnapshotContent(
+        authorizedSnapshot.content,
+        vaultMasterKey,
+      );
+      const timestamp = this.clock.now();
+      const vault = addDeviceProfileToVault(
+        authorizedVault,
+        request.payload.deviceId,
+        params.deviceName,
+        timestamp,
+      );
+      const syncAccess = await this.prepareSyncAccess(
+        response.vaultId,
+        vault,
+        params.syncConfig,
+        authorizedSnapshot,
+      );
+      const unsignedSnapshot: UnsignedVaultSnapshot = {
+        metadata: {
+          ...authorizedSnapshot.metadata,
+          revisionTimestamp: timestamp,
+          snapshotVersionVector: incrementVersionVector(
+            authorizedSnapshot.metadata.snapshotVersionVector,
+            request.payload.deviceId,
+          ),
+          createdByDeviceId: request.payload.deviceId,
+        },
+        trustChain: authorizedSnapshot.trustChain,
+        keySlots: authorizedSnapshot.keySlots,
+        content: await this.crypto.encryptVaultSnapshotContent(
+          vault,
+          vaultMasterKey,
+        ),
+      };
+      const snapshot: VaultSnapshot = {
+        ...unsignedSnapshot,
+        signature: await this.crypto.signVaultSnapshot(
+          unsignedSnapshot,
+          privateState.devicePrivateSignKey,
+        ),
+      };
+      await this.vaultTrust.verifySnapshot(
+        response.vaultId,
+        snapshot,
+        verifiedTrust,
+      );
+
+      const recoverySecretKey = await this.crypto.generateRecoveryKey();
+      ephemeralSecrets.push(recoverySecretKey);
+      const recoveryMnemonicKey =
+        await this.bip39.recoveryKeyToMnemonic(recoverySecretKey);
+      const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
+      const nextLocalRootKey = await this.crypto.deriveLocalRootKey(
+        params.masterPassword,
+        masterPasswordSalt,
+      );
+      ephemeralSecrets.push(nextLocalRootKey);
+      const localKeysProtectionSalt =
+        await this.crypto.generateLocalKeysProtectionSalt();
+      const localKeysProtectionKey =
+        await this.crypto.deriveLocalKeysProtectionKey(
+          nextLocalRootKey,
+          localKeysProtectionSalt,
+        );
+      ephemeralSecrets.push(localKeysProtectionKey);
+      const localKeysPayload: LocalKeysPayload = {
+        devicePrivateSignKey: privateState.devicePrivateSignKey,
+        devicePrivateVaultKey: privateState.devicePrivateVaultKey,
+        deviceLocalProtectionKey: privateState.deviceLocalProtectionKey,
+        vaultTrustAnchor: response.vaultTrustAnchor,
+      };
+      const recoveryLocalKeysProtectionSalt =
+        await this.crypto.generateRecoveryLocalKeysProtectionSalt();
+      const recoveryLocalKeysProtectionKey =
+        await this.crypto.deriveRecoveryLocalKeysProtectionKey(
+          recoverySecretKey,
+          recoveryLocalKeysProtectionSalt,
+        );
+      ephemeralSecrets.push(recoveryLocalKeysProtectionKey);
+      const localAccessGenerationId = await this.ids.generateId();
+
+      if (!isValidLocalAccessGenerationId(localAccessGenerationId)) {
+        throw new DeviceAccessMaterialChangedError(response.vaultId);
+      }
+      const deviceAccessMaterial: DeviceAccessMaterial = {
+        revision: INITIAL_DEVICE_ACCESS_REVISION,
+        localAccessGenerationId,
+        vaultId: response.vaultId,
+        deviceId: request.payload.deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        masterPasswordSalt,
+        localKeysProtectionSalt,
+        devicePublicSignKey: request.payload.publicSignKey,
+        devicePublicVaultKey: request.payload.publicVaultKey,
+        protectedLocalKeys: await this.crypto.wrapLocalKeysPayload(
+          localKeysPayload,
+          localKeysProtectionKey,
+        ),
+      };
+      const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
+        revision: INITIAL_DEVICE_ACCESS_REVISION,
+        localAccessGenerationId,
+        vaultId: response.vaultId,
+        deviceId: request.payload.deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        recoveryLocalKeysProtectionSalt,
+        devicePublicSignKey: request.payload.publicSignKey,
+        devicePublicVaultKey: request.payload.publicVaultKey,
+        protectedLocalKeys: await this.crypto.wrapLocalKeysPayload(
+          localKeysPayload,
+          recoveryLocalKeysProtectionKey,
+        ),
+      };
+      const descriptor: LocalVaultDescriptor = {
+        vaultId: response.vaultId,
+        displayName: await this.vaultDisplayName.generateVaultDisplayName(),
+        createdAt: authorizedSnapshot.metadata.vaultCreationTimestamp,
+      };
+      const snapshotDigest = await this.crypto.digestVaultSnapshot(snapshot);
+      const checkpoint = await this.vaultTrust.createCheckpoint(
+        snapshot,
+        verifiedTrust,
+        request.payload.deviceId,
+        privateState.devicePrivateSignKey,
+      );
+      const encryptedSyncCredentialState =
+        syncAccess === undefined
+          ? undefined
+          : await this.crypto.encryptDeviceSyncCredentialState(
+              { currentCredentials: syncAccess.credentials },
+              privateState.deviceLocalProtectionKey,
+              {
+                vaultId: response.vaultId,
+                deviceId: request.payload.deviceId,
+                provider: syncAccess.target.provider,
+                target: syncAccess.target,
+              },
             );
+      const unlockedVault: UnlockedVault = {
+        vaultId: response.vaultId,
+        deviceId: request.payload.deviceId,
+        vault,
+        vaultMasterKey,
+        devicePrivateSignKey: privateState.devicePrivateSignKey,
+        devicePrivateVaultKey: privateState.devicePrivateVaultKey,
+        deviceLocalProtectionKey: privateState.deviceLocalProtectionKey,
+        trustedSnapshotContext: {
+          snapshotDigest,
+          trust: verifiedTrust,
+        },
+        vaultTrustAnchor: response.vaultTrustAnchor,
+      };
+
+      await this.vaultLocalRepository.saveInitializedLocalVault({
+        descriptor,
+        deviceAccessMaterial,
+        deviceAccessRecoveryBackup,
+        snapshot,
+        checkpoint,
+        ...(encryptedSyncCredentialState === undefined
+          ? {}
+          : { syncCredentialState: encryptedSyncCredentialState }),
+      });
+
+      let sessionId: string;
+      let sessionGeneration: number;
+
+      try {
+        const activatedSession = await this.sessionActivation.activate({
+          activationGeneration,
+          unlockedVault,
+          sourceSnapshotVersionVector: snapshot.metadata.snapshotVersionVector,
+          lockAfterMs,
+        });
+        sessionId = activatedSession.sessionId;
+        sessionGeneration = activatedSession.generation;
+        sessionActivated = true;
+      } catch (error) {
+        try {
+          await this.vaultLocalRepository.removePersistedLocalVault(
+            response.vaultId,
+          );
+        } catch {
+          // Preserve the activation failure as the root cause.
+        }
+
+        throw error;
+      }
+
+      let syncUpload: "complete" | "pending" = "complete";
+
+      if (syncAccess !== undefined) {
+        try {
+          await this.syncProvider.uploadVaultSnapshot(
+            syncAccess,
+            snapshot,
+            toVaultSnapshotDescriptor(response.vaultId, authorizedSnapshot),
+          );
+        } catch (error) {
+          if (!(error instanceof RemoteVaultSnapshotChangedError)) {
+            syncUpload = "pending";
           } else {
+            const remoteSnapshotChanged =
+              new DeviceEnrollmentRemoteSnapshotChangedError(response.vaultId, {
+                cause: error,
+              });
+            const rollbackResult =
+              await this.lifecycleCleanup.discardIfSessionIsActive(
+                {
+                  sessionId,
+                  vaultId: response.vaultId,
+                  generation: sessionGeneration,
+                  sourceSnapshotVersionVector:
+                    snapshot.metadata.snapshotVersionVector,
+                },
+                async () =>
+                  this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
+                    response.vaultId,
+                    snapshotDigest,
+                  ),
+              );
+
+            if (rollbackResult !== "session_advanced") {
+              sessionActivated = false;
+            }
+
+            if (rollbackResult !== "discarded") {
+              throw new DeviceEnrollmentRollbackIncompleteError(
+                response.vaultId,
+                remoteSnapshotChanged,
+              );
+            }
+
             throw remoteSnapshotChanged;
           }
         }
       }
-    }
 
-    try {
-      await this.vaultLocalRepository.removePendingDeviceEnrollment(
-        response.requestId,
-      );
-    } catch {
-      // Cleanup cannot turn an already committed enrollment into a failure.
-    }
+      try {
+        await this.vaultLocalRepository.removePendingDeviceEnrollment(
+          response.requestId,
+        );
+      } catch {
+        // Cleanup cannot turn an already committed enrollment into a failure.
+      }
 
-    return {
-      vault: toVisibleVaultFields(vault),
-      deviceId: request.payload.deviceId,
-      recoveryMnemonicKey,
-      snapshotVersionVector: {
-        ...snapshot.metadata.snapshotVersionVector,
-      },
-      revisionTimestamp: snapshot.metadata.revisionTimestamp,
-      syncUpload,
-    };
+      return {
+        vault: toVisibleVaultFields(vault),
+        deviceId: request.payload.deviceId,
+        recoveryMnemonicKey,
+        snapshotVersionVector: {
+          ...snapshot.metadata.snapshotVersionVector,
+        },
+        revisionTimestamp: snapshot.metadata.revisionTimestamp,
+        syncUpload,
+      };
+    } finally {
+      bestEffortWipeArrayBuffers(ephemeralSecrets);
+
+      if (!sessionActivated) {
+        bestEffortWipeArrayBuffers(sessionSecrets);
+      }
+    }
   }
 
   private async prepareSyncAccess(

--- a/packages/core/src/use-cases/device-trust/prepare-device-revocation-consumption.ts
+++ b/packages/core/src/use-cases/device-trust/prepare-device-revocation-consumption.ts
@@ -17,6 +17,7 @@ import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-rep
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { DeviceRevocationConsumptionService } from "../../services/trust/device-revocation-consumption.service";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type PrepareDeviceRevocationConsumptionCommandParams = {
   readonly vaultId: string;
@@ -70,37 +71,42 @@ export class PrepareDeviceRevocationConsumptionUseCase {
       sourceSnapshotVersionVector,
     });
 
-    return {
-      reviewedSnapshotDescriptors: {
-        local: toVaultSnapshotDescriptor(
-          params.vaultId,
-          candidate.localSnapshot,
+    try {
+      return {
+        reviewedSnapshotDescriptors: {
+          local: toVaultSnapshotDescriptor(
+            params.vaultId,
+            candidate.localSnapshot,
+          ),
+          remote: cloneVaultSnapshotDescriptor(
+            candidate.remoteSnapshotDescriptor,
+          ),
+        },
+        revokedDeviceIds: candidate.revocations.map(
+          (transition) => transition.revokedDeviceId,
         ),
-        remote: cloneVaultSnapshotDescriptor(
-          candidate.remoteSnapshotDescriptor,
+        enrolledDeviceIds: candidate.enrollments.map(
+          (transition) => transition.enrolledDeviceId,
         ),
-      },
-      revokedDeviceIds: candidate.revocations.map(
-        (transition) => transition.revokedDeviceId,
-      ),
-      enrolledDeviceIds: candidate.enrollments.map(
-        (transition) => transition.enrolledDeviceId,
-      ),
-      vaultKeyGeneration: candidate.remoteSnapshot.metadata.vaultKeyGeneration,
-      review: {
-        entryReviews: findChangedEntries(
-          candidate.trustTransitionBaseline,
-          candidate.remoteVault,
-        ).map(toVisibleEntryReviewItem),
-        tagReviews: findChangedTags(
-          candidate.trustTransitionBaseline,
-          candidate.remoteVault,
-        ),
-        deviceProfileReviews: findChangedDeviceProfiles(
-          candidate.trustTransitionBaseline,
-          candidate.remoteVault,
-        ),
-      },
-    };
+        vaultKeyGeneration:
+          candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+        review: {
+          entryReviews: findChangedEntries(
+            candidate.trustTransitionBaseline,
+            candidate.remoteVault,
+          ).map(toVisibleEntryReviewItem),
+          tagReviews: findChangedTags(
+            candidate.trustTransitionBaseline,
+            candidate.remoteVault,
+          ),
+          deviceProfileReviews: findChangedDeviceProfiles(
+            candidate.trustTransitionBaseline,
+            candidate.remoteVault,
+          ),
+        },
+      };
+    } finally {
+      bestEffortWipeArrayBuffers([candidate.vaultMasterKey]);
+    }
   }
 }

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -6,6 +6,7 @@ import {
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import type { DeviceAccessRecoveryBackup } from "../../domain/device-trust";
 import type { RawMasterPassword } from "../../domain/master-password";
+import type { VaultMasterKey } from "../../domain/snapshot";
 import { InvalidNewMasterPasswordError } from "../../errors/master-password.errors";
 import {
   DeviceKeySlotNotFoundError,
@@ -61,8 +62,11 @@ function deferRecoveryReplacement(ctx: ReturnType<typeof createContext>) {
   const recoveryWrappingCanContinue = new Promise<void>((resolve) => {
     continueRecoveryWrapping = resolve;
   });
+  let wrapCallCount = 0;
   wrapLocalKeysPayload.mockImplementation(async (payload, protectionKey) => {
-    if (protectionKey === ctx.values.rotatedRecoveryLocalKeysProtectionKey) {
+    wrapCallCount += 1;
+
+    if (wrapCallCount === 2) {
       markRecoveryWrappingStarted();
       await recoveryWrappingCanContinue;
     }
@@ -116,6 +120,11 @@ describe("RecoverDeviceAccessUseCase", () => {
 
   it("recovers the wrapping key and re-protects the complete local identity", async () => {
     const ctx = createContext();
+    const recoveredVaultMasterKey = new Uint8Array([7])
+      .buffer as VaultMasterKey;
+    vi.mocked(
+      ctx.ports.crypto.openDeviceVaultKeyEnvelope,
+    ).mockResolvedValueOnce(recoveredVaultMasterKey);
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
@@ -138,6 +147,14 @@ describe("RecoverDeviceAccessUseCase", () => {
       revision: ctx.backup.revision + 1,
       localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
     });
+    const recoverySecretKey = await vi.mocked(
+      ctx.ports.bip39.mnemonicToRecoveryKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(recoveredVaultMasterKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(recoverySecretKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(ctx.values.recoverySecretKey))).toEqual([
+      2,
+    ]);
   });
 
   it("rejects the old backup after a successful recovery rotation", async () => {
@@ -244,7 +261,7 @@ describe("RecoverDeviceAccessUseCase", () => {
             : ctx.deviceAccessMaterial.devicePublicSignKey,
         devicePublicVaultKey:
           identityPart === "vault key"
-            ? (new Uint8Array([2])
+            ? (new Uint8Array([3])
                 .buffer as typeof ctx.values.devicePublicVaultKey)
             : ctx.deviceAccessMaterial.devicePublicVaultKey,
       };
@@ -495,8 +512,7 @@ describe("RecoverDeviceAccessUseCase", () => {
     const passwordChangedMaterial = {
       ...ctx.deviceAccessMaterial,
       revision: ctx.deviceAccessMaterial.revision + 1,
-      localAccessGenerationId:
-        ctx.values.replacementLocalAccessGenerationId,
+      localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
       masterPasswordSalt: ctx.values.newMasterPasswordSalt,
       localKeysProtectionSalt: ctx.values.newLocalKeysProtectionSalt,
       protectedLocalKeys: ctx.values.reprotectedLocalKeys,
@@ -505,12 +521,9 @@ describe("RecoverDeviceAccessUseCase", () => {
     const passwordChangedBackup = {
       ...ctx.backup,
       revision: ctx.backup.revision + 1,
-      localAccessGenerationId:
-        ctx.values.replacementLocalAccessGenerationId,
+      localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
     };
-    expect(ctx.saved.deviceAccessRecoveryBackup).toEqual(
-      passwordChangedBackup,
-    );
+    expect(ctx.saved.deviceAccessRecoveryBackup).toEqual(passwordChangedBackup);
 
     const materialChange = recovery.catch((caught: unknown) => caught);
     continueRecoveryWrapping();
@@ -527,9 +540,7 @@ describe("RecoverDeviceAccessUseCase", () => {
     });
 
     expect(ctx.saved.deviceAccessMaterial).toEqual(passwordChangedMaterial);
-    expect(ctx.saved.deviceAccessRecoveryBackup).toEqual(
-      passwordChangedBackup,
-    );
+    expect(ctx.saved.deviceAccessRecoveryBackup).toEqual(passwordChangedBackup);
   });
 
   it("does not overwrite a concurrently replaced recovery backup", async () => {
@@ -655,7 +666,7 @@ describe("RecoverDeviceAccessUseCase", () => {
             : ctx.backup.devicePublicSignKey,
         devicePublicVaultKey:
           identityField === "devicePublicVaultKey"
-            ? (new Uint8Array([2])
+            ? (new Uint8Array([3])
                 .buffer as typeof ctx.values.devicePublicVaultKey)
             : ctx.backup.devicePublicVaultKey,
       };
@@ -714,14 +725,12 @@ describe("RecoverDeviceAccessUseCase", () => {
       deviceAccessMaterial: {
         ...ctx.deviceAccessMaterial,
         revision: 1,
-        localAccessGenerationId:
-          ctx.values.replacementLocalAccessGenerationId,
+        localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
       },
       deviceAccessRecoveryBackup: {
         ...ctx.backup,
         revision: ctx.backup.revision + 1,
-        localAccessGenerationId:
-          ctx.values.replacementLocalAccessGenerationId,
+        localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
       },
     } as unknown as Parameters<
       typeof ctx.ports.vaultLocalRepository.saveDeviceAccessRecords
@@ -751,8 +760,7 @@ describe("RecoverDeviceAccessUseCase", () => {
   it.each([
     {
       expectedDeviceAccessMaterialRevision: null,
-      expectedDeviceAccessMaterialGenerationId:
-        "local-access-generation-id",
+      expectedDeviceAccessMaterialGenerationId: "local-access-generation-id",
     },
     {
       expectedDeviceAccessMaterialRevision: 1,
@@ -821,7 +829,7 @@ describe("RecoverDeviceAccessUseCase", () => {
       ctx.saved.deviceAccessMaterial = undefined;
       const replacementPublicSignKey = new Uint8Array([1])
         .buffer as typeof ctx.values.devicePublicSignKey;
-      const replacementPublicVaultKey = new Uint8Array([2])
+      const replacementPublicVaultKey = new Uint8Array([3])
         .buffer as typeof ctx.values.devicePublicVaultKey;
       const replacementIdentity = {
         vaultId:

--- a/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.test.ts
@@ -46,6 +46,32 @@ function deferRecoveryReplacement(ctx: ReturnType<typeof createContext>) {
     ctx.ports.crypto.generateRecoveryLocalKeysProtectionSalt,
   ).mockResolvedValue(ctx.values.rotatedRecoveryLocalKeysProtectionSalt);
 
+  const deriveRecoveryLocalKeysProtectionKey = vi.mocked(
+    ctx.ports.crypto.deriveRecoveryLocalKeysProtectionKey,
+  );
+  const defaultDeriveRecoveryLocalKeysProtectionKey =
+    deriveRecoveryLocalKeysProtectionKey.getMockImplementation();
+
+  if (defaultDeriveRecoveryLocalKeysProtectionKey === undefined) {
+    throw new Error("Expected a recovery-key derivation implementation.");
+  }
+
+  let rotatedRecoveryLocalKeysProtectionKey: ArrayBuffer | undefined;
+  deriveRecoveryLocalKeysProtectionKey.mockImplementation(
+    async (recoveryKey, salt) => {
+      const protectionKey = await defaultDeriveRecoveryLocalKeysProtectionKey(
+        recoveryKey,
+        salt,
+      );
+
+      if (salt === ctx.values.rotatedRecoveryLocalKeysProtectionSalt) {
+        rotatedRecoveryLocalKeysProtectionKey = protectionKey;
+      }
+
+      return protectionKey;
+    },
+  );
+
   const wrapLocalKeysPayload = vi.mocked(ctx.ports.crypto.wrapLocalKeysPayload);
   const defaultWrapLocalKeysPayload =
     wrapLocalKeysPayload.getMockImplementation();
@@ -67,6 +93,8 @@ function deferRecoveryReplacement(ctx: ReturnType<typeof createContext>) {
     wrapCallCount += 1;
 
     if (wrapCallCount === 2) {
+      expect(rotatedRecoveryLocalKeysProtectionKey).toBeDefined();
+      expect(protectionKey).toBe(rotatedRecoveryLocalKeysProtectionKey);
       markRecoveryWrappingStarted();
       await recoveryWrappingCanContinue;
     }

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -36,6 +36,7 @@ import {
   LocalVaultTrustCheckpointNotFoundError,
   VaultTrustStateInvalidError,
 } from "../../errors/vault-trust.errors";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type RecoverDeviceAccessCommandParams = {
   readonly vaultId: string;
@@ -179,213 +180,231 @@ export class RecoverDeviceAccessUseCase {
       );
     }
 
-    const recoverySecretKey = await this.bip39.mnemonicToRecoveryKey(
-      params.recoveryMnemonicKey,
-    );
-    const recoveryLocalKeysProtectionKey =
-      await this.crypto.deriveRecoveryLocalKeysProtectionKey(
-        recoverySecretKey,
-        recoveryBackup.recoveryLocalKeysProtectionSalt,
+    const ownedSecrets: ArrayBuffer[] = [];
+
+    try {
+      const recoverySecretKey = await this.bip39.mnemonicToRecoveryKey(
+        params.recoveryMnemonicKey,
       );
-    const localKeysPayload: LocalKeysPayload =
-      await this.crypto.unwrapLocalKeysPayload(
-        recoveryBackup.protectedLocalKeys,
-        recoveryLocalKeysProtectionKey,
-      );
-    const doesDeviceSigningKeyMatchBackup =
-      await this.crypto.verifyDeviceSignKeyPair(
-        recoveryBackup.devicePublicSignKey,
+      ownedSecrets.push(recoverySecretKey);
+      const recoveryLocalKeysProtectionKey =
+        await this.crypto.deriveRecoveryLocalKeysProtectionKey(
+          recoverySecretKey,
+          recoveryBackup.recoveryLocalKeysProtectionSalt,
+        );
+      ownedSecrets.push(recoveryLocalKeysProtectionKey);
+      const localKeysPayload: LocalKeysPayload =
+        await this.crypto.unwrapLocalKeysPayload(
+          recoveryBackup.protectedLocalKeys,
+          recoveryLocalKeysProtectionKey,
+        );
+      ownedSecrets.push(
         localKeysPayload.devicePrivateSignKey,
-      );
-    const doesDeviceVaultKeyMatchBackup =
-      await this.crypto.verifyDeviceVaultKeyPair(
-        recoveryBackup.devicePublicVaultKey,
         localKeysPayload.devicePrivateVaultKey,
+        localKeysPayload.deviceLocalProtectionKey,
       );
+      const doesDeviceSigningKeyMatchBackup =
+        await this.crypto.verifyDeviceSignKeyPair(
+          recoveryBackup.devicePublicSignKey,
+          localKeysPayload.devicePrivateSignKey,
+        );
+      const doesDeviceVaultKeyMatchBackup =
+        await this.crypto.verifyDeviceVaultKeyPair(
+          recoveryBackup.devicePublicVaultKey,
+          localKeysPayload.devicePrivateVaultKey,
+        );
 
-    if (!doesDeviceSigningKeyMatchBackup || !doesDeviceVaultKeyMatchBackup) {
-      throw new DeviceKeySlotVerificationFailedError(
+      if (!doesDeviceSigningKeyMatchBackup || !doesDeviceVaultKeyMatchBackup) {
+        throw new DeviceKeySlotVerificationFailedError(
+          params.vaultId,
+          recoveryBackup.deviceId,
+        );
+      }
+
+      if (vaultSnapshot.trustChain === undefined) {
+        throw new VaultTrustStateInvalidError(
+          params.vaultId,
+          "trust chain is missing",
+        );
+      }
+
+      const checkpoint =
+        await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+          params.vaultId,
+        );
+
+      if (checkpoint === null) {
+        throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
+      }
+
+      const localDeviceIdentity = {
+        deviceId: recoveryBackup.deviceId,
+        publicSignKey: recoveryBackup.devicePublicSignKey,
+        publicVaultKey: recoveryBackup.devicePublicVaultKey,
+      };
+      await this.vaultTrust.verifyCheckpoint(
         params.vaultId,
-        recoveryBackup.deviceId,
+        checkpoint,
+        localDeviceIdentity,
       );
-    }
-
-    if (vaultSnapshot.trustChain === undefined) {
-      throw new VaultTrustStateInvalidError(
+      const verifiedTrust = await this.vaultTrust.verifyTrustChain(
         params.vaultId,
-        "trust chain is missing",
+        localKeysPayload.vaultTrustAnchor,
+        vaultSnapshot.trustChain,
       );
-    }
-
-    const checkpoint =
-      await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
-        params.vaultId,
+      const trustedRecoveredDevice = verifiedTrust.trustedDevices.find(
+        (device) => device.deviceId === recoveryBackup.deviceId,
       );
 
-    if (checkpoint === null) {
-      throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
-    }
+      if (
+        trustedRecoveredDevice === undefined ||
+        !(await this.crypto.verifyDeviceSignKeyPair(
+          trustedRecoveredDevice.publicSignKey,
+          localKeysPayload.devicePrivateSignKey,
+        )) ||
+        !(await this.crypto.verifyDeviceVaultKeyPair(
+          trustedRecoveredDevice.publicVaultKey,
+          localKeysPayload.devicePrivateVaultKey,
+        ))
+      ) {
+        throw new VaultTrustStateInvalidError(
+          params.vaultId,
+          "recovered device is not trusted",
+        );
+      }
 
-    const localDeviceIdentity = {
-      deviceId: recoveryBackup.deviceId,
-      publicSignKey: recoveryBackup.devicePublicSignKey,
-      publicVaultKey: recoveryBackup.devicePublicVaultKey,
-    };
-    await this.vaultTrust.verifyCheckpoint(
-      params.vaultId,
-      checkpoint,
-      localDeviceIdentity,
-    );
-    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
-      params.vaultId,
-      localKeysPayload.vaultTrustAnchor,
-      vaultSnapshot.trustChain,
-    );
-    const trustedRecoveredDevice = verifiedTrust.trustedDevices.find(
-      (device) => device.deviceId === recoveryBackup.deviceId,
-    );
-
-    if (
-      trustedRecoveredDevice === undefined ||
-      !(await this.crypto.verifyDeviceSignKeyPair(
-        trustedRecoveredDevice.publicSignKey,
-        localKeysPayload.devicePrivateSignKey,
-      )) ||
-      !(await this.crypto.verifyDeviceVaultKeyPair(
-        trustedRecoveredDevice.publicVaultKey,
-        localKeysPayload.devicePrivateVaultKey,
-      ))
-    ) {
-      throw new VaultTrustStateInvalidError(
-        params.vaultId,
-        "recovered device is not trusted",
-      );
-    }
-
-    await this.vaultTrust.verifySnapshot(
-      params.vaultId,
-      vaultSnapshot,
-      verifiedTrust,
-    );
-    const checkpointRelation =
-      await this.vaultTrust.requireSnapshotNotRolledBack(
+      await this.vaultTrust.verifySnapshot(
         params.vaultId,
         vaultSnapshot,
         verifiedTrust,
-        checkpoint,
       );
-
-    const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
-      deviceKeySlot.envelope,
-      localKeysPayload.devicePrivateVaultKey,
-      {
-        vaultId: params.vaultId,
-        deviceId: recoveryBackup.deviceId,
-        vaultKeyGeneration: vaultSnapshot.metadata.vaultKeyGeneration,
-        algorithmSuiteId: vaultSnapshot.metadata.algorithmSuiteId,
-      },
-    );
-
-    await this.crypto.decryptVaultSnapshotContent(
-      vaultSnapshot.content,
-      vaultMasterKey,
-    );
-
-    if (checkpointRelation === "newer") {
-      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
-        expectedSnapshotDigest:
-          await this.crypto.digestVaultSnapshot(vaultSnapshot),
-        snapshot: vaultSnapshot,
-        checkpoint: await this.vaultTrust.createCheckpoint(
+      const checkpointRelation =
+        await this.vaultTrust.requireSnapshotNotRolledBack(
+          params.vaultId,
           vaultSnapshot,
           verifiedTrust,
-          recoveryBackup.deviceId,
-          localKeysPayload.devicePrivateSignKey,
-        ),
-      });
-    }
+          checkpoint,
+        );
 
-    const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
-    const localRootKey = await this.crypto.deriveLocalRootKey(
-      params.newMasterPassword,
-      masterPasswordSalt,
-    );
-    const localKeysProtectionSalt =
-      await this.crypto.generateLocalKeysProtectionSalt();
-    const localKeysProtectionKey =
-      await this.crypto.deriveLocalKeysProtectionKey(
-        localRootKey,
-        localKeysProtectionSalt,
+      const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
+        deviceKeySlot.envelope,
+        localKeysPayload.devicePrivateVaultKey,
+        {
+          vaultId: params.vaultId,
+          deviceId: recoveryBackup.deviceId,
+          vaultKeyGeneration: vaultSnapshot.metadata.vaultKeyGeneration,
+          algorithmSuiteId: vaultSnapshot.metadata.algorithmSuiteId,
+        },
       );
-    const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
-      localKeysPayload,
-      localKeysProtectionKey,
-    );
-    const nextRecoverySecretKey = await this.crypto.generateRecoveryKey();
-    const nextRecoveryMnemonicKey = await this.bip39.recoveryKeyToMnemonic(
-      nextRecoverySecretKey,
-    );
-    const nextRecoveryLocalKeysProtectionSalt =
-      await this.crypto.generateRecoveryLocalKeysProtectionSalt();
-    const nextRecoveryLocalKeysProtectionKey =
-      await this.crypto.deriveRecoveryLocalKeysProtectionKey(
-        nextRecoverySecretKey,
-        nextRecoveryLocalKeysProtectionSalt,
+      ownedSecrets.push(vaultMasterKey);
+
+      await this.crypto.decryptVaultSnapshotContent(
+        vaultSnapshot.content,
+        vaultMasterKey,
       );
-    const nextRecoveryProtectedLocalKeys =
-      await this.crypto.wrapLocalKeysPayload(
+
+      if (checkpointRelation === "newer") {
+        await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+          expectedSnapshotDigest:
+            await this.crypto.digestVaultSnapshot(vaultSnapshot),
+          snapshot: vaultSnapshot,
+          checkpoint: await this.vaultTrust.createCheckpoint(
+            vaultSnapshot,
+            verifiedTrust,
+            recoveryBackup.deviceId,
+            localKeysPayload.devicePrivateSignKey,
+          ),
+        });
+      }
+
+      const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
+      const localRootKey = await this.crypto.deriveLocalRootKey(
+        params.newMasterPassword,
+        masterPasswordSalt,
+      );
+      ownedSecrets.push(localRootKey);
+      const localKeysProtectionSalt =
+        await this.crypto.generateLocalKeysProtectionSalt();
+      const localKeysProtectionKey =
+        await this.crypto.deriveLocalKeysProtectionKey(
+          localRootKey,
+          localKeysProtectionSalt,
+        );
+      ownedSecrets.push(localKeysProtectionKey);
+      const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
         localKeysPayload,
-        nextRecoveryLocalKeysProtectionKey,
+        localKeysProtectionKey,
       );
-    const deviceAccessMaterial: DeviceAccessMaterial = {
-      revision: nextDeviceAccessMaterialRevision,
-      localAccessGenerationId,
-      vaultId: params.vaultId,
-      deviceId: recoveryBackup.deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      masterPasswordSalt,
-      localKeysProtectionSalt,
-      devicePublicSignKey: recoveryBackup.devicePublicSignKey,
-      devicePublicVaultKey: recoveryBackup.devicePublicVaultKey,
-      protectedLocalKeys,
-    };
-    const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
-      revision: nextDeviceAccessRecoveryBackupRevision,
-      localAccessGenerationId,
-      vaultId: params.vaultId,
-      deviceId: recoveryBackup.deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      recoveryLocalKeysProtectionSalt: nextRecoveryLocalKeysProtectionSalt,
-      devicePublicSignKey: recoveryBackup.devicePublicSignKey,
-      devicePublicVaultKey: recoveryBackup.devicePublicVaultKey,
-      protectedLocalKeys: nextRecoveryProtectedLocalKeys,
-    };
+      const nextRecoverySecretKey = await this.crypto.generateRecoveryKey();
+      ownedSecrets.push(nextRecoverySecretKey);
+      const nextRecoveryMnemonicKey = await this.bip39.recoveryKeyToMnemonic(
+        nextRecoverySecretKey,
+      );
+      const nextRecoveryLocalKeysProtectionSalt =
+        await this.crypto.generateRecoveryLocalKeysProtectionSalt();
+      const nextRecoveryLocalKeysProtectionKey =
+        await this.crypto.deriveRecoveryLocalKeysProtectionKey(
+          nextRecoverySecretKey,
+          nextRecoveryLocalKeysProtectionSalt,
+        );
+      ownedSecrets.push(nextRecoveryLocalKeysProtectionKey);
+      const nextRecoveryProtectedLocalKeys =
+        await this.crypto.wrapLocalKeysPayload(
+          localKeysPayload,
+          nextRecoveryLocalKeysProtectionKey,
+        );
+      const deviceAccessMaterial: DeviceAccessMaterial = {
+        revision: nextDeviceAccessMaterialRevision,
+        localAccessGenerationId,
+        vaultId: params.vaultId,
+        deviceId: recoveryBackup.deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        masterPasswordSalt,
+        localKeysProtectionSalt,
+        devicePublicSignKey: recoveryBackup.devicePublicSignKey,
+        devicePublicVaultKey: recoveryBackup.devicePublicVaultKey,
+        protectedLocalKeys,
+      };
+      const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
+        revision: nextDeviceAccessRecoveryBackupRevision,
+        localAccessGenerationId,
+        vaultId: params.vaultId,
+        deviceId: recoveryBackup.deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        recoveryLocalKeysProtectionSalt: nextRecoveryLocalKeysProtectionSalt,
+        devicePublicSignKey: recoveryBackup.devicePublicSignKey,
+        devicePublicVaultKey: recoveryBackup.devicePublicVaultKey,
+        protectedLocalKeys: nextRecoveryProtectedLocalKeys,
+      };
 
-    const expectedDeviceAccessMaterialState =
-      expectedDeviceAccessMaterial === null
-        ? {
-            expectedDeviceAccessMaterialRevision: null,
-            expectedDeviceAccessMaterialGenerationId: null,
-          }
-        : {
-            expectedDeviceAccessMaterialRevision:
-              expectedDeviceAccessMaterial.revision,
-            expectedDeviceAccessMaterialGenerationId:
-              expectedDeviceAccessMaterial.localAccessGenerationId,
-          };
+      const expectedDeviceAccessMaterialState =
+        expectedDeviceAccessMaterial === null
+          ? {
+              expectedDeviceAccessMaterialRevision: null,
+              expectedDeviceAccessMaterialGenerationId: null,
+            }
+          : {
+              expectedDeviceAccessMaterialRevision:
+                expectedDeviceAccessMaterial.revision,
+              expectedDeviceAccessMaterialGenerationId:
+                expectedDeviceAccessMaterial.localAccessGenerationId,
+            };
 
-    await this.vaultLocalRepository.saveDeviceAccessRecords({
-      ...expectedDeviceAccessMaterialState,
-      expectedDeviceAccessRecoveryBackupRevision: recoveryBackup.revision,
-      expectedDeviceAccessRecoveryBackupGenerationId:
-        recoveryBackup.localAccessGenerationId,
-      deviceAccessMaterial,
-      deviceAccessRecoveryBackup,
-    });
+      await this.vaultLocalRepository.saveDeviceAccessRecords({
+        ...expectedDeviceAccessMaterialState,
+        expectedDeviceAccessRecoveryBackupRevision: recoveryBackup.revision,
+        expectedDeviceAccessRecoveryBackupGenerationId:
+          recoveryBackup.localAccessGenerationId,
+        deviceAccessMaterial,
+        deviceAccessRecoveryBackup,
+      });
 
-    return {
-      deviceId: recoveryBackup.deviceId,
-      recoveryMnemonicKey: nextRecoveryMnemonicKey,
-    };
+      return {
+        deviceId: recoveryBackup.deviceId,
+        recoveryMnemonicKey: nextRecoveryMnemonicKey,
+      };
+    } finally {
+      bestEffortWipeArrayBuffers(ownedSecrets);
+    }
   }
 }

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -13,6 +13,7 @@ import type { UnlockedVault } from "../../domain/session";
 import type { VaultSnapshot } from "../../domain/snapshot";
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import { InvalidDeviceRevocationTransitionError } from "../../errors/device-revocation.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import {
   ProviderCredentialRevocationPendingError,
   ReplacementSyncCredentialsRequiredError,
@@ -160,6 +161,16 @@ function createContext() {
   );
 
   return { values, ports, snapshot, useCase };
+}
+
+async function expectGeneratedVaultMasterKeyWiped(
+  ctx: ReturnType<typeof createContext>,
+): Promise<void> {
+  const generatedVaultMasterKey = await vi.mocked(
+    ctx.ports.crypto.generateVaultMasterKey,
+  ).mock.results[0]!.value;
+
+  expect(Array.from(new Uint8Array(generatedVaultMasterKey))).toEqual([0]);
 }
 
 describe("RevokeDeviceUseCase", () => {
@@ -345,10 +356,19 @@ describe("RevokeDeviceUseCase", () => {
     expect(
       ctx.ports.saved.unlockedVaultSession?.unlockedVault.vaultMasterKey,
     ).toBe(ctx.values.vaultMasterKey);
+    await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
   it("restores the old state when the session expires during upload", async () => {
     const ctx = createContext();
+    vi.mocked(
+      ctx.ports.crypto.signLocalVaultTrustCheckpoint,
+    ).mockImplementation(async (_payload, privateKey) => {
+      expect(
+        Array.from(new Uint8Array(privateKey)).some((byte) => byte !== 0),
+      ).toBe(true);
+      return ctx.values.localVaultTrustCheckpoint.signature;
+    });
     vi.mocked(
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(async () => {
@@ -369,6 +389,14 @@ describe("RevokeDeviceUseCase", () => {
       ctx.values.encryptedDeviceSyncCredentialState,
     );
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    const checkpointSignCalls = vi.mocked(
+      ctx.ports.crypto.signLocalVaultTrustCheckpoint,
+    ).mock.invocationCallOrder;
+    expect(checkpointSignCalls.at(-1)).toBeLessThan(
+      vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
+        .invocationCallOrder[0]!,
+    );
+    await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
   it.each([
@@ -397,6 +425,9 @@ describe("RevokeDeviceUseCase", () => {
       expect(
         ctx.ports.saved.unlockedVaultSession?.unlockedVault.vaultMasterKey,
       ).toBe(ctx.values.vaultMasterKey);
+      if (method === "createDeviceVaultKeyEnvelope") {
+        await expectGeneratedVaultMasterKeyWiped(ctx);
+      }
     },
   );
 
@@ -418,6 +449,7 @@ describe("RevokeDeviceUseCase", () => {
     expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
+    await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
   it("invalidates the session when upload rollback cannot be persisted", async () => {
@@ -435,9 +467,10 @@ describe("RevokeDeviceUseCase", () => {
         deviceId: ctx.values.pendingDeviceId,
         replacementSyncConfig: ctx.values.replacementSyncConfigInput,
       }),
-    ).rejects.toThrow("upload failed");
+    ).rejects.toBeInstanceOf(PersistedVaultRollbackIncompleteError);
 
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
   it("retains the rotated state and invalidates the session when post-upload session commit fails", async () => {
@@ -460,6 +493,7 @@ describe("RevokeDeviceUseCase", () => {
       ctx.values.replacementEncryptedDeviceSyncCredentialState,
     );
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
   it("can revoke an authorized device that has not created a profile yet", async () => {

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -20,6 +20,7 @@ import {
   ReplacementSyncTargetMismatchError,
   SyncConflictDetectedError,
 } from "../../errors/sync.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { ClockPort } from "../../ports/system/clock.port";
@@ -306,27 +307,37 @@ export class RevokeDeviceUseCase {
           );
       }
 
-      const persistedSnapshot =
+      const { persistedSnapshot, preparedRestore } =
         await this.unlockedVaultSession.persistForActiveSession(
           sessionId,
           params.vaultId,
-          async () =>
-            this.vaultSnapshot.persistUnlockedVault(
-              params.vaultId,
-              rotatedUnlockedVault,
-              sourceSnapshotVersionVector,
-              {
-                vaultKeyGeneration,
-                keySlots: { deviceSlots },
-                nextTrust: {
-                  chain: nextTrust.chain,
-                  state: nextTrust.trust,
+          async () => {
+            const preparedRestore =
+              await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+                currentSnapshot,
+                unlockedVault,
+                previousEncryptedCredentials,
+              );
+            const persistedSnapshot =
+              await this.vaultSnapshot.persistUnlockedVault(
+                params.vaultId,
+                rotatedUnlockedVault,
+                sourceSnapshotVersionVector,
+                {
+                  vaultKeyGeneration,
+                  keySlots: { deviceSlots },
+                  nextTrust: {
+                    chain: nextTrust.chain,
+                    state: nextTrust.trust,
+                  },
+                  ...(encryptedCredentialState === undefined
+                    ? {}
+                    : { syncCredentialState: encryptedCredentialState }),
                 },
-                ...(encryptedCredentialState === undefined
-                  ? {}
-                  : { syncCredentialState: encryptedCredentialState }),
-              },
-            ),
+              );
+
+            return { persistedSnapshot, preparedRestore };
+          },
         );
 
       try {
@@ -341,17 +352,24 @@ export class RevokeDeviceUseCase {
           );
         }
       } catch (error) {
-        await this.unlockedVaultSession.restorePersistedState(
-          sessionId,
-          params.vaultId,
-          async () =>
-            this.vaultSnapshot.restoreLocalVaultSnapshot(
-              currentSnapshot,
-              persistedSnapshot.snapshot,
-              unlockedVault,
-              previousEncryptedCredentials,
-            ),
-        );
+        const rollbackResult =
+          await this.unlockedVaultSession.restorePersistedState(
+            sessionId,
+            params.vaultId,
+            sourceSnapshotVersionVector,
+            async () =>
+              this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+                preparedRestore,
+                persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+              ),
+          );
+
+        if (rollbackResult === "rollback_failed") {
+          throw new PersistedVaultRollbackIncompleteError(
+            params.vaultId,
+            error,
+          );
+        }
 
         if (error instanceof RemoteVaultSnapshotChangedError) {
           throw new SyncConflictDetectedError(params.vaultId);

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -33,6 +33,7 @@ import {
   DeviceToRevokeNotTrustedError,
   InvalidDeviceRevocationTransitionError,
 } from "../../errors/device-revocation.errors";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type RevokeDeviceCommandParams = {
   readonly vaultId: string;
@@ -263,118 +264,127 @@ export class RevokeDeviceUseCase {
       unlockedVault.devicePrivateSignKey,
     );
     const vaultMasterKey = await this.crypto.generateVaultMasterKey();
-    const deviceSlots = await Promise.all(
-      survivors.map(async (device) => ({
-        deviceId: device.deviceId,
-        vaultKeyGeneration,
-        envelope: await this.crypto.createDeviceVaultKeyEnvelope(
-          vaultMasterKey,
-          device.publicVaultKey,
-          {
-            vaultId: params.vaultId,
-            deviceId: device.deviceId,
-            vaultKeyGeneration,
-            algorithmSuiteId: this.crypto.algorithmSuite.id,
-          },
-        ),
-      })),
-    );
-    const rotatedUnlockedVault = {
-      ...unlockedVault,
-      vault: revokedVault,
-      vaultMasterKey,
-    };
-
-    if (
-      stagedCredentialState !== undefined &&
-      replacementAccess !== undefined
-    ) {
-      encryptedCredentialState =
-        await this.crypto.encryptDeviceSyncCredentialState(
-          stagedCredentialState,
-          unlockedVault.deviceLocalProtectionKey,
-          {
-            vaultId: params.vaultId,
-            deviceId: unlockedVault.deviceId,
-            provider: replacementAccess.target.provider,
-            target: replacementAccess.target,
-          },
-        );
-    }
-
-    const persistedSnapshot =
-      await this.unlockedVaultSession.persistForActiveSession(
-        sessionId,
-        params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            rotatedUnlockedVault,
-            sourceSnapshotVersionVector,
-            {
-              vaultKeyGeneration,
-              keySlots: { deviceSlots },
-              nextTrust: {
-                chain: nextTrust.chain,
-                state: nextTrust.trust,
-              },
-              ...(encryptedCredentialState === undefined
-                ? {}
-                : { syncCredentialState: encryptedCredentialState }),
-            },
-          ),
-      );
+    let vaultMasterKeyTransferred = false;
 
     try {
-      if (
-        replacementAccess !== undefined &&
-        syncState.remoteSnapshotDescriptor !== undefined
-      ) {
-        await this.syncProvider.uploadVaultSnapshot(
-          replacementAccess,
-          persistedSnapshot.snapshot,
-          syncState.remoteSnapshotDescriptor,
-        );
-      }
-    } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        sessionId,
-        params.vaultId,
-        async () =>
-          this.vaultSnapshot.restoreLocalVaultSnapshot(
-            currentSnapshot,
-            persistedSnapshot.snapshot,
-            unlockedVault,
-            previousEncryptedCredentials,
+      const deviceSlots = await Promise.all(
+        survivors.map(async (device) => ({
+          deviceId: device.deviceId,
+          vaultKeyGeneration,
+          envelope: await this.crypto.createDeviceVaultKeyEnvelope(
+            vaultMasterKey,
+            device.publicVaultKey,
+            {
+              vaultId: params.vaultId,
+              deviceId: device.deviceId,
+              vaultKeyGeneration,
+              algorithmSuiteId: this.crypto.algorithmSuite.id,
+            },
           ),
+        })),
       );
+      const rotatedUnlockedVault = {
+        ...unlockedVault,
+        vault: revokedVault,
+        vaultMasterKey,
+      };
 
-      if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(params.vaultId);
+      if (
+        stagedCredentialState !== undefined &&
+        replacementAccess !== undefined
+      ) {
+        encryptedCredentialState =
+          await this.crypto.encryptDeviceSyncCredentialState(
+            stagedCredentialState,
+            unlockedVault.deviceLocalProtectionKey,
+            {
+              vaultId: params.vaultId,
+              deviceId: unlockedVault.deviceId,
+              provider: replacementAccess.target.provider,
+              target: replacementAccess.target,
+            },
+          );
       }
 
-      throw error;
+      const persistedSnapshot =
+        await this.unlockedVaultSession.persistForActiveSession(
+          sessionId,
+          params.vaultId,
+          async () =>
+            this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              rotatedUnlockedVault,
+              sourceSnapshotVersionVector,
+              {
+                vaultKeyGeneration,
+                keySlots: { deviceSlots },
+                nextTrust: {
+                  chain: nextTrust.chain,
+                  state: nextTrust.trust,
+                },
+                ...(encryptedCredentialState === undefined
+                  ? {}
+                  : { syncCredentialState: encryptedCredentialState }),
+              },
+            ),
+        );
+
+      try {
+        if (
+          replacementAccess !== undefined &&
+          syncState.remoteSnapshotDescriptor !== undefined
+        ) {
+          await this.syncProvider.uploadVaultSnapshot(
+            replacementAccess,
+            persistedSnapshot.snapshot,
+            syncState.remoteSnapshotDescriptor,
+          );
+        }
+      } catch (error) {
+        await this.unlockedVaultSession.restorePersistedState(
+          sessionId,
+          params.vaultId,
+          async () =>
+            this.vaultSnapshot.restoreLocalVaultSnapshot(
+              currentSnapshot,
+              persistedSnapshot.snapshot,
+              unlockedVault,
+              previousEncryptedCredentials,
+            ),
+        );
+
+        if (error instanceof RemoteVaultSnapshotChangedError) {
+          throw new SyncConflictDetectedError(params.vaultId);
+        }
+
+        throw error;
+      }
+
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        {
+          ...rotatedUnlockedVault,
+          trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+        },
+        persistedSnapshot.snapshotVersionVector,
+      );
+      vaultMasterKeyTransferred = true;
+
+      return {
+        vault: toVisibleVaultFields(revokedVault),
+        snapshotVersionVector: {
+          ...persistedSnapshot.snapshotVersionVector,
+        },
+        revisionTimestamp: persistedSnapshot.revisionTimestamp,
+        providerCredentialRevocation:
+          replacementAccess === undefined
+            ? "not_configured"
+            : "pending_external_disable",
+      };
+    } finally {
+      if (!vaultMasterKeyTransferred) {
+        bestEffortWipeArrayBuffers([vaultMasterKey]);
+      }
     }
-
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...rotatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
-
-    return {
-      vault: toVisibleVaultFields(revokedVault),
-      snapshotVersionVector: {
-        ...persistedSnapshot.snapshotVersionVector,
-      },
-      revisionTimestamp: persistedSnapshot.revisionTimestamp,
-      providerCredentialRevocation:
-        replacementAccess === undefined
-          ? "not_configured"
-          : "pending_external_disable",
-    };
   }
 }

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -35,7 +35,10 @@ import {
   SyncResolutionIncompleteError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
-import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
+import {
+  LocalVaultSnapshotChangedError,
+  PersistedVaultRollbackIncompleteError,
+} from "../../errors/vault-snapshot.errors";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
@@ -352,22 +355,31 @@ export class ApplySyncResolutionUseCase {
       ...unlockedVault,
       vault: resolvedVault,
     };
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            sourceSnapshotVersionVector,
-            {
-              baseSnapshotVersionVector: mergeVersionVectors(
-                localSnapshot.metadata.snapshotVersionVector,
-                remoteSnapshotDescriptor.snapshotVersionVector,
-              ),
-            },
-          ),
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              localSnapshot,
+              unlockedVault,
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+              {
+                baseSnapshotVersionVector: mergeVersionVectors(
+                  localSnapshot.metadata.snapshotVersionVector,
+                  remoteSnapshotDescriptor.snapshotVersionVector,
+                ),
+              },
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     try {
@@ -377,17 +389,22 @@ export class ApplySyncResolutionUseCase {
         cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
       );
     } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        sessionId,
-        params.vaultId,
-        async () => {
-          await this.vaultSnapshot.restoreLocalVaultSnapshot(
-            localSnapshot,
-            persistedSnapshot.snapshot,
-            unlockedVault,
-          );
-        },
-      );
+      const rollbackResult =
+        await this.unlockedVaultSession.restorePersistedState(
+          sessionId,
+          params.vaultId,
+          sourceSnapshotVersionVector,
+          async () => {
+            await this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+              preparedRestore,
+              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+            );
+          },
+        );
+
+      if (rollbackResult === "rollback_failed") {
+        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
+      }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(params.vaultId);

--- a/packages/core/src/use-cases/sync/complete-provider-credential-revocation.ts
+++ b/packages/core/src/use-cases/sync/complete-provider-credential-revocation.ts
@@ -13,6 +13,7 @@ import {
   SyncNotConfiguredError,
 } from "../../errors/sync.errors";
 import { InvalidDeviceRevocationTransitionError } from "../../errors/device-revocation.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import { LocalVaultTrustCheckpointNotFoundError } from "../../errors/vault-trust.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
@@ -199,17 +200,27 @@ export class CompleteProviderCredentialRevocationUseCase {
       ...unlockedVault,
       vault: clearVaultProviderCredentialRevocationPending(unlockedVault.vault),
     };
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            completedUnlockedVault,
-            sourceSnapshotVersionVector,
-            { syncCredentialState: completedState },
-          ),
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              snapshot,
+              unlockedVault,
+              encryptedState,
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              completedUnlockedVault,
+              sourceSnapshotVersionVector,
+              { syncCredentialState: completedState },
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     try {
@@ -219,17 +230,21 @@ export class CompleteProviderCredentialRevocationUseCase {
         remoteSnapshotDescriptor,
       );
     } catch (error) {
-      await this.unlockedVaultSession.restorePersistedState(
-        sessionId,
-        params.vaultId,
-        async () =>
-          this.vaultSnapshot.restoreLocalVaultSnapshot(
-            snapshot,
-            persistedSnapshot.snapshot,
-            unlockedVault,
-            encryptedState,
-          ),
-      );
+      const rollbackResult =
+        await this.unlockedVaultSession.restorePersistedState(
+          sessionId,
+          params.vaultId,
+          sourceSnapshotVersionVector,
+          async () =>
+            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
+              preparedRestore,
+              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+            ),
+        );
+
+      if (rollbackResult === "rollback_failed") {
+        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
+      }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
         throw new SyncConflictDetectedError(params.vaultId);

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -65,6 +65,75 @@ function createContext() {
   return { ...ctx, useCase };
 }
 
+function configureMultiDeviceSync(ctx: ReturnType<typeof createContext>): void {
+  const session = ctx.saved.unlockedVaultSession;
+
+  if (session === undefined) {
+    throw new Error("Expected an unlocked test session.");
+  }
+
+  const otherIdentity = {
+    deviceId: ctx.values.pendingDeviceId,
+    publicSignKey: ctx.values.pendingDevicePublicSignKey,
+    publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
+  };
+  const trustedDevices = [
+    ...session.unlockedVault.trustedSnapshotContext.trust.trustedDevices,
+    otherIdentity,
+  ];
+  const trustChain: VaultTrustChain = {
+    certificates: [
+      ...ctx.vaultSnapshot.trustChain.certificates,
+      {
+        payload: {
+          version: 1,
+          vaultId: ctx.values.vaultId,
+          generation: 1,
+          vaultKeyGeneration: 1,
+          previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
+          authorizedByDeviceId: ctx.values.deviceId,
+          trustedDevices,
+        },
+        signature: ctx.values.vaultTrustCertificateSignature,
+      },
+    ],
+  };
+  const trust: VerifiedVaultTrustState = {
+    generation: 1,
+    vaultKeyGeneration: 1,
+    certificateDigest: ctx.values.vaultTrustCertificateDigest,
+    trustedDevices,
+  };
+  const snapshot = {
+    ...ctx.vaultSnapshot,
+    trustChain,
+    keySlots: {
+      deviceSlots: [
+        ...ctx.vaultSnapshot.keySlots.deviceSlots,
+        {
+          deviceId: ctx.values.pendingDeviceId,
+          vaultKeyGeneration: 1,
+          envelope: ctx.values.pendingDeviceVaultKeyEnvelope,
+        },
+      ],
+    },
+  };
+  ctx.saved.vaultSnapshot = snapshot;
+  ctx.saved.unlockedVaultSession = {
+    ...session,
+    unlockedVault: {
+      ...session.unlockedVault,
+      trustedSnapshotContext: {
+        ...session.unlockedVault.trustedSnapshotContext,
+        trust,
+      },
+    },
+  };
+  vi.mocked(
+    ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+  ).mockResolvedValue(toVaultSnapshotDescriptor(ctx.values.vaultId, snapshot));
+}
+
 describe("DisableSyncUseCase", () => {
   it("removes remote state, local target, and local credentials", async () => {
     const ctx = createContext();
@@ -107,7 +176,9 @@ describe("DisableSyncUseCase", () => {
     vi.mocked(ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor)
       .mockResolvedValueOnce(expectedRemoteSnapshotDescriptor)
       .mockResolvedValueOnce(remoteAheadDescriptor);
-    vi.mocked(ctx.ports.syncProvider.removeVaultSnapshots).mockRejectedValueOnce(
+    vi.mocked(
+      ctx.ports.syncProvider.removeVaultSnapshots,
+    ).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
 
@@ -122,9 +193,9 @@ describe("DisableSyncUseCase", () => {
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
     ).toBeUndefined();
     expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
-    expect(
-      ctx.saved.unlockedVaultSession?.sourceSnapshotVersionVector,
-    ).toEqual(ctx.vaultSnapshot.metadata.snapshotVersionVector);
+    expect(ctx.saved.unlockedVaultSession?.sourceSnapshotVersionVector).toEqual(
+      ctx.vaultSnapshot.metadata.snapshotVersionVector,
+    );
     expect(ctx.saved.deviceSyncCredentialState).toBe(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
@@ -169,7 +240,9 @@ describe("DisableSyncUseCase", () => {
     expect(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).toHaveBeenCalledOnce();
-    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledTimes(2);
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledTimes(
+      2,
+    );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
     ).toBeUndefined();
@@ -371,74 +444,7 @@ describe("DisableSyncUseCase", () => {
 
   it("rotates the vault key and rebuilds slots when disabling multi-device sync", async () => {
     const ctx = createContext();
-    const session = ctx.saved.unlockedVaultSession;
-
-    if (session === undefined) {
-      throw new Error("Expected an unlocked test session.");
-    }
-
-    const otherIdentity = {
-      deviceId: ctx.values.pendingDeviceId,
-      publicSignKey: ctx.values.pendingDevicePublicSignKey,
-      publicVaultKey: ctx.values.pendingDevicePublicVaultKey,
-    };
-    const trustedDevices = [
-      ...session.unlockedVault.trustedSnapshotContext.trust.trustedDevices,
-      otherIdentity,
-    ];
-    const trustChain: VaultTrustChain = {
-      certificates: [
-        ...ctx.vaultSnapshot.trustChain.certificates,
-        {
-          payload: {
-            version: 1,
-            vaultId: ctx.values.vaultId,
-            generation: 1,
-            vaultKeyGeneration: 1,
-            previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
-            authorizedByDeviceId: ctx.values.deviceId,
-            trustedDevices,
-          },
-          signature: ctx.values.vaultTrustCertificateSignature,
-        },
-      ],
-    };
-    const trust: VerifiedVaultTrustState = {
-      generation: 1,
-      vaultKeyGeneration: 1,
-      certificateDigest: ctx.values.vaultTrustCertificateDigest,
-      trustedDevices,
-    };
-    const snapshot = {
-      ...ctx.vaultSnapshot,
-      trustChain,
-      keySlots: {
-        deviceSlots: [
-          ...ctx.vaultSnapshot.keySlots.deviceSlots,
-          {
-            deviceId: ctx.values.pendingDeviceId,
-            vaultKeyGeneration: 1,
-            envelope: ctx.values.pendingDeviceVaultKeyEnvelope,
-          },
-        ],
-      },
-    };
-    ctx.saved.vaultSnapshot = snapshot;
-    ctx.saved.unlockedVaultSession = {
-      ...session,
-      unlockedVault: {
-        ...session.unlockedVault,
-        trustedSnapshotContext: {
-          ...session.unlockedVault.trustedSnapshotContext,
-          trust,
-        },
-      },
-    };
-    vi.mocked(
-      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
-    ).mockResolvedValue(
-      toVaultSnapshotDescriptor(ctx.values.vaultId, snapshot),
-    );
+    configureMultiDeviceSync(ctx);
 
     await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
@@ -463,5 +469,26 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vaultMasterKey).toBe(
       ctx.values.rotatedVaultMasterKey,
     );
+  });
+
+  it("wipes a generated vault key when multi-device disable persistence fails", async () => {
+    const ctx = createContext();
+    configureMultiDeviceSync(ctx);
+    vi.mocked(
+      ctx.ports.syncProvider.removeVaultSnapshots,
+    ).mockImplementationOnce(async () => {
+      vi.mocked(
+        ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+      ).mockRejectedValueOnce(new Error("snapshot persistence failed"));
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toThrow("snapshot persistence failed");
+
+    const generatedVaultMasterKey = await vi.mocked(
+      ctx.ports.crypto.generateVaultMasterKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(generatedVaultMasterKey))).toEqual([0]);
   });
 });

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -23,6 +23,7 @@ import type { ClockPort } from "../../ports/system/clock.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultSyncGuardService } from "../../services/sync";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type DisableSyncCommandParams = {
   readonly vaultId: string;
@@ -248,60 +249,69 @@ export class DisableSyncUseCase {
     const vaultMasterKey = revokesOtherDevices
       ? await this.crypto.generateVaultMasterKey()
       : currentUnlockedVault.vaultMasterKey;
-    const deviceSlots = revokesOtherDevices
-      ? [
-          {
-            deviceId: currentUnlockedVault.deviceId,
-            vaultKeyGeneration,
-            envelope: await this.crypto.createDeviceVaultKeyEnvelope(
-              vaultMasterKey,
-              currentIdentity.publicVaultKey,
+    let vaultMasterKeyTransferred = false;
+
+    try {
+      const deviceSlots = revokesOtherDevices
+        ? [
+            {
+              deviceId: currentUnlockedVault.deviceId,
+              vaultKeyGeneration,
+              envelope: await this.crypto.createDeviceVaultKeyEnvelope(
+                vaultMasterKey,
+                currentIdentity.publicVaultKey,
+                {
+                  vaultId: params.vaultId,
+                  deviceId: currentUnlockedVault.deviceId,
+                  vaultKeyGeneration,
+                  algorithmSuiteId: this.crypto.algorithmSuite.id,
+                },
+              ),
+            },
+          ]
+        : currentSnapshot.keySlots.deviceSlots;
+      const updatedUnlockedVault = {
+        ...currentUnlockedVault,
+        vault: updatedVault,
+        vaultMasterKey,
+      };
+
+      const persistedSnapshot =
+        await this.unlockedVaultSession.persistForActiveSession(
+          sessionId,
+          params.vaultId,
+          async () =>
+            this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              currentSnapshotVersionVector,
               {
-                vaultId: params.vaultId,
-                deviceId: currentUnlockedVault.deviceId,
                 vaultKeyGeneration,
-                algorithmSuiteId: this.crypto.algorithmSuite.id,
+                keySlots: {
+                  deviceSlots,
+                },
+                nextTrust: {
+                  chain: nextTrust.chain,
+                  state: nextTrust.trust,
+                },
+                syncCredentialState: null,
               },
             ),
-          },
-        ]
-      : currentSnapshot.keySlots.deviceSlots;
-    const updatedUnlockedVault = {
-      ...currentUnlockedVault,
-      vault: updatedVault,
-      vaultMasterKey,
-    };
+        );
 
-    const persistedSnapshot =
-      await this.unlockedVaultSession.persistForActiveSession(
+      await this.unlockedVaultSession.commitPersistedSnapshot(
         sessionId,
-        params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            currentSnapshotVersionVector,
-            {
-              vaultKeyGeneration,
-              keySlots: {
-                deviceSlots,
-              },
-              nextTrust: {
-                chain: nextTrust.chain,
-                state: nextTrust.trust,
-              },
-              syncCredentialState: null,
-            },
-          ),
+        {
+          ...updatedUnlockedVault,
+          trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+        },
+        persistedSnapshot.snapshotVersionVector,
       );
-
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...updatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
+      vaultMasterKeyTransferred = true;
+    } finally {
+      if (revokesOtherDevices && !vaultMasterKeyTransferred) {
+        bestEffortWipeArrayBuffers([vaultMasterKey]);
+      }
+    }
   }
 }

--- a/packages/core/src/use-cases/sync/setup-sync.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.ts
@@ -96,17 +96,27 @@ export class SetupSyncUseCase {
       },
     };
 
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            sourceSnapshotVersionVector,
-            { syncCredentialState: encryptedCredentialState },
-          ),
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              syncState.localSnapshot,
+              unlockedVault,
+              null,
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+              { syncCredentialState: encryptedCredentialState },
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     await this.vaultSyncGuard.uploadPersistedInitialSyncSnapshot(
@@ -114,7 +124,8 @@ export class SetupSyncUseCase {
       syncAccess,
       syncState.localSnapshot,
       persistedSnapshot.snapshot,
-      unlockedVault,
+      persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      preparedRestore,
       sessionId,
     );
 

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -20,6 +20,7 @@ import {
   PasswordEntryStrengthRequirementNotMetError,
 } from "../../errors/vault-entry.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
+import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import { VaultSyncGuardService } from "../../services/sync";
 import { AddEntryUseCase } from "./add-entry";
 
@@ -519,29 +520,80 @@ describe("AddEntryUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
-    expect(ctx.vaultSnapshot.restoreLocalVaultSnapshot).toHaveBeenCalledWith(
+    expect(
+      ctx.vaultSnapshot.prepareLocalVaultSnapshotRestore,
+    ).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({
-          snapshotVersionVector: {
-            [ctx.values.deviceId]: 1,
-          },
-        }),
-      }),
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          snapshotVersionVector: {
-            [ctx.values.deviceId]: 2,
-          },
+          snapshotVersionVector: { [ctx.values.deviceId]: 1 },
         }),
       }),
       expect.objectContaining({ vaultId: ctx.values.vaultId }),
+    );
+    expect(
+      ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          metadata: expect.objectContaining({
+            snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+          }),
+        }),
+      }),
+      ctx.values.vaultSnapshotDigest,
     );
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
   });
 
-  it("restores persisted state and invalidates a session opened during upload", async () => {
+  it("does not prepare synchronized rollback after the active session expires", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const session = ctx.saved.unlockedVaultSession!;
+    const expiredError = new Error("session expired before persistence");
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.spyOn(
+      ctx.ports.sessionServices.unlockedVaultSession,
+      "persistForActiveSession",
+    ).mockRejectedValueOnce(expiredError);
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBe(expiredError);
+
+    expect(
+      ctx.vaultSnapshot.prepareLocalVaultSnapshotRestore,
+    ).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("does not restore persisted state or invalidate a session opened during upload", async () => {
     const ctx = createContext();
     const remoteSnapshotDescriptor = {
       vaultId: ctx.values.vaultId,
@@ -597,8 +649,8 @@ describe("AddEntryUseCase", () => {
       }),
     ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
-    expect(ctx.vaultSnapshot.restoreLocalVaultSnapshot).toHaveBeenCalledOnce();
-    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.vaultSnapshot.restoreLocalVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession?.sessionId).toBe("new-session-id");
   });
 
   it("invalidates the session when synced upload restoration fails", async () => {
@@ -642,9 +694,63 @@ describe("AddEntryUseCase", () => {
           url: "https://example.com/login",
         },
       }),
-    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+    ).rejects.toBeInstanceOf(PersistedVaultRollbackIncompleteError);
 
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("reports incomplete rollback when session ownership cannot be read after upload failure", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const session = ctx.saved.unlockedVaultSession!;
+    const uploadError = new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(async () => {
+      vi.mocked(
+        ctx.ports.unlockedVaultSessionMaterialRepository
+          .getUnlockedVaultSessionMaterial,
+      ).mockRejectedValueOnce(new Error("material read failed"));
+      throw uploadError;
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "PersistedVaultRollbackIncompleteError",
+      cause: uploadError,
+    });
+
+    expect(
+      ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession).toBeDefined();
   });
 
   it("does not save the session vault when snapshot persistence fails", async () => {

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -29,7 +29,7 @@ const maximumStrengthPassword = "vN7#qL2!xP9@rT4$zK6&";
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
-  const vaultSnapshot = createVaultSnapshotServiceMock(values);
+  const vaultSnapshot = createVaultSnapshotServiceMock(values, ports);
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,
@@ -113,6 +113,15 @@ describe("AddEntryUseCase", () => {
       {
         [ctx.values.deviceId]: 1,
       },
+    );
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual(
+      ctx.saved.localVaultTrustCheckpoint?.payload.snapshotVersionVector,
+    );
+    expect(ctx.saved.vaultSnapshotDigest).toBe(
+      ctx.saved.localVaultTrustCheckpoint?.payload.snapshotDigest,
+    );
+    expect(ctx.saved.vaultSnapshotDigest).not.toBe(
+      ctx.values.vaultSnapshotDigest,
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
@@ -540,8 +549,32 @@ describe("AddEntryUseCase", () => {
           }),
         }),
       }),
-      ctx.values.vaultSnapshotDigest,
+      expect.any(String),
     );
+    const persistedSnapshotDigest = vi.mocked(
+      ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+    ).mock.calls[0]?.[1];
+
+    expect(persistedSnapshotDigest).toBeDefined();
+    expect(persistedSnapshotDigest).not.toBe(ctx.values.vaultSnapshotDigest);
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 1,
+    });
+    expect(ctx.saved.localVaultTrustCheckpoint).toBe(
+      ctx.values.localVaultTrustCheckpoint,
+    );
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedSnapshotDigest: persistedSnapshotDigest,
+        checkpoint: ctx.values.localVaultTrustCheckpoint,
+      }),
+    );
+    expect(ctx.saved.vaultSnapshotDigest).toBe(ctx.values.vaultSnapshotDigest);
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
@@ -677,12 +710,31 @@ describe("AddEntryUseCase", () => {
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockResolvedValueOnce(remoteSnapshotDescriptor);
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
-    );
     vi.mocked(
-      ctx.vaultSnapshot.restoreLocalVaultSnapshot,
-    ).mockRejectedValueOnce(new Error("restore failed"));
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(async () => {
+      const concurrentSnapshotDigest = "concurrent-snapshot-digest";
+      const concurrentSnapshotVersionVector = {
+        [ctx.values.deviceId]: 99,
+      };
+      ctx.saved.vaultSnapshot = {
+        ...ctx.saved.vaultSnapshot!,
+        metadata: {
+          ...ctx.saved.vaultSnapshot!.metadata,
+          snapshotVersionVector: concurrentSnapshotVersionVector,
+        },
+      };
+      ctx.saved.vaultSnapshotDigest = concurrentSnapshotDigest;
+      ctx.saved.localVaultTrustCheckpoint = {
+        ...ctx.saved.localVaultTrustCheckpoint!,
+        payload: {
+          ...ctx.saved.localVaultTrustCheckpoint!.payload,
+          snapshotVersionVector: concurrentSnapshotVersionVector,
+          snapshotDigest: concurrentSnapshotDigest,
+        },
+      };
+      throw new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+    });
 
     await expect(
       ctx.useCase.execute({
@@ -697,6 +749,20 @@ describe("AddEntryUseCase", () => {
     ).rejects.toBeInstanceOf(PersistedVaultRollbackIncompleteError);
 
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.saved.vaultSnapshotDigest).toBe("concurrent-snapshot-digest");
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 99,
+    });
+    expect(
+      ctx.saved.localVaultTrustCheckpoint?.payload.snapshotVersionVector,
+    ).toEqual({ [ctx.values.deviceId]: 99 });
+    await expect(
+      ctx.vaultSnapshot.requireLocalVaultSnapshot(ctx.values.vaultId),
+    ).resolves.toMatchObject({
+      metadata: {
+        snapshotVersionVector: { [ctx.values.deviceId]: 99 },
+      },
+    });
   });
 
   it("reports incomplete rollback when session ownership cannot be read after upload failure", async () => {

--- a/packages/core/src/use-cases/vault-entries/add-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.ts
@@ -97,25 +97,40 @@ export class AddEntryUseCase {
         unlockedVault.deviceId,
       ),
     };
-
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            sourceSnapshotVersionVector,
-          ),
+        async () => {
+          const preparedRestore =
+            syncState.syncAccess === undefined
+              ? undefined
+              : await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+                  syncState.localSnapshot,
+                  unlockedVault,
+                );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     if (syncState.syncAccess !== undefined) {
+      if (preparedRestore === undefined) {
+        throw new Error("Synchronized mutation rollback was not prepared.");
+      }
+
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
-        updatedUnlockedVault,
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        preparedRestore,
         sessionId,
       );
     }

--- a/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
@@ -16,7 +16,7 @@ import { RemoveEntryUseCase } from "./remove-entry";
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
-  const vaultSnapshot = createVaultSnapshotServiceMock(values);
+  const vaultSnapshot = createVaultSnapshotServiceMock(values, ports);
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,

--- a/packages/core/src/use-cases/vault-entries/remove-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.ts
@@ -65,25 +65,40 @@ export class RemoveEntryUseCase {
         this.clock.now(),
       ),
     };
-
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            sourceSnapshotVersionVector,
-          ),
+        async () => {
+          const preparedRestore =
+            syncState.syncAccess === undefined
+              ? undefined
+              : await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+                  syncState.localSnapshot,
+                  unlockedVault,
+                );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     if (syncState.syncAccess !== undefined) {
+      if (preparedRestore === undefined) {
+        throw new Error("Synchronized mutation rollback was not prepared.");
+      }
+
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
-        updatedUnlockedVault,
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        preparedRestore,
         sessionId,
       );
     }

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -24,7 +24,7 @@ const maximumStrengthPassword = "mQ8#sW3!cH7@uJ5$eR9%";
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
-  const vaultSnapshot = createVaultSnapshotServiceMock(values);
+  const vaultSnapshot = createVaultSnapshotServiceMock(values, ports);
   const vaultSyncGuard = new VaultSyncGuardService(
     ports.syncProvider,
     vaultSnapshot,

--- a/packages/core/src/use-cases/vault-entries/update-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.ts
@@ -101,25 +101,40 @@ export class UpdateEntryUseCase {
         unlockedVault.deviceId,
       ),
     };
-
-    const persistedSnapshot =
+    const { persistedSnapshot, preparedRestore } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
-        async () =>
-          this.vaultSnapshot.persistUnlockedVault(
-            params.vaultId,
-            updatedUnlockedVault,
-            sourceSnapshotVersionVector,
-          ),
+        async () => {
+          const preparedRestore =
+            syncState.syncAccess === undefined
+              ? undefined
+              : await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+                  syncState.localSnapshot,
+                  unlockedVault,
+                );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+            );
+
+          return { persistedSnapshot, preparedRestore };
+        },
       );
 
     if (syncState.syncAccess !== undefined) {
+      if (preparedRestore === undefined) {
+        throw new Error("Synchronized mutation rollback was not prepared.");
+      }
+
       await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
-        updatedUnlockedVault,
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        preparedRestore,
         sessionId,
       );
     }

--- a/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
@@ -203,8 +203,7 @@ describe("ChangeMasterPasswordUseCase", () => {
     expect(ctx.saved.deviceAccessMaterial).toEqual({
       ...ctx.deviceAccessMaterial,
       revision: ctx.deviceAccessMaterial.revision + 1,
-      localAccessGenerationId:
-        ctx.values.replacementLocalAccessGenerationId,
+      localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
       masterPasswordSalt: ctx.values.newMasterPasswordSalt,
       localKeysProtectionSalt: ctx.values.newLocalKeysProtectionSalt,
       protectedLocalKeys: ctx.values.reprotectedLocalKeys,
@@ -212,8 +211,7 @@ describe("ChangeMasterPasswordUseCase", () => {
     expect(ctx.saved.deviceAccessRecoveryBackup).toEqual({
       ...ctx.deviceAccessRecoveryBackup,
       revision: ctx.deviceAccessRecoveryBackup.revision + 1,
-      localAccessGenerationId:
-        ctx.values.replacementLocalAccessGenerationId,
+      localAccessGenerationId: ctx.values.replacementLocalAccessGenerationId,
     });
     expect(
       ctx.ports.vaultLocalRepository.saveDeviceAccessRecords,
@@ -898,5 +896,13 @@ describe("ChangeMasterPasswordUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveDeviceAccessRecords,
     ).not.toHaveBeenCalled();
+    const localRootKey = await vi.mocked(ctx.ports.crypto.deriveLocalRootKey)
+      .mock.results[0]!.value;
+    const localKeysProtectionKey = await vi.mocked(
+      ctx.ports.crypto.deriveLocalKeysProtectionKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(localRootKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(localKeysProtectionKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(ctx.values.localRootKey))).toEqual([2]);
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/change-master-password.test.ts
@@ -11,6 +11,7 @@ import {
   VaultMustBeUnlockedForMasterPasswordChangeError,
 } from "../../errors/change-master-password.errors";
 import { InvalidNewMasterPasswordError } from "../../errors/master-password.errors";
+import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import {
   DeviceAccessMaterialChangedError,
   DeviceAccessMaterialIdentityMismatchError,
@@ -216,6 +217,34 @@ describe("ChangeMasterPasswordUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveDeviceAccessRecords,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates an activation lease captured before password rotation", async () => {
+    const ctx = createChangeMasterPasswordTestContext();
+    const activeSession = ctx.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("Expected an unlocked test session.");
+    }
+
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+
+    await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      currentMasterPassword: ctx.values.masterPassword,
+      newMasterPassword: ctx.values.newMasterPassword,
+    });
+
+    await expect(
+      ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        activeSession.unlockedVault,
+        activeSession.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
   });
 
   it("fails when the target vault is not unlocked", async () => {

--- a/packages/core/src/use-cases/vault-lifecycle/change-master-password.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/change-master-password.ts
@@ -18,6 +18,7 @@ import {
   DeviceAccessMaterialChangedError,
   DeviceAccessMaterialIdentityMismatchError,
 } from "../../errors/vault-device.errors";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 
 export type ChangeMasterPasswordCommandParams = {
@@ -144,80 +145,95 @@ export class ChangeMasterPasswordUseCase {
           throw new DeviceAccessMaterialIdentityMismatchError(params.vaultId);
         }
 
-        const currentLocalRootKey = await this.crypto.deriveLocalRootKey(
-          params.currentMasterPassword,
-          deviceAccessMaterial.masterPasswordSalt,
-        );
+        const ownedSecrets: ArrayBuffer[] = [];
 
-        const currentLocalKeysProtectionKey =
-          await this.crypto.deriveLocalKeysProtectionKey(
-            currentLocalRootKey,
-            deviceAccessMaterial.localKeysProtectionSalt,
+        try {
+          const currentLocalRootKey = await this.crypto.deriveLocalRootKey(
+            params.currentMasterPassword,
+            deviceAccessMaterial.masterPasswordSalt,
           );
+          ownedSecrets.push(currentLocalRootKey);
 
-        const localKeysPayload = await this.crypto.unwrapLocalKeysPayload(
-          deviceAccessMaterial.protectedLocalKeys,
-          currentLocalKeysProtectionKey,
-        );
+          const currentLocalKeysProtectionKey =
+            await this.crypto.deriveLocalKeysProtectionKey(
+              currentLocalRootKey,
+              deviceAccessMaterial.localKeysProtectionSalt,
+            );
+          ownedSecrets.push(currentLocalKeysProtectionKey);
 
-        if (
-          !(await this.crypto.verifyDeviceSignKeyPair(
-            deviceAccessMaterial.devicePublicSignKey,
+          const localKeysPayload = await this.crypto.unwrapLocalKeysPayload(
+            deviceAccessMaterial.protectedLocalKeys,
+            currentLocalKeysProtectionKey,
+          );
+          ownedSecrets.push(
             localKeysPayload.devicePrivateSignKey,
-          )) ||
-          !(await this.crypto.verifyDeviceVaultKeyPair(
-            deviceAccessMaterial.devicePublicVaultKey,
             localKeysPayload.devicePrivateVaultKey,
-          ))
-        ) {
-          throw new DeviceAccessMaterialIdentityMismatchError(params.vaultId);
-        }
-
-        const newMasterPasswordSalt =
-          await this.crypto.generateMasterPasswordSalt();
-        const newLocalRootKey = await this.crypto.deriveLocalRootKey(
-          params.newMasterPassword,
-          newMasterPasswordSalt,
-        );
-
-        const newLocalKeysProtectionSalt =
-          await this.crypto.generateLocalKeysProtectionSalt();
-        const newLocalKeysProtectionKey =
-          await this.crypto.deriveLocalKeysProtectionKey(
-            newLocalRootKey,
-            newLocalKeysProtectionSalt,
+            localKeysPayload.deviceLocalProtectionKey,
           );
 
-        const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
-          localKeysPayload,
-          newLocalKeysProtectionKey,
-        );
+          if (
+            !(await this.crypto.verifyDeviceSignKeyPair(
+              deviceAccessMaterial.devicePublicSignKey,
+              localKeysPayload.devicePrivateSignKey,
+            )) ||
+            !(await this.crypto.verifyDeviceVaultKeyPair(
+              deviceAccessMaterial.devicePublicVaultKey,
+              localKeysPayload.devicePrivateVaultKey,
+            ))
+          ) {
+            throw new DeviceAccessMaterialIdentityMismatchError(params.vaultId);
+          }
 
-        const updatedDeviceAccessMaterial: DeviceAccessMaterial = {
-          ...deviceAccessMaterial,
-          revision: nextDeviceAccessMaterialRevision,
-          localAccessGenerationId,
-          masterPasswordSalt: newMasterPasswordSalt,
-          localKeysProtectionSalt: newLocalKeysProtectionSalt,
-          protectedLocalKeys,
-        };
-        const updatedDeviceAccessRecoveryBackup = {
-          ...deviceAccessRecoveryBackup,
-          revision: nextDeviceAccessRecoveryBackupRevision,
-          localAccessGenerationId,
-        };
+          const newMasterPasswordSalt =
+            await this.crypto.generateMasterPasswordSalt();
+          const newLocalRootKey = await this.crypto.deriveLocalRootKey(
+            params.newMasterPassword,
+            newMasterPasswordSalt,
+          );
+          ownedSecrets.push(newLocalRootKey);
 
-        await this.vaultLocalRepository.saveDeviceAccessRecords({
-          expectedDeviceAccessMaterialRevision: deviceAccessMaterial.revision,
-          expectedDeviceAccessMaterialGenerationId:
-            deviceAccessMaterial.localAccessGenerationId,
-          expectedDeviceAccessRecoveryBackupRevision:
-            deviceAccessRecoveryBackup.revision,
-          expectedDeviceAccessRecoveryBackupGenerationId:
-            deviceAccessRecoveryBackup.localAccessGenerationId,
-          deviceAccessMaterial: updatedDeviceAccessMaterial,
-          deviceAccessRecoveryBackup: updatedDeviceAccessRecoveryBackup,
-        });
+          const newLocalKeysProtectionSalt =
+            await this.crypto.generateLocalKeysProtectionSalt();
+          const newLocalKeysProtectionKey =
+            await this.crypto.deriveLocalKeysProtectionKey(
+              newLocalRootKey,
+              newLocalKeysProtectionSalt,
+            );
+          ownedSecrets.push(newLocalKeysProtectionKey);
+
+          const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
+            localKeysPayload,
+            newLocalKeysProtectionKey,
+          );
+
+          const updatedDeviceAccessMaterial: DeviceAccessMaterial = {
+            ...deviceAccessMaterial,
+            revision: nextDeviceAccessMaterialRevision,
+            localAccessGenerationId,
+            masterPasswordSalt: newMasterPasswordSalt,
+            localKeysProtectionSalt: newLocalKeysProtectionSalt,
+            protectedLocalKeys,
+          };
+          const updatedDeviceAccessRecoveryBackup = {
+            ...deviceAccessRecoveryBackup,
+            revision: nextDeviceAccessRecoveryBackupRevision,
+            localAccessGenerationId,
+          };
+
+          await this.vaultLocalRepository.saveDeviceAccessRecords({
+            expectedDeviceAccessMaterialRevision: deviceAccessMaterial.revision,
+            expectedDeviceAccessMaterialGenerationId:
+              deviceAccessMaterial.localAccessGenerationId,
+            expectedDeviceAccessRecoveryBackupRevision:
+              deviceAccessRecoveryBackup.revision,
+            expectedDeviceAccessRecoveryBackupGenerationId:
+              deviceAccessRecoveryBackup.localAccessGenerationId,
+            deviceAccessMaterial: updatedDeviceAccessMaterial,
+            deviceAccessRecoveryBackup: updatedDeviceAccessRecoveryBackup,
+          });
+        } finally {
+          bestEffortWipeArrayBuffers(ownedSecrets);
+        }
       },
     );
   }

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -3,11 +3,11 @@ import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import { DeleteLocalVaultUseCase } from "./delete-local-vault";
 import { VaultMustBeUnlockedForLocalDeletionError } from "../../errors/delete-local-vault.errors";
-import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 
 function createContext() {
   const values = createCoreTestValues();
@@ -31,13 +31,16 @@ function createContext() {
     ports.clock,
     ports.crypto,
   );
-  const useCase = new DeleteLocalVaultUseCase(
-    ports.vaultLocalRepository,
-    ports.sessionServices.unlockedVaultSession,
+  const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     clipboardClearTasks,
     scheduledTasks,
     ports.vaultLockTasks,
+    ports.sessionServices.unlockedVaultSession,
+  );
+  const useCase = new DeleteLocalVaultUseCase(
+    ports.vaultLocalRepository,
+    lifecycleCleanup,
   );
 
   ports.saved.unlockedVaultSession = {
@@ -214,18 +217,8 @@ describe("DeleteLocalVaultUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("serializes cleanup against a competing session activation", async () => {
+  it("does not grant a competing activation lease until deletion finishes", async () => {
     const ctx = createContext();
-    const activeSession = ctx.ports.saved.unlockedVaultSession;
-
-    if (activeSession === undefined) {
-      throw new Error("Expected an active test session.");
-    }
-
-    const activationGeneration =
-      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
-        ctx.values.vaultId,
-      );
     let cleanupCanContinue!: () => void;
     let cleanupStartedResolve!: () => void;
     const cleanupStarted = new Promise<void>((resolve) => {
@@ -239,28 +232,55 @@ describe("DeleteLocalVaultUseCase", () => {
       await cleanupCanContinuePromise;
       return null;
     });
+    const removePersistedLocalVault = vi.mocked(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    );
+    const removePersistedLocalVaultOriginal =
+      removePersistedLocalVault.getMockImplementation();
+
+    if (removePersistedLocalVaultOriginal === undefined) {
+      throw new Error("Expected a persisted-vault removal implementation.");
+    }
+
+    let deletionCanContinue!: () => void;
+    let persistedDeletionStartedResolve!: () => void;
+    const persistedDeletionStarted = new Promise<void>((resolve) => {
+      persistedDeletionStartedResolve = resolve;
+    });
+    const deletionCanContinuePromise = new Promise<void>((resolve) => {
+      deletionCanContinue = resolve;
+    });
+    removePersistedLocalVault.mockImplementationOnce(async (vaultId) => {
+      persistedDeletionStartedResolve();
+      await deletionCanContinuePromise;
+      await removePersistedLocalVaultOriginal(vaultId);
+    });
 
     const deletion = ctx.useCase.execute({ vaultId: ctx.values.vaultId });
     await cleanupStarted;
-    const competingActivation =
-      ctx.ports.sessionServices.unlockedVaultSession.activate(
-        activationGeneration,
-        activeSession.unlockedVault,
-        activeSession.sourceSnapshotVersionVector,
-      );
+    let activationLeaseGranted = false;
+    const competingActivationLease =
+      ctx.ports.sessionServices.unlockedVaultSession
+        .requireVaultCanBeActivated(ctx.values.vaultId)
+        .then((generation) => {
+          activationLeaseGranted = true;
+          return generation;
+        });
     cleanupCanContinue();
+    await persistedDeletionStarted;
+    await Promise.resolve();
+    expect(activationLeaseGranted).toBe(false);
+    deletionCanContinue();
 
     await expect(deletion).resolves.toBeUndefined();
-    await expect(competingActivation).rejects.toBeInstanceOf(
-      UnlockedVaultSessionExpiredError,
-    );
+    await expect(competingActivationLease).resolves.toEqual(expect.any(Number));
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).toHaveBeenCalledWith(ctx.values.vaultId);
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
 
-  it("continues cleanup and withholds deletion after reading session material fails", async () => {
+  it("preserves an unverified active session when target-bound material reading fails", async () => {
     const ctx = createContext();
     const error = new Error("session material unavailable");
     vi.mocked(
@@ -279,26 +299,20 @@ describe("DeleteLocalVaultUseCase", () => {
     });
 
     await expect(
-      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ctx.useCase.execute({ vaultId: "other-vault-id" }),
     ).rejects.toBe(error);
 
-    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "clearClipboard",
-      actionId: "clipboard-action-id",
-    });
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "lockVault",
-      actionId: ctx.values.vaultLockActionId,
-    });
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalled();
     expect(
       ctx.ports.unlockedVaultSessionMaterialRepository
         .removeUnlockedVaultSessionMaterial,
-    ).toHaveBeenCalledTimes(1);
+    ).not.toHaveBeenCalled();
     expect(
       ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
         .removeEncryptedUnlockedVaultSessionPayload,
-    ).toHaveBeenCalledTimes(1);
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).not.toHaveBeenCalled();
@@ -331,6 +345,7 @@ describe("DeleteLocalVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
+    expect(ctx.clipboardClearTasks.remove).toHaveBeenCalledTimes(1);
     expect(
       ctx.ports.vaultLockTasks.removeIfActionIsActive,
     ).toHaveBeenCalledTimes(1);

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -70,6 +70,7 @@ function createContext() {
     clipboard,
     clipboardClearTasks,
     scheduledTasks,
+    lifecycleCleanup,
     useCase,
   };
 }
@@ -172,6 +173,21 @@ describe("DeleteLocalVaultUseCase", () => {
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when lifecycle cleanup reports a stale action", async () => {
+    const ctx = createContext();
+    vi.spyOn(ctx.lifecycleCleanup, "cleanup").mockResolvedValueOnce(
+      "stale_action",
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(VaultMustBeUnlockedForLocalDeletionError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).not.toHaveBeenCalled();
   });
 
   it("bubbles persisted local deletion errors after removing unlocked state", async () => {

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -3,13 +3,41 @@ import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import { DeleteLocalVaultUseCase } from "./delete-local-vault";
 import { VaultMustBeUnlockedForLocalDeletionError } from "../../errors/delete-local-vault.errors";
+import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
+import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
 
 function createContext() {
   const values = createCoreTestValues();
   const ports = createCoreTestPorts(values);
+  const clipboard: ClipboardPort = {
+    readText: vi.fn(async () => "copied-password"),
+    writeText: vi.fn(async () => undefined),
+  };
+  const clipboardClearTasks: ClipboardClearTaskRepositoryPort = {
+    save: vi.fn(async () => undefined),
+    get: vi.fn(async () => null),
+    remove: vi.fn(async () => undefined),
+  };
+  const scheduledTasks: ScheduledTaskPort = {
+    scheduleTask: vi.fn(async () => undefined),
+    cancelTask: vi.fn(async () => undefined),
+  };
+  const clipboardClear = new ClipboardClearService(
+    clipboard,
+    clipboardClearTasks,
+    ports.clock,
+    ports.crypto,
+  );
   const useCase = new DeleteLocalVaultUseCase(
     ports.vaultLocalRepository,
     ports.sessionServices.unlockedVaultSession,
+    clipboardClear,
+    clipboardClearTasks,
+    scheduledTasks,
+    ports.vaultLockTasks,
   );
 
   ports.saved.unlockedVaultSession = {
@@ -36,6 +64,9 @@ function createContext() {
   return {
     values,
     ports,
+    clipboard,
+    clipboardClearTasks,
+    scheduledTasks,
     useCase,
   };
 }
@@ -43,6 +74,16 @@ function createContext() {
 describe("DeleteLocalVaultUseCase", () => {
   it("removes local vault data and unlocked state when the target vault is unlocked", async () => {
     const ctx = createContext();
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: "hash:copied-password",
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
 
     await expect(
       ctx.useCase.execute({
@@ -63,15 +104,29 @@ describe("DeleteLocalVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.removeVaultSnapshot,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
     expect(
-      vi.mocked(ctx.ports.sessionServices.unlockedVaultSession.remove).mock
-        .invocationCallOrder[0],
+      vi.mocked(
+        ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+      ).mock.invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(ctx.ports.vaultLocalRepository.removePersistedLocalVault).mock
         .invocationCallOrder[0],
     );
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(ctx.clipboardClearTasks.remove).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("fails when no vault is unlocked", async () => {
@@ -88,8 +143,8 @@ describe("DeleteLocalVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).not.toHaveBeenCalled();
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("fails when another vault is unlocked", async () => {
@@ -112,8 +167,8 @@ describe("DeleteLocalVaultUseCase", () => {
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).not.toHaveBeenCalled();
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("bubbles persisted local deletion errors after removing unlocked state", async () => {
@@ -131,7 +186,7 @@ describe("DeleteLocalVaultUseCase", () => {
     ).rejects.toBe(error);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
@@ -141,7 +196,7 @@ describe("DeleteLocalVaultUseCase", () => {
     const error = new Error("session cleanup failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).mockRejectedValueOnce(error);
 
     await expect(
@@ -150,6 +205,138 @@ describe("DeleteLocalVaultUseCase", () => {
       }),
     ).rejects.toBe(error);
 
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.vaultLockTasks.get).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("serializes cleanup against a competing session activation", async () => {
+    const ctx = createContext();
+    const activeSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("Expected an active test session.");
+    }
+
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+    let cleanupCanContinue!: () => void;
+    let cleanupStartedResolve!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      cleanupStartedResolve = resolve;
+    });
+    const cleanupCanContinuePromise = new Promise<void>((resolve) => {
+      cleanupCanContinue = resolve;
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockImplementationOnce(async () => {
+      cleanupStartedResolve();
+      await cleanupCanContinuePromise;
+      return null;
+    });
+
+    const deletion = ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    await cleanupStarted;
+    const competingActivation =
+      ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        activeSession.unlockedVault,
+        activeSession.sourceSnapshotVersionVector,
+      );
+    cleanupCanContinue();
+
+    await expect(deletion).resolves.toBeUndefined();
+    await expect(competingActivation).rejects.toBeInstanceOf(
+      UnlockedVaultSessionExpiredError,
+    );
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).toHaveBeenCalledWith(ctx.values.vaultId);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("continues cleanup and withholds deletion after reading session material fails", async () => {
+    const ctx = createContext();
+    const error = new Error("session material unavailable");
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: "hash:copied-password",
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(error);
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("continues later cleanup and withholds persisted deletion after clipboard failure", async () => {
+    const ctx = createContext();
+    const error = new Error("clipboard unavailable");
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: "hash:copied-password",
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboard.readText).mockRejectedValueOnce(error);
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(error);
+
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).not.toHaveBeenCalled();

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
@@ -1,11 +1,6 @@
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { VaultMustBeUnlockedForLocalDeletionError } from "../../errors/delete-local-vault.errors";
-import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
-import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
-import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
-import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
-import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
-import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import type { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 
 export type DeleteLocalVaultCommandParams = {
   vaultId: string;
@@ -17,31 +12,24 @@ export class DeleteLocalVaultUseCase {
 
   constructor(
     vaultLocalRepository: VaultLocalRepositoryPort,
-    unlockedVaultSession: UnlockedVaultSessionService,
-    clipboardClear: ClipboardClearService,
-    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
-    scheduledTasks: ScheduledTaskPort,
-    vaultLockTasks: VaultLockTaskRepositoryPort,
+    lifecycleCleanup: VaultLifecycleCleanupService,
   ) {
     this.vaultLocalRepository = vaultLocalRepository;
-    this.lifecycleCleanup = new VaultLifecycleCleanupService(
-      clipboardClear,
-      clipboardClearTasks,
-      scheduledTasks,
-      vaultLockTasks,
-      unlockedVaultSession,
-    );
+    this.lifecycleCleanup = lifecycleCleanup;
   }
 
   async execute(params: DeleteLocalVaultCommandParams): Promise<void> {
     const cleanupResult = await this.lifecycleCleanup.cleanup({
+      afterSessionRemoval: async () => {
+        await this.vaultLocalRepository.removePersistedLocalVault(
+          params.vaultId,
+        );
+      },
       requiredVaultId: params.vaultId,
     });
 
     if (cleanupResult === "session_unavailable") {
       throw new VaultMustBeUnlockedForLocalDeletionError(params.vaultId);
     }
-
-    await this.vaultLocalRepository.removePersistedLocalVault(params.vaultId);
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
@@ -28,7 +28,7 @@ export class DeleteLocalVaultUseCase {
       requiredVaultId: params.vaultId,
     });
 
-    if (cleanupResult === "session_unavailable") {
+    if (cleanupResult !== "cleaned") {
       throw new VaultMustBeUnlockedForLocalDeletionError(params.vaultId);
     }
   }

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.ts
@@ -1,6 +1,11 @@
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { VaultMustBeUnlockedForLocalDeletionError } from "../../errors/delete-local-vault.errors";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 
 export type DeleteLocalVaultCommandParams = {
   vaultId: string;
@@ -8,25 +13,35 @@ export type DeleteLocalVaultCommandParams = {
 
 export class DeleteLocalVaultUseCase {
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
-  private readonly unlockedVaultSession: UnlockedVaultSessionService;
+  private readonly lifecycleCleanup: VaultLifecycleCleanupService;
 
   constructor(
     vaultLocalRepository: VaultLocalRepositoryPort,
     unlockedVaultSession: UnlockedVaultSessionService,
+    clipboardClear: ClipboardClearService,
+    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
+    scheduledTasks: ScheduledTaskPort,
+    vaultLockTasks: VaultLockTaskRepositoryPort,
   ) {
     this.vaultLocalRepository = vaultLocalRepository;
-    this.unlockedVaultSession = unlockedVaultSession;
+    this.lifecycleCleanup = new VaultLifecycleCleanupService(
+      clipboardClear,
+      clipboardClearTasks,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
   }
 
   async execute(params: DeleteLocalVaultCommandParams): Promise<void> {
-    const unlockedVaultSession = await this.unlockedVaultSession.get();
-    const unlockedVault = unlockedVaultSession?.unlockedVault;
+    const cleanupResult = await this.lifecycleCleanup.cleanup({
+      requiredVaultId: params.vaultId,
+    });
 
-    if (unlockedVault?.vaultId !== params.vaultId) {
+    if (cleanupResult === "session_unavailable") {
       throw new VaultMustBeUnlockedForLocalDeletionError(params.vaultId);
     }
 
-    await this.unlockedVaultSession.remove();
     await this.vaultLocalRepository.removePersistedLocalVault(params.vaultId);
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -3,6 +3,7 @@ import { createInitializeVaultTestContext } from "../../__tests__/fixtures/initi
 import type { RawMasterPassword } from "../../domain/master-password";
 import { InvalidNewMasterPasswordError } from "../../errors/master-password.errors";
 import { DeviceAccessMaterialChangedError } from "../../errors/vault-device.errors";
+import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
 
 describe("InitializeVaultUseCase", () => {
   it("rejects a master password below maximum strength before generating IDs", async () => {
@@ -16,6 +17,7 @@ describe("InitializeVaultUseCase", () => {
       ctx.useCase.execute({
         masterPassword: "correcthorsebatterystaple" as RawMasterPassword,
         deviceName: "Laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(InvalidNewMasterPasswordError);
 
@@ -32,7 +34,11 @@ describe("InitializeVaultUseCase", () => {
     const ctx = createInitializeVaultTestContext();
     const masterPassword = "vN7#qL2!xP9@rT4$zK6&" as RawMasterPassword;
 
-    await ctx.useCase.execute({ masterPassword, deviceName: "Laptop" });
+    await ctx.useCase.execute({
+      masterPassword,
+      deviceName: "Laptop",
+      lockAfterMs: 60_000,
+    });
 
     expect(ctx.ports.crypto.deriveLocalRootKey).toHaveBeenCalledWith(
       masterPassword,
@@ -52,6 +58,7 @@ describe("InitializeVaultUseCase", () => {
       ctx.useCase.execute({
         masterPassword: ctx.values.masterPassword,
         deviceName: "Laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toBeInstanceOf(DeviceAccessMaterialChangedError);
 
@@ -67,6 +74,7 @@ describe("InitializeVaultUseCase", () => {
     await ctx.useCase.execute({
       masterPassword: ctx.values.masterPassword,
       deviceName: "Laptop",
+      lockAfterMs: 60_000,
     });
 
     const snapshot = ctx.saved.vaultSnapshot;
@@ -107,6 +115,73 @@ describe("InitializeVaultUseCase", () => {
         algorithmSuiteId: "spm-v1",
       },
     );
+    expect(ctx.ports.vaultLockTasks.save).toHaveBeenCalledWith({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    expect(ctx.ports.scheduledTasks.scheduleTask).toHaveBeenCalledWith({
+      task: {
+        name: "lockVault",
+        actionId: ctx.values.vaultLockActionId,
+      },
+      runAt: ctx.values.timestamp + 60_000,
+    });
+    const localRootKey = await vi.mocked(ctx.ports.crypto.deriveLocalRootKey)
+      .mock.results[0]!.value;
+    const vaultMasterKey = await vi.mocked(
+      ctx.ports.crypto.generateVaultMasterKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(localRootKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(vaultMasterKey))).toEqual([2]);
+    expect(Array.from(new Uint8Array(ctx.values.localRootKey))).toEqual([2]);
+  });
+
+  it("rejects an invalid lock delay before generating identifiers or secrets", async () => {
+    const ctx = createInitializeVaultTestContext();
+
+    await expect(
+      ctx.useCase.execute({
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "Laptop",
+        lockAfterMs: 1 as never,
+      }),
+    ).rejects.toBeInstanceOf(InvalidVaultLockDelayError);
+
+    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(ctx.ports.crypto.generateVaultMasterKey).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rolls back initialized state when lock scheduling fails", async () => {
+    const ctx = createInitializeVaultTestContext();
+    vi.mocked(ctx.ports.scheduledTasks.scheduleTask).mockRejectedValueOnce(
+      new Error("schedule failed"),
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "Laptop",
+        lockAfterMs: 60_000,
+      }),
+    ).rejects.toThrow("schedule failed");
+
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+    expect(ctx.saved.localVaultDescriptor).toBeUndefined();
+    const vaultMasterKey = await vi.mocked(
+      ctx.ports.crypto.generateVaultMasterKey,
+    ).mock.results[0]!.value;
+    expect(Array.from(new Uint8Array(vaultMasterKey))).toEqual([0]);
+    expect(Array.from(new Uint8Array(ctx.values.vaultMasterKey))).toEqual([2]);
   });
 
   it.each(["revision", "generation", "public key"] as const)(
@@ -116,6 +191,7 @@ describe("InitializeVaultUseCase", () => {
       await source.useCase.execute({
         masterPassword: source.values.masterPassword,
         deviceName: "Laptop",
+        lockAfterMs: 60_000,
       });
       const initializedParams = vi.mocked(
         source.ports.vaultLocalRepository.saveInitializedLocalVault,
@@ -164,18 +240,27 @@ describe("InitializeVaultUseCase", () => {
   it("removes initialized local state when session activation fails", async () => {
     const ctx = createInitializeVaultTestContext();
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.activate,
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
     ).mockRejectedValue(new Error("session failed"));
 
     await expect(
       ctx.useCase.execute({
         masterPassword: ctx.values.masterPassword,
         deviceName: "Laptop",
+        lockAfterMs: 60_000,
       }),
     ).rejects.toThrow("session failed");
 
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVault,
     ).toHaveBeenCalledWith(ctx.values.vaultId);
+    expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -253,8 +253,8 @@ describe("InitializeVaultUseCase", () => {
     ).rejects.toThrow("session failed");
 
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
-    ).toHaveBeenCalledWith(ctx.values.vaultId);
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+    ).toHaveBeenCalledWith(ctx.values.vaultId, ctx.values.vaultSnapshotDigest);
     expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
@@ -262,5 +262,40 @@ describe("InitializeVaultUseCase", () => {
     expect(
       ctx.ports.vaultLockTasks.removeIfActionIsActive,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps initialized persistence and activation in one session operation", async () => {
+    const ctx = createInitializeVaultTestContext();
+    const saveInitializedLocalVault = vi.mocked(
+      ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
+    );
+    const save = saveInitializedLocalVault.getMockImplementation();
+    let competingLease: Promise<number> | undefined;
+
+    if (save === undefined) {
+      throw new Error("Expected initialized-vault fixture implementation.");
+    }
+
+    saveInitializedLocalVault.mockImplementationOnce(async (params) => {
+      await save(params);
+      competingLease =
+        ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+          ctx.values.vaultId,
+        );
+    });
+
+    await ctx.useCase.execute({
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "Laptop",
+      lockAfterMs: 60_000,
+    });
+
+    if (competingLease === undefined) {
+      throw new Error("Expected a competing activation lease.");
+    }
+
+    await expect(competingLease).resolves.toBe(1);
+    expect(ctx.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.saved.unlockedVaultSession).toBeDefined();
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -295,31 +295,28 @@ export class InitializeVaultUseCase {
         deviceSignKeyPair.privateKey,
       );
 
-      await this.vaultLocalRepository.saveInitializedLocalVault({
-        descriptor: localVaultDescriptor,
-        deviceAccessMaterial,
-        deviceAccessRecoveryBackup,
-        snapshot: vaultSnapshot,
-        checkpoint,
+      await this.sessionActivation.activate({
+        activationGeneration,
+        unlockedVault,
+        sourceSnapshotVersionVector:
+          vaultSnapshot.metadata.snapshotVersionVector,
+        lockAfterMs,
+        prepareActivation: async () =>
+          this.vaultLocalRepository.saveInitializedLocalVault({
+            descriptor: localVaultDescriptor,
+            deviceAccessMaterial,
+            deviceAccessRecoveryBackup,
+            snapshot: vaultSnapshot,
+            checkpoint,
+          }),
+        rollbackPreparedActivation: async () => {
+          await this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
+            vaultId,
+            unlockedVault.trustedSnapshotContext.snapshotDigest,
+          );
+        },
       });
-      try {
-        await this.sessionActivation.activate({
-          activationGeneration,
-          unlockedVault,
-          sourceSnapshotVersionVector:
-            vaultSnapshot.metadata.snapshotVersionVector,
-          lockAfterMs,
-        });
-        sessionActivated = true;
-      } catch (error) {
-        try {
-          await this.vaultLocalRepository.removePersistedLocalVault(vaultId);
-        } catch {
-          // Preserve the session activation failure as the root cause.
-        }
-
-        throw error;
-      }
+      sessionActivated = true;
 
       return {
         recoveryMnemonicKey,

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -22,12 +22,18 @@ import type { IdPort } from "../../ports/system/id.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
+import type { VaultLockDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
+import { VaultSessionActivationService } from "../../services/session/vault-session-activation.service";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
 import { DeviceAccessMaterialChangedError } from "../../errors/vault-device.errors";
 
 export type InitializeVaultCommandParams = {
   masterPassword: RawMasterPassword;
   deviceName: string;
+  lockAfterMs: VaultLockDelayMs;
 };
 
 export type InitializeVaultResult = {
@@ -44,6 +50,7 @@ export class InitializeVaultUseCase {
   private readonly clock: ClockPort;
   private readonly vaultDisplayName: VaultDisplayNamePort;
   private readonly vaultTrust: VaultTrustService;
+  private readonly sessionActivation: VaultSessionActivationService;
 
   constructor(
     crypto: CryptoPort,
@@ -53,6 +60,8 @@ export class InitializeVaultUseCase {
     ids: IdPort,
     clock: ClockPort,
     vaultDisplayName: VaultDisplayNamePort,
+    scheduledTasks: ScheduledTaskPort,
+    vaultLockTasks: VaultLockTaskRepositoryPort,
   ) {
     this.crypto = crypto;
     this.bip39 = bip39;
@@ -62,15 +71,24 @@ export class InitializeVaultUseCase {
     this.clock = clock;
     this.vaultDisplayName = vaultDisplayName;
     this.vaultTrust = new VaultTrustService(crypto);
+    this.sessionActivation = new VaultSessionActivationService(
+      clock,
+      ids,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
   }
 
   async execute(
     initializeVaultCommandParams: InitializeVaultCommandParams,
   ): Promise<InitializeVaultResult> {
+    const lockAfterMs = this.sessionActivation.requireValidLockDelay(
+      initializeVaultCommandParams.lockAfterMs,
+    );
     assertNewMasterPasswordMeetsPolicy(
       initializeVaultCommandParams.masterPassword,
     );
-
     const vaultId = await this.ids.generateId();
     const activationGeneration =
       await this.unlockedVaultSession.requireVaultCanBeActivated(vaultId);
@@ -84,213 +102,235 @@ export class InitializeVaultUseCase {
     const timestamp = this.clock.now();
     const vaultDisplayName =
       await this.vaultDisplayName.generateVaultDisplayName();
+    const ephemeralSecrets: ArrayBuffer[] = [];
+    const sessionSecrets: ArrayBuffer[] = [];
+    let sessionActivated = false;
 
-    const vaultMasterKey = await this.crypto.generateVaultMasterKey();
-    const deviceSignKeyPair = await this.crypto.generateDeviceSignKeyPair();
-    const deviceVaultKeyPair = await this.crypto.generateDeviceVaultKeyPair();
-    const deviceLocalProtectionKey =
-      await this.crypto.generateDeviceLocalProtectionKey();
-    const vaultKeyGeneration = 1;
-    const genesisTrust = await this.vaultTrust.createGenesis(
-      vaultId,
-      {
+    try {
+      const vaultMasterKey = await this.crypto.generateVaultMasterKey();
+      sessionSecrets.push(vaultMasterKey);
+      const deviceSignKeyPair = await this.crypto.generateDeviceSignKeyPair();
+      sessionSecrets.push(deviceSignKeyPair.privateKey);
+      const deviceVaultKeyPair = await this.crypto.generateDeviceVaultKeyPair();
+      sessionSecrets.push(deviceVaultKeyPair.privateKey);
+      const deviceLocalProtectionKey =
+        await this.crypto.generateDeviceLocalProtectionKey();
+      sessionSecrets.push(deviceLocalProtectionKey);
+      const vaultKeyGeneration = 1;
+      const genesisTrust = await this.vaultTrust.createGenesis(
+        vaultId,
+        {
+          deviceId,
+          publicSignKey: deviceSignKeyPair.publicKey,
+          publicVaultKey: deviceVaultKeyPair.publicKey,
+        },
+        vaultKeyGeneration,
+        deviceSignKeyPair.privateKey,
+      );
+      const recoverySecretKey = await this.crypto.generateRecoveryKey();
+      ephemeralSecrets.push(recoverySecretKey);
+      const recoveryMnemonicKey =
+        await this.bip39.recoveryKeyToMnemonic(recoverySecretKey);
+
+      const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
+      const localRootKey = await this.crypto.deriveLocalRootKey(
+        initializeVaultCommandParams.masterPassword,
+        masterPasswordSalt,
+      );
+      ephemeralSecrets.push(localRootKey);
+
+      const localKeysProtectionSalt =
+        await this.crypto.generateLocalKeysProtectionSalt();
+
+      const localKeysProtectionKey =
+        await this.crypto.deriveLocalKeysProtectionKey(
+          localRootKey,
+          localKeysProtectionSalt,
+        );
+      ephemeralSecrets.push(localKeysProtectionKey);
+
+      const localKeysPayload: LocalKeysPayload = {
+        devicePrivateSignKey: deviceSignKeyPair.privateKey,
+        devicePrivateVaultKey: deviceVaultKeyPair.privateKey,
+        deviceLocalProtectionKey,
+        vaultTrustAnchor: genesisTrust.anchor,
+      };
+
+      const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
+        localKeysPayload,
+        localKeysProtectionKey,
+      );
+      const recoveryLocalKeysProtectionSalt =
+        await this.crypto.generateRecoveryLocalKeysProtectionSalt();
+      const recoveryLocalKeysProtectionKey =
+        await this.crypto.deriveRecoveryLocalKeysProtectionKey(
+          recoverySecretKey,
+          recoveryLocalKeysProtectionSalt,
+        );
+      ephemeralSecrets.push(recoveryLocalKeysProtectionKey);
+      const recoveryProtectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
+        localKeysPayload,
+        recoveryLocalKeysProtectionKey,
+      );
+
+      const envelopeContext: DeviceVaultKeyEnvelopeContext = {
+        vaultId,
         deviceId,
-        publicSignKey: deviceSignKeyPair.publicKey,
-        publicVaultKey: deviceVaultKeyPair.publicKey,
-      },
-      vaultKeyGeneration,
-      deviceSignKeyPair.privateKey,
-    );
-    const recoverySecretKey = await this.crypto.generateRecoveryKey();
-    const recoveryMnemonicKey =
-      await this.bip39.recoveryKeyToMnemonic(recoverySecretKey);
+        vaultKeyGeneration,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+      };
+      const deviceVaultKeyEnvelope =
+        await this.crypto.createDeviceVaultKeyEnvelope(
+          vaultMasterKey,
+          deviceVaultKeyPair.publicKey,
+          envelopeContext,
+        );
 
-    const masterPasswordSalt = await this.crypto.generateMasterPasswordSalt();
-    const localRootKey = await this.crypto.deriveLocalRootKey(
-      initializeVaultCommandParams.masterPassword,
-      masterPasswordSalt,
-    );
-
-    const localKeysProtectionSalt =
-      await this.crypto.generateLocalKeysProtectionSalt();
-
-    const localKeysProtectionKey =
-      await this.crypto.deriveLocalKeysProtectionKey(
-        localRootKey,
-        localKeysProtectionSalt,
-      );
-
-    const localKeysPayload: LocalKeysPayload = {
-      devicePrivateSignKey: deviceSignKeyPair.privateKey,
-      devicePrivateVaultKey: deviceVaultKeyPair.privateKey,
-      deviceLocalProtectionKey,
-      vaultTrustAnchor: genesisTrust.anchor,
-    };
-
-    const protectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
-      localKeysPayload,
-      localKeysProtectionKey,
-    );
-    const recoveryLocalKeysProtectionSalt =
-      await this.crypto.generateRecoveryLocalKeysProtectionSalt();
-    const recoveryLocalKeysProtectionKey =
-      await this.crypto.deriveRecoveryLocalKeysProtectionKey(
-        recoverySecretKey,
-        recoveryLocalKeysProtectionSalt,
-      );
-    const recoveryProtectedLocalKeys = await this.crypto.wrapLocalKeysPayload(
-      localKeysPayload,
-      recoveryLocalKeysProtectionKey,
-    );
-
-    const envelopeContext: DeviceVaultKeyEnvelopeContext = {
-      vaultId,
-      deviceId,
-      vaultKeyGeneration,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-    };
-    const deviceVaultKeyEnvelope =
-      await this.crypto.createDeviceVaultKeyEnvelope(
-        vaultMasterKey,
-        deviceVaultKeyPair.publicKey,
-        envelopeContext,
-      );
-
-    const deviceProfile: DeviceProfile = {
-      id: deviceId,
-      name: initializeVaultCommandParams.deviceName,
-      createdAt: timestamp,
-      versionVector: {
-        [deviceId]: 1,
-      },
-    };
-
-    const vault: Vault = {
-      versionVector: {
-        [deviceId]: 1,
-      },
-      entries: [],
-      deletedEntries: [],
-      deviceProfiles: [deviceProfile],
-      deletedDeviceProfiles: [],
-      tags: [],
-      deletedTags: [],
-    };
-
-    const unsignedVaultSnapshot: UnsignedVaultSnapshot = {
-      metadata: {
-        id: vaultId,
-        schemaVersion: 1,
-        vaultCreationTimestamp: timestamp,
-        revisionTimestamp: timestamp,
-        snapshotVersionVector: {
+      const deviceProfile: DeviceProfile = {
+        id: deviceId,
+        name: initializeVaultCommandParams.deviceName,
+        createdAt: timestamp,
+        versionVector: {
           [deviceId]: 1,
         },
-        algorithmSuiteId: this.crypto.algorithmSuite.id,
-        createdByDeviceId: deviceId,
-        vaultKeyGeneration,
-      },
-      trustChain: genesisTrust.chain,
-      keySlots: {
-        deviceSlots: [
-          {
-            deviceId,
-            vaultKeyGeneration,
-            envelope: deviceVaultKeyEnvelope,
+      };
+
+      const vault: Vault = {
+        versionVector: {
+          [deviceId]: 1,
+        },
+        entries: [],
+        deletedEntries: [],
+        deviceProfiles: [deviceProfile],
+        deletedDeviceProfiles: [],
+        tags: [],
+        deletedTags: [],
+      };
+
+      const unsignedVaultSnapshot: UnsignedVaultSnapshot = {
+        metadata: {
+          id: vaultId,
+          schemaVersion: 1,
+          vaultCreationTimestamp: timestamp,
+          revisionTimestamp: timestamp,
+          snapshotVersionVector: {
+            [deviceId]: 1,
           },
-        ],
-      },
-      content: await this.crypto.encryptVaultSnapshotContent(
+          algorithmSuiteId: this.crypto.algorithmSuite.id,
+          createdByDeviceId: deviceId,
+          vaultKeyGeneration,
+        },
+        trustChain: genesisTrust.chain,
+        keySlots: {
+          deviceSlots: [
+            {
+              deviceId,
+              vaultKeyGeneration,
+              envelope: deviceVaultKeyEnvelope,
+            },
+          ],
+        },
+        content: await this.crypto.encryptVaultSnapshotContent(
+          vault,
+          vaultMasterKey,
+        ),
+      };
+
+      const vaultSnapshot: VaultSnapshot = {
+        ...unsignedVaultSnapshot,
+        signature: await this.crypto.signVaultSnapshot(
+          unsignedVaultSnapshot,
+          deviceSignKeyPair.privateKey,
+        ),
+      };
+
+      const deviceAccessMaterial: DeviceAccessMaterial = {
+        revision: INITIAL_DEVICE_ACCESS_REVISION,
+        localAccessGenerationId,
+        vaultId,
+        deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        masterPasswordSalt,
+        localKeysProtectionSalt,
+        devicePublicSignKey: deviceSignKeyPair.publicKey,
+        devicePublicVaultKey: deviceVaultKeyPair.publicKey,
+        protectedLocalKeys,
+      };
+      const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
+        revision: INITIAL_DEVICE_ACCESS_REVISION,
+        localAccessGenerationId,
+        vaultId,
+        deviceId,
+        algorithmSuiteId: this.crypto.algorithmSuite.id,
+        recoveryLocalKeysProtectionSalt,
+        devicePublicSignKey: deviceSignKeyPair.publicKey,
+        devicePublicVaultKey: deviceVaultKeyPair.publicKey,
+        protectedLocalKeys: recoveryProtectedLocalKeys,
+      };
+
+      const localVaultDescriptor: LocalVaultDescriptor = {
+        vaultId,
+        displayName: vaultDisplayName,
+        createdAt: timestamp,
+      };
+
+      const unlockedVault: UnlockedVault = {
+        vaultId,
+        deviceId,
         vault,
         vaultMasterKey,
-      ),
-    };
-
-    const vaultSnapshot: VaultSnapshot = {
-      ...unsignedVaultSnapshot,
-      signature: await this.crypto.signVaultSnapshot(
-        unsignedVaultSnapshot,
+        devicePrivateSignKey: deviceSignKeyPair.privateKey,
+        devicePrivateVaultKey: deviceVaultKeyPair.privateKey,
+        deviceLocalProtectionKey,
+        trustedSnapshotContext: {
+          snapshotDigest: await this.crypto.digestVaultSnapshot(vaultSnapshot),
+          trust: genesisTrust.trust,
+        },
+        vaultTrustAnchor: genesisTrust.anchor,
+      };
+      const checkpoint = await this.vaultTrust.createCheckpoint(
+        vaultSnapshot,
+        genesisTrust.trust,
+        deviceId,
         deviceSignKeyPair.privateKey,
-      ),
-    };
-
-    const deviceAccessMaterial: DeviceAccessMaterial = {
-      revision: INITIAL_DEVICE_ACCESS_REVISION,
-      localAccessGenerationId,
-      vaultId,
-      deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      masterPasswordSalt,
-      localKeysProtectionSalt,
-      devicePublicSignKey: deviceSignKeyPair.publicKey,
-      devicePublicVaultKey: deviceVaultKeyPair.publicKey,
-      protectedLocalKeys,
-    };
-    const deviceAccessRecoveryBackup: DeviceAccessRecoveryBackup = {
-      revision: INITIAL_DEVICE_ACCESS_REVISION,
-      localAccessGenerationId,
-      vaultId,
-      deviceId,
-      algorithmSuiteId: this.crypto.algorithmSuite.id,
-      recoveryLocalKeysProtectionSalt,
-      devicePublicSignKey: deviceSignKeyPair.publicKey,
-      devicePublicVaultKey: deviceVaultKeyPair.publicKey,
-      protectedLocalKeys: recoveryProtectedLocalKeys,
-    };
-
-    const localVaultDescriptor: LocalVaultDescriptor = {
-      vaultId,
-      displayName: vaultDisplayName,
-      createdAt: timestamp,
-    };
-
-    const unlockedVault: UnlockedVault = {
-      vaultId,
-      deviceId,
-      vault,
-      vaultMasterKey,
-      devicePrivateSignKey: deviceSignKeyPair.privateKey,
-      devicePrivateVaultKey: deviceVaultKeyPair.privateKey,
-      deviceLocalProtectionKey,
-      trustedSnapshotContext: {
-        snapshotDigest: await this.crypto.digestVaultSnapshot(vaultSnapshot),
-        trust: genesisTrust.trust,
-      },
-      vaultTrustAnchor: genesisTrust.anchor,
-    };
-    const checkpoint = await this.vaultTrust.createCheckpoint(
-      vaultSnapshot,
-      genesisTrust.trust,
-      deviceId,
-      deviceSignKeyPair.privateKey,
-    );
-
-    await this.vaultLocalRepository.saveInitializedLocalVault({
-      descriptor: localVaultDescriptor,
-      deviceAccessMaterial,
-      deviceAccessRecoveryBackup,
-      snapshot: vaultSnapshot,
-      checkpoint,
-    });
-    try {
-      await this.unlockedVaultSession.activate(
-        activationGeneration,
-        unlockedVault,
-        vaultSnapshot.metadata.snapshotVersionVector,
       );
-    } catch (error) {
+
+      await this.vaultLocalRepository.saveInitializedLocalVault({
+        descriptor: localVaultDescriptor,
+        deviceAccessMaterial,
+        deviceAccessRecoveryBackup,
+        snapshot: vaultSnapshot,
+        checkpoint,
+      });
       try {
-        await this.vaultLocalRepository.removePersistedLocalVault(vaultId);
-      } catch {
-        // Preserve the session activation failure as the root cause.
+        await this.sessionActivation.activate({
+          activationGeneration,
+          unlockedVault,
+          sourceSnapshotVersionVector:
+            vaultSnapshot.metadata.snapshotVersionVector,
+          lockAfterMs,
+        });
+        sessionActivated = true;
+      } catch (error) {
+        try {
+          await this.vaultLocalRepository.removePersistedLocalVault(vaultId);
+        } catch {
+          // Preserve the session activation failure as the root cause.
+        }
+
+        throw error;
       }
 
-      throw error;
-    }
+      return {
+        recoveryMnemonicKey,
+        vaultDisplayName,
+      };
+    } finally {
+      bestEffortWipeArrayBuffers(ephemeralSecrets);
 
-    return {
-      recoveryMnemonicKey,
-      vaultDisplayName,
-    };
+      if (!sessionActivated) {
+        bestEffortWipeArrayBuffers(sessionSecrets);
+      }
+    }
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
@@ -9,6 +9,7 @@ import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/cli
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import { LockVaultUseCase } from "./lock-vault";
 
@@ -40,13 +41,14 @@ function createContext() {
     clock,
     ports.crypto,
   );
-  const useCase = new LockVaultUseCase(
+  const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     clipboardClearTasks,
     scheduledTasks,
     ports.vaultLockTasks,
     ports.sessionServices.unlockedVaultSession,
   );
+  const useCase = new LockVaultUseCase(lifecycleCleanup);
 
   return {
     values,
@@ -137,6 +139,37 @@ describe("LockVaultUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("preserves the session when lock metadata advances during scheduled cleanup", async () => {
+    const ctx = createContext();
+    const newerLockTask = {
+      actionId: "newer-lock-action-id",
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 120_000,
+    };
+    await ctx.ports.vaultLockTasks.save({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.scheduledTasks.cancelTask).mockImplementation(
+      async (task) => {
+        if (task.name === "lockVault") {
+          await ctx.ports.vaultLockTasks.save(newerLockTask);
+        }
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).resolves.toBeUndefined();
+
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    await expect(ctx.ports.vaultLockTasks.get()).resolves.toBe(newerLockTask);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+  });
+
   it("ignores scheduled vault lock when metadata is missing", async () => {
     const ctx = createContext();
 
@@ -159,7 +192,7 @@ describe("LockVaultUseCase", () => {
   it("cleans matching scheduled state when the session is already absent", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSession = undefined;
-    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+    await ctx.ports.vaultLockTasks.save({
       actionId: ctx.values.vaultLockActionId,
       vaultId: ctx.values.vaultId,
       expiresAt: ctx.values.timestamp + 60_000,
@@ -234,7 +267,7 @@ describe("LockVaultUseCase", () => {
 
   it("locks current session for matching scheduled vault lock action", async () => {
     const ctx = createContext();
-    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+    await ctx.ports.vaultLockTasks.save({
       actionId: ctx.values.vaultLockActionId,
       vaultId: ctx.values.vaultId,
       expiresAt: ctx.values.timestamp + 60_000,
@@ -266,6 +299,12 @@ describe("LockVaultUseCase", () => {
       await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
         ctx.values.vaultId,
       );
+    const activeLockTask = {
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    };
+    await ctx.ports.vaultLockTasks.save(activeLockTask);
     let cleanupCanContinue!: () => void;
     let cleanupStartedResolve!: () => void;
     const cleanupStarted = new Promise<void>((resolve) => {
@@ -277,11 +316,7 @@ describe("LockVaultUseCase", () => {
     vi.mocked(ctx.ports.vaultLockTasks.get).mockImplementationOnce(async () => {
       cleanupStartedResolve();
       await cleanupCanContinuePromise;
-      return {
-        actionId: ctx.values.vaultLockActionId,
-        vaultId: ctx.values.vaultId,
-        expiresAt: ctx.values.timestamp + 60_000,
-      };
+      return activeLockTask;
     });
 
     const cleanup = ctx.useCase.execute({
@@ -404,6 +439,11 @@ describe("LockVaultUseCase", () => {
   it("authenticates scheduled cleanup after reading active session material fails", async () => {
     const ctx = createContext();
     const error = new Error("session material unavailable");
+    await ctx.ports.vaultLockTasks.save({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
     vi.mocked(
       ctx.ports.unlockedVaultSessionMaterialRepository
         .getUnlockedVaultSessionMaterial,
@@ -413,12 +453,6 @@ describe("LockVaultUseCase", () => {
       copiedValueHash: `hash:${singlePasswordEntry.password}`,
       expiresAt: ctx.values.timestamp + 60_000,
     });
-    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
-      actionId: ctx.values.vaultLockActionId,
-      vaultId: ctx.values.vaultId,
-      expiresAt: ctx.values.timestamp + 60_000,
-    });
-
     await expect(
       ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
     ).rejects.toBe(error);
@@ -469,6 +503,11 @@ describe("LockVaultUseCase", () => {
   it("continues scheduled cleanup after lock task metadata read fails", async () => {
     const ctx = createContext();
     const error = new Error("lock task metadata unavailable");
+    await ctx.ports.vaultLockTasks.save({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
     vi.mocked(ctx.ports.vaultLockTasks.get).mockRejectedValueOnce(error);
     vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
       actionId: "clipboard-action-id",

--- a/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
@@ -9,6 +9,7 @@ import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/cli
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import { LockVaultUseCase } from "./lock-vault";
 
 function createContext() {
@@ -64,7 +65,7 @@ describe("LockVaultUseCase", () => {
     await expect(ctx.useCase.execute()).resolves.toBeUndefined();
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -83,7 +84,9 @@ describe("LockVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("removes lock task metadata when canceling pending scheduled vault lock fails", async () => {
@@ -103,9 +106,11 @@ describe("LockVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -125,12 +130,14 @@ describe("LockVaultUseCase", () => {
 
     expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
     expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
     ).not.toHaveBeenCalled();
   });
 
-  it("locks current session for scheduled vault lock when metadata is missing", async () => {
+  it("ignores scheduled vault lock when metadata is missing", async () => {
     const ctx = createContext();
 
     await expect(
@@ -139,10 +146,90 @@ describe("LockVaultUseCase", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalledTimes(1);
-    expect(ctx.ports.vaultLockTasks.remove).not.toHaveBeenCalled();
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("cleans matching scheduled state when the session is already absent", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSession = undefined;
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+  });
+
+  it("invalidates an authorized activation when manual lock finds no session", async () => {
+    const ctx = createContext();
+    const previousSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (previousSession === undefined) {
+      throw new Error("Expected an active test session.");
+    }
+
+    ctx.ports.saved.unlockedVaultSession = undefined;
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+
+    await expect(ctx.useCase.execute()).resolves.toBeUndefined();
+    await expect(
+      ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        previousSession.unlockedVault,
+        previousSession.sourceSnapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(UnlockedVaultSessionExpiredError);
+  });
+
+  it("ignores scheduled vault lock metadata for another active vault", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: "other-vault-id",
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
   });
 
   it("locks current session for matching scheduled vault lock action", async () => {
@@ -160,9 +247,64 @@ describe("LockVaultUseCase", () => {
     ).resolves.toBeUndefined();
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes cleanup against a competing session activation", async () => {
+    const ctx = createContext();
+    const activeSession = ctx.ports.saved.unlockedVaultSession;
+
+    if (activeSession === undefined) {
+      throw new Error("Expected an active test session.");
+    }
+
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+    let cleanupCanContinue!: () => void;
+    let cleanupStartedResolve!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      cleanupStartedResolve = resolve;
+    });
+    const cleanupCanContinuePromise = new Promise<void>((resolve) => {
+      cleanupCanContinue = resolve;
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockImplementationOnce(async () => {
+      cleanupStartedResolve();
+      await cleanupCanContinuePromise;
+      return {
+        actionId: ctx.values.vaultLockActionId,
+        vaultId: ctx.values.vaultId,
+        expiresAt: ctx.values.timestamp + 60_000,
+      };
+    });
+
+    const cleanup = ctx.useCase.execute({
+      actionId: ctx.values.vaultLockActionId,
+    });
+    await cleanupStarted;
+    const competingActivation =
+      ctx.ports.sessionServices.unlockedVaultSession.activate(
+        activationGeneration,
+        activeSession.unlockedVault,
+        activeSession.sourceSnapshotVersionVector,
+      );
+    cleanupCanContinue();
+
+    await expect(cleanup).resolves.toBeUndefined();
+    await expect(competingActivation).rejects.toBeInstanceOf(
+      UnlockedVaultSessionExpiredError,
+    );
+
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
   });
 
   it("clears pending copied password before removing unlocked vault state", async () => {
@@ -183,7 +325,7 @@ describe("LockVaultUseCase", () => {
       actionId: "clipboard-action-id",
     });
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -201,7 +343,7 @@ describe("LockVaultUseCase", () => {
     await expect(ctx.useCase.execute()).rejects.toThrow(error);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -213,10 +355,140 @@ describe("LockVaultUseCase", () => {
 
     await expect(ctx.useCase.execute()).rejects.toBe(error);
 
+    expect(ctx.clipboardClearTasks.get).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues all cleanup after reading active session material fails", async () => {
+    const ctx = createContext();
+    const error = new Error("session material unavailable");
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(ctx.useCase.execute()).rejects.toBe(error);
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledTimes(1);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("authenticates scheduled cleanup after reading active session material fails", async () => {
+    const ctx = createContext();
+    const error = new Error("session material unavailable");
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(error);
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledTimes(1);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+  });
+
+  it("preserves a session material read failure when scheduled metadata is missing", async () => {
+    const ctx = createContext();
+    const error = new Error("session material unavailable");
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(error);
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(error);
+
     expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
-    ).toHaveBeenCalledTimes(1);
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+  });
+
+  it("continues scheduled cleanup after lock task metadata read fails", async () => {
+    const ctx = createContext();
+    const error = new Error("lock task metadata unavailable");
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(error);
+
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
 
   it("removes unlocked vault state when reading clipboard task metadata fails", async () => {
@@ -228,7 +500,7 @@ describe("LockVaultUseCase", () => {
     await expect(ctx.useCase.execute()).rejects.toBe(error);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -244,13 +516,14 @@ describe("LockVaultUseCase", () => {
     });
     vi.mocked(ctx.clipboard.readText).mockRejectedValueOnce(cleanupError);
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
     ).mockRejectedValueOnce(removeError);
 
     await expect(ctx.useCase.execute()).rejects.toBe(cleanupError);
 
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -280,9 +553,56 @@ describe("LockVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalledTimes(1);
     expect(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues cleanup when clipboard task metadata removal fails", async () => {
+    const ctx = createContext();
+    const error = new Error("clipboard metadata removal failed");
+
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboardClearTasks.get).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.remove).mockRejectedValueOnce(error);
+
+    await expect(ctx.useCase.execute()).rejects.toBe(error);
+
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues session cleanup when lock task metadata removal fails", async () => {
+    const ctx = createContext();
+    const error = new Error("lock metadata removal failed");
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).mockRejectedValueOnce(error);
+
+    await expect(ctx.useCase.execute()).rejects.toBe(error);
+
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -291,7 +611,7 @@ describe("LockVaultUseCase", () => {
     const error = new Error("lock failed");
 
     vi.mocked(
-      ctx.ports.sessionServices.unlockedVaultSession.remove,
+      ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).mockRejectedValueOnce(error);
 
     await expect(ctx.useCase.execute()).rejects.toThrow(error);

--- a/packages/core/src/use-cases/vault-lifecycle/lock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/lock-vault.ts
@@ -3,17 +3,14 @@ import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
 import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 
 export type LockVaultCommandParams = {
   actionId?: string;
 };
 
 export class LockVaultUseCase {
-  private readonly clipboardClear: ClipboardClearService;
-  private readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
-  private readonly scheduledTasks: ScheduledTaskPort;
-  private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
-  private readonly unlockedVaultSession: UnlockedVaultSessionService;
+  private readonly lifecycleCleanup: VaultLifecycleCleanupService;
 
   constructor(
     clipboardClear: ClipboardClearService,
@@ -22,83 +19,16 @@ export class LockVaultUseCase {
     vaultLockTasks: VaultLockTaskRepositoryPort,
     unlockedVaultSession: UnlockedVaultSessionService,
   ) {
-    this.clipboardClear = clipboardClear;
-    this.clipboardClearTasks = clipboardClearTasks;
-    this.scheduledTasks = scheduledTasks;
-    this.vaultLockTasks = vaultLockTasks;
-    this.unlockedVaultSession = unlockedVaultSession;
+    this.lifecycleCleanup = new VaultLifecycleCleanupService(
+      clipboardClear,
+      clipboardClearTasks,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
   }
 
   async execute(params: LockVaultCommandParams = {}): Promise<void> {
-    let executionError: unknown;
-    let sessionRemovalError: unknown;
-    let shouldRemoveSession = true;
-
-    try {
-      const vaultLockTask = await this.vaultLockTasks.get();
-
-      if (
-        params.actionId !== undefined &&
-        vaultLockTask !== null &&
-        vaultLockTask.actionId !== params.actionId
-      ) {
-        shouldRemoveSession = false;
-        return;
-      }
-
-      const clipboardClearTask = await this.clipboardClearTasks.get();
-      let cleanupError: unknown;
-
-      try {
-        await this.clipboardClear.clearTask({
-          task: clipboardClearTask,
-          requireExpired: false,
-        });
-
-        if (clipboardClearTask !== null) {
-          await this.scheduledTasks.cancelTask({
-            name: "clearClipboard",
-            actionId: clipboardClearTask.actionId,
-          });
-        }
-      } catch (error) {
-        cleanupError = error;
-      }
-
-      if (vaultLockTask !== null) {
-        try {
-          await this.scheduledTasks.cancelTask({
-            name: "lockVault",
-            actionId: vaultLockTask.actionId,
-          });
-        } finally {
-          await this.vaultLockTasks.remove();
-        }
-      }
-
-      if (cleanupError !== undefined) {
-        throw cleanupError;
-      }
-    } catch (error) {
-      executionError = error;
-    } finally {
-      if (shouldRemoveSession) {
-        try {
-          await this.unlockedVaultSession.remove();
-        } catch (error) {
-          if (executionError === undefined) {
-            sessionRemovalError = error;
-          }
-        }
-      }
-    }
-
-    if (executionError !== undefined) {
-      throw executionError;
-    }
-
-    if (sessionRemovalError !== undefined) {
-      throw sessionRemovalError;
-    }
+    await this.lifecycleCleanup.cleanup(params);
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/lock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/lock-vault.ts
@@ -1,9 +1,4 @@
-import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
-import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
-import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
-import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
-import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
-import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import type { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
 
 export type LockVaultCommandParams = {
   actionId?: string;
@@ -12,20 +7,8 @@ export type LockVaultCommandParams = {
 export class LockVaultUseCase {
   private readonly lifecycleCleanup: VaultLifecycleCleanupService;
 
-  constructor(
-    clipboardClear: ClipboardClearService,
-    clipboardClearTasks: ClipboardClearTaskRepositoryPort,
-    scheduledTasks: ScheduledTaskPort,
-    vaultLockTasks: VaultLockTaskRepositoryPort,
-    unlockedVaultSession: UnlockedVaultSessionService,
-  ) {
-    this.lifecycleCleanup = new VaultLifecycleCleanupService(
-      clipboardClear,
-      clipboardClearTasks,
-      scheduledTasks,
-      vaultLockTasks,
-      unlockedVaultSession,
-    );
+  constructor(lifecycleCleanup: VaultLifecycleCleanupService) {
+    this.lifecycleCleanup = lifecycleCleanup;
   }
 
   async execute(params: LockVaultCommandParams = {}): Promise<void> {

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -11,6 +11,32 @@ import {
 import { DeviceAccessMaterialIdentityMismatchError } from "../../errors/vault-device.errors";
 import { ChangeMasterPasswordUseCase } from "./change-master-password";
 
+async function expectUnlockOwnedBuffersWiped(
+  ctx: ReturnType<typeof createUnlockVaultTestContext>,
+): Promise<void> {
+  const localRootKey = await vi.mocked(ctx.ports.crypto.deriveLocalRootKey).mock
+    .results[0]!.value;
+  const localKeysProtectionKey = await vi.mocked(
+    ctx.ports.crypto.deriveLocalKeysProtectionKey,
+  ).mock.results[0]!.value;
+  const localKeys = await vi.mocked(ctx.ports.crypto.unwrapLocalKeysPayload)
+    .mock.results[0]!.value;
+  const vaultMasterKey = await vi.mocked(
+    ctx.ports.crypto.openDeviceVaultKeyEnvelope,
+  ).mock.results[0]!.value;
+
+  for (const buffer of [
+    localRootKey,
+    localKeysProtectionKey,
+    localKeys.devicePrivateSignKey,
+    localKeys.devicePrivateVaultKey,
+    localKeys.deviceLocalProtectionKey,
+    vaultMasterKey,
+  ]) {
+    expect(Array.from(new Uint8Array(buffer))).toEqual([0]);
+  }
+}
+
 describe("UnlockVaultUseCase", () => {
   it("continues to attempt a current password below the new strength requirement", async () => {
     const ctx = createUnlockVaultTestContext();
@@ -310,8 +336,11 @@ describe("UnlockVaultUseCase", () => {
       }),
     ).rejects.toThrow("schedule failed");
 
-    expect(ctx.ports.vaultLockTasks.removeIfActionIsActive).toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    await expectUnlockOwnedBuffersWiped(ctx);
   });
 
   it("cancels the scheduled lock and removes metadata when activation fails", async () => {
@@ -337,7 +366,10 @@ describe("UnlockVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.ports.vaultLockTasks.removeIfActionIsActive).toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    await expectUnlockOwnedBuffersWiped(ctx);
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.test.ts
@@ -310,13 +310,16 @@ describe("UnlockVaultUseCase", () => {
       }),
     ).rejects.toThrow("schedule failed");
 
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalled();
+    expect(ctx.ports.vaultLockTasks.removeIfActionIsActive).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 
   it("cancels the scheduled lock and removes metadata when activation fails", async () => {
     const ctx = createUnlockVaultTestContext();
     const activationError = new Error("session activation failed");
+    vi.mocked(ctx.ports.scheduledTasks.cancelTask).mockRejectedValueOnce(
+      new Error("cancel failed"),
+    );
     vi.mocked(
       ctx.ports.unlockedVaultSessionMaterialRepository
         .saveUnlockedVaultSessionMaterial,
@@ -334,7 +337,7 @@ describe("UnlockVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.ports.vaultLockTasks.remove).toHaveBeenCalled();
+    expect(ctx.ports.vaultLockTasks.removeIfActionIsActive).toHaveBeenCalled();
     expect(ctx.saved.unlockedVaultSession).toBeUndefined();
   });
 });

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
@@ -1,7 +1,6 @@
 import type { LocalKeysPayload } from "../../domain/device-trust/local-protection.type";
 import type { RawMasterPassword } from "../../domain/master-password";
 import { areDeviceAccessRecordsConsistent } from "../../domain/device-trust/device-access-records";
-import { vaultLockDelayMsSchema } from "../../domain/scheduled-task/scheduled-task-delay.schema";
 import type { VaultLockDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
 import type { DeviceKeySlot } from "../../domain/snapshot/key-slot";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
@@ -21,14 +20,15 @@ import {
   DeviceKeySlotVerificationFailedError,
   VaultSnapshotNotFoundError,
 } from "../../errors/unlock-vault.errors";
-import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
 import { PersistedVaultMismatchError } from "../../errors/vault-snapshot.errors";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
+import { VaultSessionActivationService } from "../../services/session/vault-session-activation.service";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
 import { DeviceAccessMaterialIdentityMismatchError } from "../../errors/vault-device.errors";
 import { LocalVaultTrustCheckpointNotFoundError } from "../../errors/vault-trust.errors";
 import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
+import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 
 export type UnlockVaultCommandParams = {
   vaultId: string;
@@ -45,12 +45,9 @@ export type UnlockVaultResult = {
 };
 
 export class UnlockVaultUseCase {
-  private readonly clock: ClockPort;
   private readonly crypto: CryptoPort;
-  private readonly ids: IdPort;
-  private readonly scheduledTasks: ScheduledTaskPort;
+  private readonly sessionActivation: VaultSessionActivationService;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
-  private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultTrust: VaultTrustService;
 
@@ -63,24 +60,23 @@ export class UnlockVaultUseCase {
     vaultLockTasks: VaultLockTaskRepositoryPort,
     unlockedVaultSession: UnlockedVaultSessionService,
   ) {
-    this.clock = clock;
     this.crypto = crypto;
-    this.ids = ids;
-    this.scheduledTasks = scheduledTasks;
     this.vaultLocalRepository = vaultLocalRepository;
-    this.vaultLockTasks = vaultLockTasks;
     this.unlockedVaultSession = unlockedVaultSession;
+    this.sessionActivation = new VaultSessionActivationService(
+      clock,
+      ids,
+      scheduledTasks,
+      vaultLockTasks,
+      unlockedVaultSession,
+    );
     this.vaultTrust = new VaultTrustService(crypto);
   }
 
   async execute(params: UnlockVaultCommandParams): Promise<UnlockVaultResult> {
-    const lockDelayResult = vaultLockDelayMsSchema.safeParse(
+    const lockAfterMs = this.sessionActivation.requireValidLockDelay(
       params.lockAfterMs,
     );
-
-    if (!lockDelayResult.success) {
-      throw new InvalidVaultLockDelayError(lockDelayResult.error);
-    }
 
     const activationGeneration =
       await this.unlockedVaultSession.requireVaultCanBeActivated(
@@ -153,204 +149,186 @@ export class UnlockVaultUseCase {
       );
     }
 
-    const localRootKey = await this.crypto.deriveLocalRootKey(
-      params.masterPassword,
-      deviceAccessMaterial.masterPasswordSalt,
-    );
+    const ephemeralSecrets: ArrayBuffer[] = [];
+    const sessionSecrets: ArrayBuffer[] = [];
+    let sessionActivated = false;
 
-    const localKeysProtectionKey =
-      await this.crypto.deriveLocalKeysProtectionKey(
-        localRootKey,
-        deviceAccessMaterial.localKeysProtectionSalt,
+    try {
+      const localRootKey = await this.crypto.deriveLocalRootKey(
+        params.masterPassword,
+        deviceAccessMaterial.masterPasswordSalt,
       );
+      ephemeralSecrets.push(localRootKey);
 
-    const localKeysPayload: LocalKeysPayload =
-      await this.crypto.unwrapLocalKeysPayload(
-        deviceAccessMaterial.protectedLocalKeys,
-        localKeysProtectionKey,
-      );
-    const doesDeviceSigningKeyMatchMaterial =
-      await this.crypto.verifyDeviceSignKeyPair(
-        deviceAccessMaterial.devicePublicSignKey,
+      const localKeysProtectionKey =
+        await this.crypto.deriveLocalKeysProtectionKey(
+          localRootKey,
+          deviceAccessMaterial.localKeysProtectionSalt,
+        );
+      ephemeralSecrets.push(localKeysProtectionKey);
+
+      const localKeysPayload: LocalKeysPayload =
+        await this.crypto.unwrapLocalKeysPayload(
+          deviceAccessMaterial.protectedLocalKeys,
+          localKeysProtectionKey,
+        );
+      sessionSecrets.push(
         localKeysPayload.devicePrivateSignKey,
-      );
-    const doesDeviceVaultKeyMatchMaterial =
-      await this.crypto.verifyDeviceVaultKeyPair(
-        deviceAccessMaterial.devicePublicVaultKey,
         localKeysPayload.devicePrivateVaultKey,
+        localKeysPayload.deviceLocalProtectionKey,
       );
+      const doesDeviceSigningKeyMatchMaterial =
+        await this.crypto.verifyDeviceSignKeyPair(
+          deviceAccessMaterial.devicePublicSignKey,
+          localKeysPayload.devicePrivateSignKey,
+        );
+      const doesDeviceVaultKeyMatchMaterial =
+        await this.crypto.verifyDeviceVaultKeyPair(
+          deviceAccessMaterial.devicePublicVaultKey,
+          localKeysPayload.devicePrivateVaultKey,
+        );
 
-    if (
-      !doesDeviceSigningKeyMatchMaterial ||
-      !doesDeviceVaultKeyMatchMaterial
-    ) {
-      throw new DeviceKeySlotVerificationFailedError(
+      if (
+        !doesDeviceSigningKeyMatchMaterial ||
+        !doesDeviceVaultKeyMatchMaterial
+      ) {
+        throw new DeviceKeySlotVerificationFailedError(
+          params.vaultId,
+          deviceAccessMaterial.deviceId,
+        );
+      }
+
+      const localDeviceIdentity = {
+        deviceId: deviceAccessMaterial.deviceId,
+        publicSignKey: deviceAccessMaterial.devicePublicSignKey,
+        publicVaultKey: deviceAccessMaterial.devicePublicVaultKey,
+      };
+      const checkpoint =
+        await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+          params.vaultId,
+        );
+
+      if (checkpoint === null) {
+        throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
+      }
+
+      await this.vaultTrust.verifyCheckpoint(
         params.vaultId,
-        deviceAccessMaterial.deviceId,
+        checkpoint,
+        localDeviceIdentity,
       );
-    }
-
-    const localDeviceIdentity = {
-      deviceId: deviceAccessMaterial.deviceId,
-      publicSignKey: deviceAccessMaterial.devicePublicSignKey,
-      publicVaultKey: deviceAccessMaterial.devicePublicVaultKey,
-    };
-    const checkpoint =
-      await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+      const verifiedTrust = await this.vaultTrust.verifyTrustChain(
         params.vaultId,
+        localKeysPayload.vaultTrustAnchor,
+        this.requireTrustChain(params.vaultId, vaultSnapshot),
+      );
+      const trustedLocalDevice = verifiedTrust.trustedDevices.find(
+        (device) => device.deviceId === deviceAccessMaterial.deviceId,
       );
 
-    if (checkpoint === null) {
-      throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
-    }
+      if (
+        trustedLocalDevice === undefined ||
+        !(await this.crypto.verifyDeviceSignKeyPair(
+          trustedLocalDevice.publicSignKey,
+          localKeysPayload.devicePrivateSignKey,
+        )) ||
+        !(await this.crypto.verifyDeviceVaultKeyPair(
+          trustedLocalDevice.publicVaultKey,
+          localKeysPayload.devicePrivateVaultKey,
+        ))
+      ) {
+        throw new VaultTrustStateInvalidError(
+          params.vaultId,
+          "local device is not trusted",
+        );
+      }
 
-    await this.vaultTrust.verifyCheckpoint(
-      params.vaultId,
-      checkpoint,
-      localDeviceIdentity,
-    );
-    const verifiedTrust = await this.vaultTrust.verifyTrustChain(
-      params.vaultId,
-      localKeysPayload.vaultTrustAnchor,
-      this.requireTrustChain(params.vaultId, vaultSnapshot),
-    );
-    const trustedLocalDevice = verifiedTrust.trustedDevices.find(
-      (device) => device.deviceId === deviceAccessMaterial.deviceId,
-    );
-
-    if (
-      trustedLocalDevice === undefined ||
-      !(await this.crypto.verifyDeviceSignKeyPair(
-        trustedLocalDevice.publicSignKey,
-        localKeysPayload.devicePrivateSignKey,
-      )) ||
-      !(await this.crypto.verifyDeviceVaultKeyPair(
-        trustedLocalDevice.publicVaultKey,
-        localKeysPayload.devicePrivateVaultKey,
-      ))
-    ) {
-      throw new VaultTrustStateInvalidError(
-        params.vaultId,
-        "local device is not trusted",
-      );
-    }
-
-    await this.vaultTrust.verifySnapshot(
-      params.vaultId,
-      vaultSnapshot,
-      verifiedTrust,
-    );
-    const checkpointRelation =
-      await this.vaultTrust.requireSnapshotNotRolledBack(
+      await this.vaultTrust.verifySnapshot(
         params.vaultId,
         vaultSnapshot,
         verifiedTrust,
-        checkpoint,
       );
-
-    const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
-      deviceKeySlot.envelope,
-      localKeysPayload.devicePrivateVaultKey,
-      {
-        vaultId: params.vaultId,
-        deviceId: deviceAccessMaterial.deviceId,
-        vaultKeyGeneration: vaultSnapshot.metadata.vaultKeyGeneration,
-        algorithmSuiteId: vaultSnapshot.metadata.algorithmSuiteId,
-      },
-    );
-
-    const vault = await this.crypto.decryptVaultSnapshotContent(
-      vaultSnapshot.content,
-      vaultMasterKey,
-    );
-
-    const snapshotDigest = await this.crypto.digestVaultSnapshot(vaultSnapshot);
-
-    if (checkpointRelation === "newer") {
-      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
-        expectedSnapshotDigest: snapshotDigest,
-        snapshot: vaultSnapshot,
-        checkpoint: await this.vaultTrust.createCheckpoint(
+      const checkpointRelation =
+        await this.vaultTrust.requireSnapshotNotRolledBack(
+          params.vaultId,
           vaultSnapshot,
           verifiedTrust,
-          deviceAccessMaterial.deviceId,
-          localKeysPayload.devicePrivateSignKey,
-        ),
-      });
-    }
+          checkpoint,
+        );
 
-    const unlockedVault: UnlockedVault = {
-      vaultId: params.vaultId,
-      deviceId: deviceAccessMaterial.deviceId,
-      vault,
-      vaultMasterKey,
-      devicePrivateSignKey: localKeysPayload.devicePrivateSignKey,
-      devicePrivateVaultKey: localKeysPayload.devicePrivateVaultKey,
-      deviceLocalProtectionKey: localKeysPayload.deviceLocalProtectionKey,
-      trustedSnapshotContext: {
-        snapshotDigest,
-        trust: verifiedTrust,
-      },
-      vaultTrustAnchor: localKeysPayload.vaultTrustAnchor,
-    };
+      const vaultMasterKey = await this.crypto.openDeviceVaultKeyEnvelope(
+        deviceKeySlot.envelope,
+        localKeysPayload.devicePrivateVaultKey,
+        {
+          vaultId: params.vaultId,
+          deviceId: deviceAccessMaterial.deviceId,
+          vaultKeyGeneration: vaultSnapshot.metadata.vaultKeyGeneration,
+          algorithmSuiteId: vaultSnapshot.metadata.algorithmSuiteId,
+        },
+      );
+      sessionSecrets.push(vaultMasterKey);
 
-    const lockVaultActionId = await this.ids.generateId();
-    const lockScheduledAt = this.clock.now() + params.lockAfterMs;
+      const vault = await this.crypto.decryptVaultSnapshotContent(
+        vaultSnapshot.content,
+        vaultMasterKey,
+      );
 
-    const lockVaultTask = {
-      name: "lockVault",
-      actionId: lockVaultActionId,
-    } as const;
+      const snapshotDigest =
+        await this.crypto.digestVaultSnapshot(vaultSnapshot);
 
-    await this.vaultLockTasks.save({
-      actionId: lockVaultActionId,
-      vaultId: params.vaultId,
-      expiresAt: lockScheduledAt,
-    });
-
-    try {
-      await this.scheduledTasks.scheduleTask({
-        task: lockVaultTask,
-        runAt: lockScheduledAt,
-      });
-    } catch (error) {
-      try {
-        await this.vaultLockTasks.remove();
-      } catch {
-        // Preserve the schedule failure.
+      if (checkpointRelation === "newer") {
+        await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+          expectedSnapshotDigest: snapshotDigest,
+          snapshot: vaultSnapshot,
+          checkpoint: await this.vaultTrust.createCheckpoint(
+            vaultSnapshot,
+            verifiedTrust,
+            deviceAccessMaterial.deviceId,
+            localKeysPayload.devicePrivateSignKey,
+          ),
+        });
       }
-      throw error;
-    }
 
-    try {
-      await this.unlockedVaultSession.activate(
+      const unlockedVault: UnlockedVault = {
+        vaultId: params.vaultId,
+        deviceId: deviceAccessMaterial.deviceId,
+        vault,
+        vaultMasterKey,
+        devicePrivateSignKey: localKeysPayload.devicePrivateSignKey,
+        devicePrivateVaultKey: localKeysPayload.devicePrivateVaultKey,
+        deviceLocalProtectionKey: localKeysPayload.deviceLocalProtectionKey,
+        trustedSnapshotContext: {
+          snapshotDigest,
+          trust: verifiedTrust,
+        },
+        vaultTrustAnchor: localKeysPayload.vaultTrustAnchor,
+      };
+
+      await this.sessionActivation.activate({
         activationGeneration,
         unlockedVault,
-        vaultSnapshot.metadata.snapshotVersionVector,
-      );
-    } catch (error) {
-      try {
-        await this.scheduledTasks.cancelTask(lockVaultTask);
-      } catch {
-        // Preserve the save failure; repository cleanup still needs to run.
-      }
-      try {
-        await this.vaultLockTasks.remove();
-      } catch {
-        // Preserve the save failure.
-      }
-      throw error;
-    }
+        sourceSnapshotVersionVector:
+          vaultSnapshot.metadata.snapshotVersionVector,
+        lockAfterMs,
+      });
+      sessionActivated = true;
 
-    return {
-      vaultId: params.vaultId,
-      deviceId: deviceAccessMaterial.deviceId,
-      snapshotVersionVector: {
-        ...vaultSnapshot.metadata.snapshotVersionVector,
-      },
-      revisionTimestamp: vaultSnapshot.metadata.revisionTimestamp,
-      vault: toVisibleVaultFields(vault),
-    };
+      return {
+        vaultId: params.vaultId,
+        deviceId: deviceAccessMaterial.deviceId,
+        snapshotVersionVector: {
+          ...vaultSnapshot.metadata.snapshotVersionVector,
+        },
+        revisionTimestamp: vaultSnapshot.metadata.revisionTimestamp,
+        vault: toVisibleVaultFields(vault),
+      };
+    } finally {
+      bestEffortWipeArrayBuffers(ephemeralSecrets);
+
+      if (!sessionActivated) {
+        bestEffortWipeArrayBuffers(sessionSecrets);
+      }
+    }
   }
 
   private requireTrustChain(


### PR DESCRIPTION
## Summary

- Centralize vault session activation and lifecycle cleanup under serialized ownership boundaries.
- Wipe caller-owned secret buffers during session removal, decoding failures, and ownership transitions.
- Prevent stale lock actions and concurrent activations from removing newer session or task metadata.
- Update vault lifecycle security specifications, diagrams, ports, fixtures, and regression coverage.

## Testing

- Not run (change request content only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic vault locking with configurable delays during initialization, unlocking, and device enrollment.
  * Added coordinated cleanup for vault sessions, clipboard contents, and scheduled lock tasks.
  * Improved handling of concurrent or stale session actions to prevent unintended cleanup.

* **Bug Fixes**
  * Strengthened recovery and rollback after activation, synchronization, and persistence failures.
  * Improved protection of sensitive key material by securely wiping temporary secrets after use or failed operations.
  * Added in-memory session-material caching for faster repeated access.
  * Improved reporting when rollback cannot fully complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->