### PR TITLE
fix: coordinate clipboard ownership atomically

### DIFF
--- a/apps/extension/config/manifest.json
+++ b/apps/extension/config/manifest.json
@@ -2,15 +2,24 @@
   "manifest_version": 3,
   "name": "Serverless Password Manager",
   "version": "1.0.0",
+  "minimum_chrome_version": "120",
   "description": "A secure, serverless password manager extension",
-  "permissions": ["storage", "activeTab"],
+  "permissions": [
+    "storage",
+    "activeTab",
+    "alarms",
+    "clipboardRead",
+    "clipboardWrite",
+    "offscreen"
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_title": "SPM Extension"
   },
   "options_page": "options.html",
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'none'; base-uri 'none';"

--- a/apps/extension/config/vite.config.ts
+++ b/apps/extension/config/vite.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
       input: {
         popup: resolve(__dirname, "..", "popup.html"),
         options: resolve(__dirname, "..", "options.html"),
+        offscreen: resolve(__dirname, "..", "offscreen.html"),
         background: resolve(
           __dirname,
           "..",

--- a/apps/extension/offscreen.html
+++ b/apps/extension/offscreen.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Clipboard operations</title>
+  </head>
+  <body>
+    <textarea
+      id="clipboard-transfer"
+      tabindex="-1"
+      aria-label="Clipboard transfer"
+    ></textarea>
+    <script type="module" src="/src/extension/offscreen/offscreen.ts"></script>
+  </body>
+</html>

--- a/apps/extension/src/__tests__/fixtures/chrome-storage-area.ts
+++ b/apps/extension/src/__tests__/fixtures/chrome-storage-area.ts
@@ -1,0 +1,41 @@
+import { vi } from "vitest";
+import type { ChromeStorageArea } from "../../adapters/storage/chrome-storage-area";
+
+export function createChromeStorageArea(
+  initialRecords: Record<string, unknown> = {},
+) {
+  let records = { ...initialRecords };
+  const storageArea: ChromeStorageArea = {
+    setAccessLevel: vi.fn(async () => undefined),
+    async get(keys?: unknown) {
+      if (typeof keys === "string") {
+        return { [keys]: records[keys] };
+      }
+
+      if (Array.isArray(keys)) {
+        return Object.fromEntries(keys.map((key) => [key, records[key]]));
+      }
+
+      return { ...records };
+    },
+    async set(items: Record<string, unknown>) {
+      records = {
+        ...records,
+        ...items,
+      };
+    },
+    async remove(keys: string | string[]) {
+      const keysToRemove = new Set(Array.isArray(keys) ? keys : [keys]);
+      records = Object.fromEntries(
+        Object.entries(records).filter(
+          ([recordKey]) => !keysToRemove.has(recordKey),
+        ),
+      );
+    },
+  };
+
+  return {
+    getRecords: () => records,
+    storageArea,
+  };
+}

--- a/apps/extension/src/adapters/clipboard/index.ts
+++ b/apps/extension/src/adapters/clipboard/index.ts
@@ -1,0 +1,3 @@
+export * from "./offscreen-clipboard";
+export * from "./web-crypto-clipboard-secret-hash";
+export * from "./web-locks-clipboard-operation-coordinator";

--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ChromeOffscreenApi,
+  type ChromeRuntimeMessenger,
+  type OffscreenClipboardResponse,
+  type OffscreenClientDirectory,
+  OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+  OFFSCREEN_CLIPBOARD_REASON,
+  OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
+  OFFSCREEN_DOCUMENT_CONTEXT,
+  OffscreenClipboard,
+} from "./offscreen-clipboard";
+
+function createContext(documentExists = false) {
+  const createDocument = vi.fn(async () => undefined);
+  const offscreen: ChromeOffscreenApi = {
+    createDocument,
+  };
+  let nextResponse: OffscreenClipboardResponse | undefined;
+  let respond = true;
+  const postMessage = vi.fn(
+    (request: { readonly operation?: unknown }, transfer: Transferable[]) => {
+      const responsePort = transfer[0];
+
+      if (!(responsePort instanceof MessagePort)) {
+        throw new Error("Expected a response message port.");
+      }
+
+      if (!respond) {
+        return;
+      }
+
+      responsePort.postMessage(
+        nextResponse ??
+          (request.operation === "read"
+            ? { ok: true, value: "clipboard-value" }
+            : { ok: true }),
+      );
+      nextResponse = undefined;
+    },
+  );
+  const otherClientPostMessage = vi.fn();
+  const documentUrl = "chrome-extension://extension-id/offscreen.html";
+  const matchAll = vi.fn(async () => [
+    {
+      url: "chrome-extension://extension-id/options.html",
+      postMessage: otherClientPostMessage,
+    },
+    { url: documentUrl, postMessage },
+  ]);
+  const clients: OffscreenClientDirectory = { matchAll };
+  const getContexts = vi.fn(async () =>
+    documentExists ? [{ contextType: OFFSCREEN_DOCUMENT_CONTEXT }] : [],
+  );
+  const runtime: ChromeRuntimeMessenger = { getContexts };
+  const clipboard = new OffscreenClipboard(
+    offscreen,
+    runtime,
+    documentUrl,
+    clients,
+  );
+
+  return {
+    clipboard,
+    createDocument,
+    getContexts,
+    matchAll,
+    otherClientPostMessage,
+    postMessage,
+    setNextResponse(response: OffscreenClipboardResponse) {
+      nextResponse = response;
+    },
+    stopResponding() {
+      respond = false;
+    },
+  };
+}
+
+describe("OffscreenClipboard", () => {
+  it("creates the offscreen document and reads clipboard text", async () => {
+    const ctx = createContext();
+
+    await expect(ctx.clipboard.readText()).resolves.toBe("clipboard-value");
+
+    expect(ctx.createDocument).toHaveBeenCalledWith({
+      url: "chrome-extension://extension-id/offscreen.html",
+      reasons: [OFFSCREEN_CLIPBOARD_REASON],
+      justification: "Clear password-manager clipboard contents after timeout.",
+    });
+    expect(ctx.getContexts).toHaveBeenCalledWith({
+      contextTypes: [OFFSCREEN_DOCUMENT_CONTEXT],
+      documentUrls: ["chrome-extension://extension-id/offscreen.html"],
+    });
+    expect(ctx.postMessage.mock.calls[0]?.[0]).toEqual({
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      operation: "read",
+    });
+    expect(ctx.otherClientPostMessage).not.toHaveBeenCalled();
+    expect(ctx.matchAll).toHaveBeenCalledWith({
+      includeUncontrolled: true,
+      type: "window",
+    });
+  });
+
+  it("reuses an existing document when writing clipboard text", async () => {
+    const ctx = createContext(true);
+
+    await expect(
+      ctx.clipboard.writeText("next-value"),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.createDocument).not.toHaveBeenCalled();
+    expect(ctx.postMessage.mock.calls[0]?.[0]).toEqual({
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      operation: "write",
+      value: "next-value",
+    });
+  });
+
+  it("rejects failed offscreen operations", async () => {
+    const ctx = createContext(true);
+    ctx.setNextResponse({
+      ok: false,
+      error: "Clipboard operation failed.",
+    });
+
+    await expect(ctx.clipboard.readText()).rejects.toThrow(
+      "Clipboard operation failed.",
+    );
+  });
+
+  it("times out when the offscreen document does not respond", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const ctx = createContext(true);
+      ctx.stopResponding();
+      const pendingRead = expect(ctx.clipboard.readText()).rejects.toThrow(
+        "Offscreen clipboard response timed out.",
+      );
+
+      await vi.advanceTimersByTimeAsync(
+        OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
+      );
+
+      await pendingRead;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
@@ -1,0 +1,214 @@
+import type { ClipboardPort } from "@lfspm/core";
+
+export const OFFSCREEN_CLIPBOARD_DOCUMENT_PATH = "offscreen.html";
+export const OFFSCREEN_CLIPBOARD_MESSAGE_TARGET = "lfspm:offscreen-clipboard";
+export const OFFSCREEN_CLIPBOARD_REASON =
+  "CLIPBOARD" as chrome.offscreen.Reason;
+export const OFFSCREEN_DOCUMENT_CONTEXT =
+  "OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType;
+export const OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS = 5_000;
+
+export type OffscreenClipboardRequest =
+  | {
+      readonly target: typeof OFFSCREEN_CLIPBOARD_MESSAGE_TARGET;
+      readonly operation: "read";
+    }
+  | {
+      readonly target: typeof OFFSCREEN_CLIPBOARD_MESSAGE_TARGET;
+      readonly operation: "write";
+      readonly value: string;
+    };
+
+export type OffscreenClipboardResponse =
+  | { readonly ok: true; readonly value?: string }
+  | { readonly ok: false; readonly error: string };
+
+export type ChromeOffscreenApi = {
+  createDocument: (parameters: {
+    readonly url: string;
+    readonly reasons: chrome.offscreen.Reason[];
+    readonly justification: string;
+  }) => Promise<void>;
+};
+
+export type ChromeRuntimeMessenger = {
+  getContexts: (filter: {
+    readonly contextTypes: chrome.runtime.ContextType[];
+    readonly documentUrls: string[];
+  }) => Promise<readonly unknown[]>;
+};
+
+export type OffscreenDocumentClient = {
+  readonly url: string;
+  postMessage(message: unknown, transfer: Transferable[]): void;
+};
+
+export type OffscreenClientDirectory = {
+  matchAll(options: {
+    readonly includeUncontrolled: true;
+    readonly type: "window";
+  }): Promise<readonly OffscreenDocumentClient[]>;
+};
+
+type MessageChannelFactory = () => MessageChannel;
+
+function getServiceWorkerClients(): OffscreenClientDirectory {
+  const serviceWorkerScope = globalThis as typeof globalThis & {
+    readonly clients?: OffscreenClientDirectory;
+  };
+
+  if (serviceWorkerScope.clients === undefined) {
+    throw new Error("Offscreen clipboard requires a service-worker context.");
+  }
+
+  return serviceWorkerScope.clients;
+}
+
+function isOffscreenClipboardResponse(
+  response: unknown,
+): response is OffscreenClipboardResponse {
+  if (typeof response !== "object" || response === null) {
+    return false;
+  }
+
+  const record = response as Record<string, unknown>;
+
+  return (
+    (record.ok === true &&
+      (record.value === undefined || typeof record.value === "string")) ||
+    (record.ok === false && typeof record.error === "string")
+  );
+}
+
+export class OffscreenClipboard implements ClipboardPort {
+  private readonly offscreen: ChromeOffscreenApi;
+  private readonly runtime: ChromeRuntimeMessenger;
+  private readonly documentUrl: string;
+  private readonly clients: OffscreenClientDirectory;
+  private readonly createMessageChannel: MessageChannelFactory;
+  private documentCreation: Promise<void> | undefined;
+
+  constructor(
+    offscreen: ChromeOffscreenApi = chrome.offscreen,
+    runtime: ChromeRuntimeMessenger = chrome.runtime,
+    documentUrl = chrome.runtime.getURL(OFFSCREEN_CLIPBOARD_DOCUMENT_PATH),
+    clients: OffscreenClientDirectory = getServiceWorkerClients(),
+    createMessageChannel: MessageChannelFactory = () => new MessageChannel(),
+  ) {
+    this.offscreen = offscreen;
+    this.runtime = runtime;
+    this.documentUrl = documentUrl;
+    this.clients = clients;
+    this.createMessageChannel = createMessageChannel;
+  }
+
+  async readText(): Promise<string> {
+    const response = await this.send({
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      operation: "read",
+    });
+
+    if (typeof response.value !== "string") {
+      throw new Error("Offscreen clipboard read returned no value.");
+    }
+
+    return response.value;
+  }
+
+  async writeText(value: string): Promise<void> {
+    await this.send({
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      operation: "write",
+      value,
+    });
+  }
+
+  private async send(
+    request: OffscreenClipboardRequest,
+  ): Promise<{ readonly ok: true; readonly value?: string }> {
+    await this.ensureDocument();
+    const response = await this.sendToOffscreenDocument(request);
+
+    if (!response.ok) {
+      throw new Error(response.error);
+    }
+
+    return response;
+  }
+
+  private async sendToOffscreenDocument(
+    request: OffscreenClipboardRequest,
+  ): Promise<OffscreenClipboardResponse> {
+    const documentClients = await this.clients.matchAll({
+      includeUncontrolled: true,
+      type: "window",
+    });
+    const documentClient = documentClients.find(
+      (candidate) => candidate.url === this.documentUrl,
+    );
+
+    if (documentClient === undefined) {
+      throw new Error("Offscreen clipboard document client is unavailable.");
+    }
+
+    return new Promise((resolve, reject) => {
+      const channel = this.createMessageChannel();
+      const responseTimeout = globalThis.setTimeout(() => {
+        channel.port1.close();
+        reject(new Error("Offscreen clipboard response timed out."));
+      }, OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS);
+
+      const closeResponsePort = () => {
+        globalThis.clearTimeout(responseTimeout);
+        channel.port1.close();
+      };
+
+      channel.port1.onmessage = (event) => {
+        closeResponsePort();
+
+        if (!isOffscreenClipboardResponse(event.data)) {
+          reject(
+            new Error("Offscreen clipboard returned an invalid response."),
+          );
+          return;
+        }
+
+        resolve(event.data);
+      };
+      channel.port1.onmessageerror = () => {
+        closeResponsePort();
+        reject(new Error("Offscreen clipboard response could not be decoded."));
+      };
+
+      try {
+        documentClient.postMessage(request, [channel.port2]);
+      } catch (error) {
+        closeResponsePort();
+        reject(error);
+      }
+    });
+  }
+
+  private async ensureDocument(): Promise<void> {
+    const existingContexts = await this.runtime.getContexts({
+      contextTypes: [OFFSCREEN_DOCUMENT_CONTEXT],
+      documentUrls: [this.documentUrl],
+    });
+
+    if (existingContexts.length > 0) {
+      return;
+    }
+
+    this.documentCreation ??= this.offscreen.createDocument({
+      url: this.documentUrl,
+      reasons: [OFFSCREEN_CLIPBOARD_REASON],
+      justification: "Clear password-manager clipboard contents after timeout.",
+    });
+
+    try {
+      await this.documentCreation;
+    } finally {
+      this.documentCreation = undefined;
+    }
+  }
+}

--- a/apps/extension/src/adapters/clipboard/web-crypto-clipboard-secret-hash.test.ts
+++ b/apps/extension/src/adapters/clipboard/web-crypto-clipboard-secret-hash.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { WebCryptoClipboardSecretHash } from "./web-crypto-clipboard-secret-hash";
+
+describe("WebCryptoClipboardSecretHash", () => {
+  it("uses the same canonical digest across independent extension contexts", async () => {
+    const copyContextHash = new WebCryptoClipboardSecretHash();
+    const alarmContextHash = new WebCryptoClipboardSecretHash();
+    const copiedValueHash = await copyContextHash.hashSecretValue("password");
+
+    expect(copiedValueHash).toBe(
+      "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+    );
+    await expect(
+      alarmContextHash.compareSecretValueHash(
+        await alarmContextHash.hashSecretValue("password"),
+        copiedValueHash,
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/extension/src/adapters/clipboard/web-crypto-clipboard-secret-hash.ts
+++ b/apps/extension/src/adapters/clipboard/web-crypto-clipboard-secret-hash.ts
@@ -1,0 +1,32 @@
+import type { ClipboardSecretHashPort } from "@lfspm/core";
+
+export class WebCryptoClipboardSecretHash implements ClipboardSecretHashPort {
+  private readonly subtleCrypto: SubtleCrypto;
+
+  constructor(subtleCrypto: SubtleCrypto = crypto.subtle) {
+    this.subtleCrypto = subtleCrypto;
+  }
+
+  async hashSecretValue(value: string): Promise<string> {
+    const digest = await this.subtleCrypto.digest(
+      "SHA-256",
+      new TextEncoder().encode(value),
+    );
+
+    return Array.from(new Uint8Array(digest), (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+  }
+
+  async compareSecretValueHash(left: string, right: string): Promise<boolean> {
+    const comparisonLength = Math.max(left.length, right.length);
+    let difference = left.length ^ right.length;
+
+    for (let index = 0; index < comparisonLength; index += 1) {
+      difference |=
+        (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+    }
+
+    return difference === 0;
+  }
+}

--- a/apps/extension/src/adapters/clipboard/web-locks-clipboard-operation-coordinator.test.ts
+++ b/apps/extension/src/adapters/clipboard/web-locks-clipboard-operation-coordinator.test.ts
@@ -1,0 +1,235 @@
+import {
+  ClearClipboardTaskUseCase,
+  CopyEntryPasswordUseCase,
+  LockVaultUseCase,
+  type ClipboardPort,
+} from "@lfspm/core";
+import {
+  ClipboardClearService,
+  VaultLifecycleCleanupService,
+} from "@lfspm/core/services";
+import { describe, expect, it, vi } from "vitest";
+import { createCoreTestPorts } from "../../../../../packages/core/src/__tests__/fixtures/ports";
+import { createCoreTestValues } from "../../../../../packages/core/src/__tests__/fixtures/values";
+import {
+  saveUnlockedVaultWithEntries,
+  singlePasswordEntry,
+} from "../../../../../packages/core/src/__tests__/fixtures/vault-entries";
+import { createChromeStorageArea } from "../../__tests__/fixtures/chrome-storage-area";
+import { ChromeClipboardClearTaskRepository } from "../storage/chrome-clipboard-clear-task.repository";
+import {
+  CLIPBOARD_OPERATION_LOCK_NAME,
+  type WebLockManager,
+  WebLocksClipboardOperationCoordinator,
+} from "./web-locks-clipboard-operation-coordinator";
+import { WebCryptoClipboardSecretHash } from "./web-crypto-clipboard-secret-hash";
+
+class SerializedWebLockManager implements WebLockManager {
+  readonly requestedNames: string[] = [];
+  private tail: Promise<void> = Promise.resolve();
+
+  request<T>(
+    name: string,
+    callback: (lock: Lock | null) => Promise<T>,
+  ): Promise<T> {
+    this.requestedNames.push(name);
+    const previous = this.tail;
+    let release = (): void => undefined;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    return previous.then(() => callback(null)).finally(release);
+  }
+}
+
+function createDeferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+describe("WebLocksClipboardOperationCoordinator", () => {
+  it("serializes independent adapter instances around shared task storage", async () => {
+    const hashA = "a".repeat(64);
+    const hashB = "b".repeat(64);
+    const lockManager = new SerializedWebLockManager();
+    const coordinatorA = new WebLocksClipboardOperationCoordinator(lockManager);
+    const coordinatorB = new WebLocksClipboardOperationCoordinator(lockManager);
+    const { storageArea } = createChromeStorageArea();
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+    const firstStarted = createDeferred();
+    const releaseFirst = createDeferred();
+    let secondStarted = false;
+
+    const firstOperation = coordinatorA.runExclusive(async () => {
+      await repository.save({
+        actionId: "action-a",
+        copiedValueHash: hashA,
+        expiresAt: 1_000,
+      });
+      firstStarted.resolve();
+      await releaseFirst.promise;
+
+      await expect(repository.get()).resolves.toEqual({
+        actionId: "action-a",
+        copiedValueHash: hashA,
+        expiresAt: 1_000,
+      });
+    });
+
+    await firstStarted.promise;
+
+    const secondOperation = coordinatorB.runExclusive(async () => {
+      secondStarted = true;
+      await repository.save({
+        actionId: "action-b",
+        copiedValueHash: hashB,
+        expiresAt: 2_000,
+      });
+    });
+
+    expect(secondStarted).toBe(false);
+    releaseFirst.resolve();
+    await Promise.all([firstOperation, secondOperation]);
+
+    expect(secondStarted).toBe(true);
+    expect(lockManager.requestedNames).toEqual([
+      CLIPBOARD_OPERATION_LOCK_NAME,
+      CLIPBOARD_OPERATION_LOCK_NAME,
+    ]);
+    await expect(repository.get()).resolves.toEqual({
+      actionId: "action-b",
+      copiedValueHash: hashB,
+      expiresAt: 2_000,
+    });
+  });
+
+  it("returns values and preserves operation failures", async () => {
+    const lockManager = new SerializedWebLockManager();
+    const coordinator = new WebLocksClipboardOperationCoordinator(lockManager);
+    const error = new Error("operation failed");
+
+    await expect(coordinator.runExclusive(async () => "result")).resolves.toBe(
+      "result",
+    );
+    await expect(
+      coordinator.runExclusive(async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it.each(["clear", "lock"] as const)(
+    "serializes a real copy against an independent %s workflow",
+    async (competingOperation) => {
+      const values = createCoreTestValues();
+      const ports = createCoreTestPorts(values);
+      saveUnlockedVaultWithEntries(ports, values, [singlePasswordEntry]);
+      vi.mocked(ports.ids.generateId).mockReset();
+      vi.mocked(ports.ids.generateId).mockResolvedValue("clipboard-action-id");
+
+      const lockManager = new SerializedWebLockManager();
+      const copyCoordinator = new WebLocksClipboardOperationCoordinator(
+        lockManager,
+      );
+      const clearCoordinator = new WebLocksClipboardOperationCoordinator(
+        lockManager,
+      );
+      const lockCoordinator = new WebLocksClipboardOperationCoordinator(
+        lockManager,
+      );
+      const { storageArea } = createChromeStorageArea();
+      const repository = new ChromeClipboardClearTaskRepository(storageArea);
+      const copyWriteStarted = createDeferred();
+      const releaseCopyWrite = createDeferred();
+      let clipboardValue = "";
+      const clipboard: ClipboardPort = {
+        readText: vi.fn(async () => clipboardValue),
+        writeText: vi.fn(async (value) => {
+          if (value !== "") {
+            copyWriteStarted.resolve();
+            await releaseCopyWrite.promise;
+          }
+
+          clipboardValue = value;
+        }),
+      };
+      const clock = { now: vi.fn(() => 1_000) };
+      const secretHash = new WebCryptoClipboardSecretHash();
+      const clipboardClear = new ClipboardClearService(
+        clipboard,
+        repository,
+        clock,
+        secretHash,
+      );
+      const copy = new CopyEntryPasswordUseCase(
+        clipboard,
+        clipboardClear,
+        copyCoordinator,
+        secretHash,
+        ports.ids,
+        repository,
+        ports.scheduledTasks,
+        clock,
+        ports.sessionServices.unlockedVaultSession,
+      );
+      const clear = new ClearClipboardTaskUseCase(
+        clipboardClear,
+        clearCoordinator,
+      );
+      const lock = new LockVaultUseCase(
+        new VaultLifecycleCleanupService(
+          clipboardClear,
+          repository,
+          lockCoordinator,
+          ports.scheduledTasks,
+          ports.vaultLockTasks,
+          ports.sessionServices.unlockedVaultSession,
+        ),
+      );
+
+      const copying = copy.execute({
+        vaultId: values.vaultId,
+        entryId: singlePasswordEntry.id,
+        clearAfterMs: 60_000,
+      });
+      await copyWriteStarted.promise;
+      const competing =
+        competingOperation === "clear"
+          ? clear.execute({
+              actionId: "clipboard-action-id",
+              requireExpired: false,
+            })
+          : lock.execute();
+
+      expect(clipboard.readText).not.toHaveBeenCalled();
+      expect(ports.saved.unlockedVaultSession).toBeDefined();
+
+      releaseCopyWrite.resolve();
+      await expect(copying).resolves.toEqual({ copied: true });
+
+      if (competingOperation === "clear") {
+        await expect(competing).resolves.toEqual({ cleared: true });
+        expect(ports.saved.unlockedVaultSession).toBeDefined();
+      } else {
+        await expect(competing).resolves.toBeUndefined();
+        expect(ports.saved.unlockedVaultSession).toBeUndefined();
+        expect(ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+          name: "clearClipboard",
+          actionId: "clipboard-action-id",
+        });
+      }
+
+      expect(clipboardValue).toBe("");
+      await expect(repository.get()).resolves.toBeNull();
+      expect(lockManager.requestedNames).toEqual([
+        CLIPBOARD_OPERATION_LOCK_NAME,
+        CLIPBOARD_OPERATION_LOCK_NAME,
+      ]);
+    },
+  );
+});

--- a/apps/extension/src/adapters/clipboard/web-locks-clipboard-operation-coordinator.ts
+++ b/apps/extension/src/adapters/clipboard/web-locks-clipboard-operation-coordinator.ts
@@ -1,0 +1,26 @@
+import type { ClipboardOperationCoordinatorPort } from "@lfspm/core";
+
+export const CLIPBOARD_OPERATION_LOCK_NAME = "lfspm:clipboard-operation";
+
+export type WebLockManager = {
+  request: <T>(
+    name: string,
+    callback: (lock: Lock | null) => Promise<T>,
+  ) => Promise<T>;
+};
+
+/**
+ * Uses one origin-scoped Web Lock so independent extension contexts coordinate
+ * the same clipboard ownership transition.
+ */
+export class WebLocksClipboardOperationCoordinator implements ClipboardOperationCoordinatorPort {
+  private readonly lockManager: WebLockManager;
+
+  constructor(lockManager: WebLockManager = navigator.locks) {
+    this.lockManager = lockManager;
+  }
+
+  async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    return this.lockManager.request(CLIPBOARD_OPERATION_LOCK_NAME, operation);
+  }
+}

--- a/apps/extension/src/adapters/storage/chrome-clipboard-clear-task.repository.test.ts
+++ b/apps/extension/src/adapters/storage/chrome-clipboard-clear-task.repository.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChromeStorageArea } from "../../__tests__/fixtures/chrome-storage-area";
+import {
+  ChromeClipboardClearTaskRepository,
+  CLIPBOARD_CLEAR_TASK_STORAGE_ACCESS_LEVEL,
+  CLIPBOARD_CLEAR_TASK_STORAGE_KEY,
+} from "./chrome-clipboard-clear-task.repository";
+
+const clipboardClearTask = {
+  actionId: "clipboard-action-id",
+  copiedValueHash: "a".repeat(64),
+  expiresAt: 61_000,
+};
+
+describe("ChromeClipboardClearTaskRepository", () => {
+  it("stores only volatile trusted-context ownership metadata", async () => {
+    const { getRecords, storageArea } = createChromeStorageArea();
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await repository.save(clipboardClearTask);
+
+    expect(getRecords()[CLIPBOARD_CLEAR_TASK_STORAGE_KEY]).toEqual(
+      clipboardClearTask,
+    );
+    expect(storageArea.setAccessLevel).toHaveBeenCalledWith({
+      accessLevel: CLIPBOARD_CLEAR_TASK_STORAGE_ACCESS_LEVEL,
+    });
+  });
+
+  it("retrieves and replaces the current clipboard ownership task", async () => {
+    const { storageArea } = createChromeStorageArea();
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await repository.save(clipboardClearTask);
+    await repository.save({
+      actionId: "replacement-action-id",
+      copiedValueHash: "b".repeat(64),
+      expiresAt: 62_000,
+    });
+
+    await expect(repository.get()).resolves.toEqual({
+      actionId: "replacement-action-id",
+      copiedValueHash: "b".repeat(64),
+      expiresAt: 62_000,
+    });
+  });
+
+  it("returns null when clipboard ownership metadata is missing", async () => {
+    const { storageArea } = createChromeStorageArea();
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await expect(repository.get()).resolves.toBeNull();
+  });
+
+  it("rejects malformed clipboard ownership metadata", async () => {
+    const { storageArea } = createChromeStorageArea({
+      [CLIPBOARD_CLEAR_TASK_STORAGE_KEY]: {
+        actionId: "clipboard-action-id",
+        copiedValueHash: "a".repeat(64),
+        expiresAt: "tomorrow",
+      },
+    });
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await expect(repository.get()).rejects.toThrow(
+      "Clipboard clear task metadata is malformed.",
+    );
+  });
+
+  it.each([
+    {
+      actionId: "",
+      copiedValueHash: "a".repeat(64),
+      expiresAt: 61_000,
+    },
+    {
+      actionId: "clipboard-action-id",
+      copiedValueHash: "not-a-sha-256-digest",
+      expiresAt: 61_000,
+    },
+    {
+      actionId: "clipboard-action-id",
+      copiedValueHash: "A".repeat(64),
+      expiresAt: 61_000,
+    },
+    {
+      actionId: "\uD800",
+      copiedValueHash: "a".repeat(64),
+      expiresAt: 61_000,
+    },
+  ])("rejects unusable clipboard ownership identities", async (storedTask) => {
+    const { storageArea } = createChromeStorageArea({
+      [CLIPBOARD_CLEAR_TASK_STORAGE_KEY]: storedTask,
+    });
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await expect(repository.get()).rejects.toThrow(
+      "Clipboard clear task metadata is malformed.",
+    );
+  });
+
+  it("removes clipboard ownership metadata", async () => {
+    const { getRecords, storageArea } = createChromeStorageArea({
+      [CLIPBOARD_CLEAR_TASK_STORAGE_KEY]: clipboardClearTask,
+    });
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+
+    await repository.remove();
+
+    expect(getRecords()).not.toHaveProperty(CLIPBOARD_CLEAR_TASK_STORAGE_KEY);
+  });
+
+  it("preserves ownership metadata when removal fails", async () => {
+    const error = new Error("session storage unavailable");
+    const { getRecords, storageArea } = createChromeStorageArea({
+      [CLIPBOARD_CLEAR_TASK_STORAGE_KEY]: clipboardClearTask,
+    });
+    const repository = new ChromeClipboardClearTaskRepository(storageArea);
+    vi.spyOn(storageArea, "remove").mockRejectedValueOnce(error);
+
+    await expect(repository.remove()).rejects.toBe(error);
+
+    expect(getRecords()).toHaveProperty(CLIPBOARD_CLEAR_TASK_STORAGE_KEY);
+  });
+});

--- a/apps/extension/src/adapters/storage/chrome-clipboard-clear-task.repository.ts
+++ b/apps/extension/src/adapters/storage/chrome-clipboard-clear-task.repository.ts
@@ -1,0 +1,92 @@
+import type {
+  ClipboardClearTask,
+  ClipboardClearTaskRepositoryPort,
+} from "@lfspm/core";
+import type { ChromeStorageArea } from "./chrome-storage-area";
+
+export const CLIPBOARD_CLEAR_TASK_STORAGE_KEY = "clipboardClearTask";
+export const CLIPBOARD_CLEAR_TASK_STORAGE_ACCESS_LEVEL = "TRUSTED_CONTEXTS";
+
+export class ChromeClipboardClearTaskRepository implements ClipboardClearTaskRepositoryPort {
+  private readonly storageArea: ChromeStorageArea;
+  private readonly storageKey: string;
+  private readonly accessRestriction: Promise<void>;
+
+  constructor(
+    storageArea: ChromeStorageArea = chrome.storage
+      .session as ChromeStorageArea,
+    storageKey = CLIPBOARD_CLEAR_TASK_STORAGE_KEY,
+  ) {
+    this.storageArea = storageArea;
+    this.storageKey = storageKey;
+    this.accessRestriction =
+      storageArea.setAccessLevel?.({
+        accessLevel: CLIPBOARD_CLEAR_TASK_STORAGE_ACCESS_LEVEL,
+      }) ?? Promise.resolve();
+  }
+
+  async save(task: ClipboardClearTask): Promise<void> {
+    await this.accessRestriction;
+    await this.storageArea.set({
+      [this.storageKey]: {
+        actionId: task.actionId,
+        copiedValueHash: task.copiedValueHash,
+        expiresAt: task.expiresAt,
+      },
+    });
+  }
+
+  async get(): Promise<ClipboardClearTask | null> {
+    await this.accessRestriction;
+    const storedRecords = await this.storageArea.get(this.storageKey);
+    const task = storedRecords[this.storageKey];
+
+    if (task === undefined) {
+      return null;
+    }
+
+    if (!isClipboardClearTask(task)) {
+      throw new Error("Clipboard clear task metadata is malformed.");
+    }
+
+    return {
+      actionId: task.actionId,
+      copiedValueHash: task.copiedValueHash,
+      expiresAt: task.expiresAt,
+    };
+  }
+
+  async remove(): Promise<void> {
+    await this.accessRestriction;
+    await this.storageArea.remove(this.storageKey);
+  }
+}
+
+function isClipboardClearTask(value: unknown): value is ClipboardClearTask {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    isValidActionId(record.actionId) &&
+    typeof record.copiedValueHash === "string" &&
+    /^[0-9a-f]{64}$/.test(record.copiedValueHash) &&
+    typeof record.expiresAt === "number" &&
+    Number.isFinite(record.expiresAt)
+  );
+}
+
+function isValidActionId(value: unknown): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    encodeURIComponent(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/extension/src/adapters/storage/chrome-storage-area.ts
+++ b/apps/extension/src/adapters/storage/chrome-storage-area.ts
@@ -1,0 +1,8 @@
+export type ChromeStorageArea = {
+  get: (keys?: unknown) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+  remove: (keys: string | string[]) => Promise<void>;
+  setAccessLevel?: (parameters: {
+    readonly accessLevel: "TRUSTED_CONTEXTS";
+  }) => Promise<void>;
+};

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.test.ts
@@ -8,11 +8,12 @@ import type {
   UnlockedVaultSessionPayloadKey,
   VaultMasterKey,
 } from "@lfspm/core";
+import { createChromeStorageArea } from "../../__tests__/fixtures/chrome-storage-area";
 import {
   ChromeUnlockedVaultSessionMaterialRepository,
-  type ChromeStorageArea,
   UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY,
 } from "./chrome-unlocked-vault-session-material.repository";
+import type { ChromeStorageArea } from "./chrome-storage-area";
 
 const { bestEffortWipeArrayBuffersSpy, secureWipeSpy } = vi.hoisted(() => ({
   bestEffortWipeArrayBuffersSpy: vi.fn(
@@ -41,43 +42,6 @@ beforeEach(() => {
   bestEffortWipeArrayBuffersSpy.mockClear();
   secureWipeSpy.mockClear();
 });
-
-function createStorageArea(initialRecords: Record<string, unknown> = {}) {
-  let records = { ...initialRecords };
-  const storageArea: ChromeStorageArea = {
-    async get(keys?: unknown) {
-      if (typeof keys === "string") {
-        return { [keys]: records[keys] };
-      }
-
-      if (Array.isArray(keys)) {
-        return Object.fromEntries(keys.map((key) => [key, records[key]]));
-      }
-
-      return { ...records };
-    },
-    async set(items: Record<string, unknown>) {
-      records = {
-        ...records,
-        ...items,
-      };
-    },
-    async remove(keys: string | string[]) {
-      const keysToRemove = new Set(Array.isArray(keys) ? keys : [keys]);
-      records = Object.fromEntries(
-        Object.entries(records).filter(
-          ([recordKey]) => !keysToRemove.has(recordKey),
-        ),
-      );
-    },
-  };
-
-  return {
-    getRecords: () => records,
-    storageArea,
-  };
-}
-
 function createMaterial() {
   return {
     sessionId: "session-id",
@@ -122,7 +86,7 @@ function createMaterial() {
 
 describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   it("saves session material as storage-safe strings", async () => {
-    const { getRecords, storageArea } = createStorageArea();
+    const { getRecords, storageArea } = createChromeStorageArea();
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
@@ -171,7 +135,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("restores session material from storage", async () => {
-    const { storageArea } = createStorageArea({
+    const { storageArea } = createChromeStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
         vaultId: "vault-id",
@@ -226,7 +190,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("returns one decoded material identity to concurrent cold readers", async () => {
-    const { storageArea } = createStorageArea();
+    const { storageArea } = createChromeStorageArea();
     const writer = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
@@ -248,7 +212,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("does not let a delayed cold read repopulate material after removal", async () => {
-    const { storageArea } = createStorageArea();
+    const { storageArea } = createChromeStorageArea();
     const writer = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
@@ -289,7 +253,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("returns null when session material is missing", async () => {
-    const { storageArea } = createStorageArea();
+    const { storageArea } = createChromeStorageArea();
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
@@ -300,7 +264,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("names the malformed field when stored material is corrupted", async () => {
-    const { storageArea } = createStorageArea({
+    const { storageArea } = createChromeStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
         vaultId: "vault-id",
@@ -325,7 +289,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("wipes decoded secret copies when a later secret cannot be decoded", async () => {
-    const { storageArea } = createStorageArea({
+    const { storageArea } = createChromeStorageArea({
       [UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY]: {
         sessionId: "session-id",
         vaultId: "vault-id",
@@ -372,7 +336,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("removes session material", async () => {
-    const { getRecords, storageArea } = createStorageArea();
+    const { getRecords, storageArea } = createChromeStorageArea();
     const repository = new ChromeUnlockedVaultSessionMaterialRepository(
       storageArea,
     );
@@ -390,7 +354,7 @@ describe("ChromeUnlockedVaultSessionMaterialRepository", () => {
   });
 
   it("keeps session material logically removed when storage removal fails", async () => {
-    const { getRecords, storageArea } = createStorageArea();
+    const { getRecords, storageArea } = createChromeStorageArea();
     const get = vi.fn(storageArea.get);
     const removeError = new Error("storage removal failed");
     const failingStorageArea: ChromeStorageArea = {

--- a/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
+++ b/apps/extension/src/adapters/storage/chrome-unlocked-vault-session-material.repository.ts
@@ -6,15 +6,10 @@ import {
   deserializeUnlockedVaultSessionMaterial,
   serializeUnlockedVaultSessionMaterial,
 } from "./unlocked-vault-session-material.codec";
+import type { ChromeStorageArea } from "./chrome-storage-area";
 
 export const UNLOCKED_VAULT_SESSION_MATERIAL_STORAGE_KEY =
   "unlockedVaultSessionMaterial";
-
-export type ChromeStorageArea = {
-  get: (keys?: unknown) => Promise<Record<string, unknown>>;
-  set: (items: Record<string, unknown>) => Promise<void>;
-  remove: (keys: string | string[]) => Promise<void>;
-};
 
 export class ChromeUnlockedVaultSessionMaterialRepository implements UnlockedVaultSessionMaterialRepositoryPort {
   private readonly storageArea: ChromeStorageArea;

--- a/apps/extension/src/adapters/storage/index.ts
+++ b/apps/extension/src/adapters/storage/index.ts
@@ -1,2 +1,4 @@
+export * from "./chrome-clipboard-clear-task.repository";
+export * from "./chrome-storage-area";
 export * from "./chrome-unlocked-vault-session-material.repository";
 export * from "./indexeddb-encrypted-unlocked-vault-session-payload.repository";

--- a/apps/extension/src/adapters/system/chrome-alarms-scheduled-task.ts
+++ b/apps/extension/src/adapters/system/chrome-alarms-scheduled-task.ts
@@ -1,0 +1,74 @@
+import type { ScheduledTask, ScheduledTaskPort } from "@lfspm/core";
+
+export const SCHEDULED_TASK_ALARM_PREFIX = "lfspm:scheduled-task:";
+
+export type ChromeAlarmsApi = {
+  create: (
+    name: string,
+    alarmInfo: { readonly when: number },
+  ) => void | Promise<void>;
+  clear: (name: string) => boolean | Promise<boolean>;
+};
+
+export class ChromeAlarmsScheduledTask implements ScheduledTaskPort {
+  private readonly alarms: ChromeAlarmsApi;
+
+  constructor(alarms: ChromeAlarmsApi = chrome.alarms) {
+    this.alarms = alarms;
+  }
+
+  async scheduleTask(params: {
+    readonly task: ScheduledTask;
+    readonly runAt: number;
+  }): Promise<void> {
+    await this.alarms.create(serializeScheduledTask(params.task), {
+      when: params.runAt,
+    });
+  }
+
+  async cancelTask(task: ScheduledTask): Promise<void> {
+    await this.alarms.clear(serializeScheduledTask(task));
+  }
+}
+
+export function serializeScheduledTask(task: ScheduledTask): string {
+  return `${SCHEDULED_TASK_ALARM_PREFIX}${task.name}:${encodeURIComponent(task.actionId)}`;
+}
+
+export function parseScheduledTask(alarmName: string): ScheduledTask | null {
+  if (!alarmName.startsWith(SCHEDULED_TASK_ALARM_PREFIX)) {
+    return null;
+  }
+
+  const serializedTask = alarmName.slice(SCHEDULED_TASK_ALARM_PREFIX.length);
+  const separatorIndex = serializedTask.indexOf(":");
+
+  if (separatorIndex < 1) {
+    return null;
+  }
+
+  const name = serializedTask.slice(0, separatorIndex);
+  const encodedActionId = serializedTask.slice(separatorIndex + 1);
+
+  if (
+    (name !== "clearClipboard" && name !== "lockVault") ||
+    encodedActionId.length === 0
+  ) {
+    return null;
+  }
+
+  try {
+    const actionId = decodeURIComponent(encodedActionId);
+
+    if (actionId.trim().length === 0) {
+      return null;
+    }
+
+    return {
+      name,
+      actionId,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/extension/src/adapters/system/index.ts
+++ b/apps/extension/src/adapters/system/index.ts
@@ -1,0 +1,1 @@
+export * from "./chrome-alarms-scheduled-task";

--- a/apps/extension/src/core-composition-api.typecheck.ts
+++ b/apps/extension/src/core-composition-api.typecheck.ts
@@ -10,7 +10,9 @@ import {
 import type {
   Bip39Port,
   ClipboardClearTaskRepositoryPort,
+  ClipboardOperationCoordinatorPort,
   ClipboardPort,
+  ClipboardSecretHashPort,
   ClockPort,
   CryptoPort,
   EncryptedUnlockedVaultSessionPayloadRepositoryPort,
@@ -34,6 +36,8 @@ type CoreCompositionPorts = {
   readonly bip39: Bip39Port;
   readonly clipboard: ClipboardPort;
   readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
+  readonly clipboardOperations: ClipboardOperationCoordinatorPort;
+  readonly clipboardSecretHash: ClipboardSecretHashPort;
   readonly clock: ClockPort;
   readonly crypto: CryptoPort;
   readonly encryptedSessionPayloads: EncryptedUnlockedVaultSessionPayloadRepositoryPort;
@@ -69,11 +73,12 @@ export function composeCoreApi(ports: CoreCompositionPorts) {
     ports.clipboard,
     ports.clipboardClearTasks,
     ports.clock,
-    ports.crypto,
+    ports.clipboardSecretHash,
   );
   const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     ports.clipboardClearTasks,
+    ports.clipboardOperations,
     ports.scheduledTasks,
     ports.vaultLockTasks,
     unlockedVaultSession,
@@ -118,7 +123,8 @@ export function composeCoreApi(ports: CoreCompositionPorts) {
     clipboard: new CopyEntryPasswordUseCase(
       ports.clipboard,
       clipboardClear,
-      ports.crypto,
+      ports.clipboardOperations,
+      ports.clipboardSecretHash,
       ports.ids,
       ports.clipboardClearTasks,
       ports.scheduledTasks,

--- a/apps/extension/src/extension/background/background-entry.test.ts
+++ b/apps/extension/src/extension/background/background-entry.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("background entrypoint", () => {
+  afterEach(() => {
+    vi.doUnmock("./clipboard-alarm-runtime");
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("composes and forwards Chrome alarm events", async () => {
+    const handleAlarm = vi.fn(async () => undefined);
+    const composeClipboardAlarmHandler = vi.fn(() => handleAlarm);
+    let alarmListener: ((alarm: { readonly name: string }) => void) | undefined;
+    const addAlarmListener = vi.fn(
+      (listener: (alarm: { readonly name: string }) => void) => {
+        alarmListener = listener;
+      },
+    );
+
+    vi.doMock("./clipboard-alarm-runtime", () => ({
+      composeClipboardAlarmHandler,
+    }));
+    vi.stubGlobal("chrome", {
+      alarms: {
+        onAlarm: { addListener: addAlarmListener },
+      },
+    });
+
+    await import("./background");
+
+    expect(composeClipboardAlarmHandler).toHaveBeenCalledOnce();
+    expect(addAlarmListener).toHaveBeenCalledOnce();
+
+    alarmListener?.({ name: "clipboard-alarm" });
+
+    await vi.waitFor(() => {
+      expect(handleAlarm).toHaveBeenCalledWith({ name: "clipboard-alarm" });
+    });
+  });
+});

--- a/apps/extension/src/extension/background/background.test.ts
+++ b/apps/extension/src/extension/background/background.test.ts
@@ -1,7 +1,317 @@
-import { describe, it, expect } from "vitest";
+import type { ClipboardPort } from "@lfspm/core";
+import { ClearClipboardTaskUseCase } from "@lfspm/core";
+import { ClipboardClearService } from "@lfspm/core/services";
+import { describe, expect, it, vi } from "vitest";
+import { createChromeStorageArea } from "../../__tests__/fixtures/chrome-storage-area";
+import {
+  type WebLockManager,
+  WebCryptoClipboardSecretHash,
+  WebLocksClipboardOperationCoordinator,
+} from "../../adapters/clipboard";
+import { ChromeClipboardClearTaskRepository } from "../../adapters/storage";
+import { CLIPBOARD_CLEAR_TASK_STORAGE_KEY } from "../../adapters/storage";
+import {
+  type ChromeAlarmsApi,
+  ChromeAlarmsScheduledTask,
+  serializeScheduledTask,
+} from "../../adapters/system";
+import {
+  CLIPBOARD_CLEAR_RETRY_DELAY_MS,
+  createClipboardAlarmHandler,
+} from "./clipboard-alarm-runtime";
 
-describe("Background Script", () => {
-  it("placeholder test", () => {
-    expect(true).toBe(true);
+const immediateLockManager: WebLockManager = {
+  request: async (_name, operation) => operation(null),
+};
+
+function createContext() {
+  const clock = { now: vi.fn(() => 1_000) };
+  const { storageArea } = createChromeStorageArea();
+  const clipboardClearTasks = new ChromeClipboardClearTaskRepository(
+    storageArea,
+  );
+  const clipboardOperations = new WebLocksClipboardOperationCoordinator(
+    immediateLockManager,
+  );
+  const copyContextSecretHash = new WebCryptoClipboardSecretHash();
+  const alarmContextSecretHash = new WebCryptoClipboardSecretHash();
+  let clipboardValue = "copied-password";
+  const clipboard: ClipboardPort = {
+    readText: vi.fn(async () => clipboardValue),
+    writeText: vi.fn(async (value) => {
+      clipboardValue = value;
+    }),
+  };
+  const createAlarm = vi.fn(async () => undefined);
+  const clearAlarm = vi.fn(async () => true);
+  const alarms: ChromeAlarmsApi = {
+    create: createAlarm,
+    clear: clearAlarm,
+  };
+  const scheduledTasks = new ChromeAlarmsScheduledTask(alarms);
+  const clearClipboardTask = new ClearClipboardTaskUseCase(
+    new ClipboardClearService(
+      clipboard,
+      clipboardClearTasks,
+      clock,
+      alarmContextSecretHash,
+    ),
+    clipboardOperations,
+  );
+  const handleAlarm = createClipboardAlarmHandler(
+    clearClipboardTask,
+    scheduledTasks,
+    clock,
+  );
+
+  return {
+    clock,
+    clipboard,
+    clipboardClearTasks,
+    storageArea,
+    clearAlarm,
+    createAlarm,
+    getClipboardValue: () => clipboardValue,
+    handleAlarm,
+    copyContextSecretHash,
+  };
+}
+
+describe("clipboard alarm runtime", () => {
+  it("routes a Chrome alarm through coordinated volatile ownership cleanup", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now(),
+    });
+
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+    });
+
+    expect(ctx.getClipboardValue()).toBe("");
+    await expect(ctx.clipboardClearTasks.get()).resolves.toBeNull();
+    expect(ctx.createAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+      { when: ctx.clock.now() + CLIPBOARD_CLEAR_RETRY_DELAY_MS },
+    );
+    expect(ctx.clearAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+    );
+    expect(ctx.createAlarm.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(ctx.clipboard.readText).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("retains ownership and schedules a retry when clipboard access fails", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    const error = new Error("clipboard unavailable");
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now(),
+    });
+    vi.mocked(ctx.clipboard.readText).mockRejectedValueOnce(error);
+
+    await expect(
+      ctx.handleAlarm({
+        name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+      }),
+    ).rejects.toBe(error);
+
+    await expect(ctx.clipboardClearTasks.get()).resolves.toMatchObject({
+      actionId,
+    });
+    expect(ctx.createAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+      { when: ctx.clock.now() + CLIPBOARD_CLEAR_RETRY_DELAY_MS },
+    );
+    expect(ctx.clearAlarm).not.toHaveBeenCalled();
+  });
+
+  it("does not clear clipboard content that no longer matches ownership", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now(),
+    });
+    vi.mocked(ctx.clipboard.readText).mockResolvedValueOnce("new clipboard");
+
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+    });
+
+    expect(ctx.getClipboardValue()).toBe("copied-password");
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+    await expect(ctx.clipboardClearTasks.get()).resolves.toBeNull();
+    expect(ctx.clearAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+    );
+  });
+
+  it("retains changed clipboard ownership when metadata removal fails", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    const removalError = new Error("session storage unavailable");
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now(),
+    });
+    vi.mocked(ctx.clipboard.readText).mockResolvedValueOnce("new clipboard");
+    vi.spyOn(ctx.storageArea, "remove").mockRejectedValueOnce(removalError);
+
+    await expect(
+      ctx.handleAlarm({
+        name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+      }),
+    ).rejects.toBe(removalError);
+
+    expect(ctx.getClipboardValue()).toBe("copied-password");
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+    await expect(ctx.clipboardClearTasks.get()).resolves.toMatchObject({
+      actionId,
+    });
+    expect(ctx.clearAlarm).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite unverifiable clipboard content for a stale persisted alarm", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+    });
+
+    expect(ctx.getClipboardValue()).toBe("copied-password");
+    expect(ctx.clipboard.readText).not.toHaveBeenCalled();
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctx.clearAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+    );
+  });
+
+  it("retains a retry when volatile ownership metadata is malformed", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    await ctx.storageArea.set({
+      [CLIPBOARD_CLEAR_TASK_STORAGE_KEY]: {
+        actionId,
+        copiedValueHash: "invalid",
+        expiresAt: ctx.clock.now(),
+      },
+    });
+
+    await expect(
+      ctx.handleAlarm({
+        name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+      }),
+    ).rejects.toThrow("Clipboard clear task metadata is malformed.");
+
+    expect(ctx.getClipboardValue()).toBe("copied-password");
+    expect(ctx.clipboard.readText).not.toHaveBeenCalled();
+    expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctx.clearAlarm).not.toHaveBeenCalled();
+  });
+
+  it("retries alarm creation when pre-arming and clipboard access both fail", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    const alarmError = new Error("alarms unavailable");
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now(),
+    });
+    ctx.createAlarm.mockRejectedValueOnce(alarmError);
+    vi.mocked(ctx.clipboard.readText).mockRejectedValueOnce(
+      new Error("clipboard unavailable"),
+    );
+
+    await expect(
+      ctx.handleAlarm({
+        name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+      }),
+    ).rejects.toBe(alarmError);
+
+    expect(ctx.createAlarm).toHaveBeenCalledTimes(2);
+    await expect(ctx.clipboardClearTasks.get()).resolves.toMatchObject({
+      actionId,
+    });
+  });
+
+  it("keeps the pre-armed retry when an alarm fires before expiry", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now() + 1_000,
+    });
+
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+    });
+
+    expect(ctx.createAlarm).toHaveBeenCalledWith(
+      serializeScheduledTask({ name: "clearClipboard", actionId }),
+      { when: ctx.clock.now() + CLIPBOARD_CLEAR_RETRY_DELAY_MS },
+    );
+    expect(ctx.clearAlarm).not.toHaveBeenCalled();
+    expect(ctx.clipboard.readText).not.toHaveBeenCalled();
+  });
+
+  it("clears early when an alarm cannot be armed persistently", async () => {
+    const ctx = createContext();
+    const actionId = "clipboard-action-id";
+    await ctx.clipboardClearTasks.save({
+      actionId,
+      copiedValueHash: await ctx.copyContextSecretHash.hashSecretValue(
+        ctx.getClipboardValue(),
+      ),
+      expiresAt: ctx.clock.now() + 1_000,
+    });
+    ctx.createAlarm.mockRejectedValue(new Error("alarms unavailable"));
+
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({ name: "clearClipboard", actionId }),
+    });
+
+    expect(ctx.createAlarm).toHaveBeenCalledTimes(2);
+    expect(ctx.getClipboardValue()).toBe("");
+    await expect(ctx.clipboardClearTasks.get()).resolves.toBeNull();
+  });
+
+  it("ignores unrelated and vault-lock alarms", async () => {
+    const ctx = createContext();
+
+    await ctx.handleAlarm({ name: "unrelated" });
+    await ctx.handleAlarm({
+      name: serializeScheduledTask({
+        name: "lockVault",
+        actionId: "lock-action-id",
+      }),
+    });
+
+    expect(ctx.clipboard.readText).not.toHaveBeenCalled();
+    expect(ctx.createAlarm).not.toHaveBeenCalled();
+    expect(ctx.clearAlarm).not.toHaveBeenCalled();
   });
 });

--- a/apps/extension/src/extension/background/background.ts
+++ b/apps/extension/src/extension/background/background.ts
@@ -1,17 +1,7 @@
-// Chrome Extension Background Script
-chrome.runtime.onInstalled.addListener(() => {
-  console.log("SPM Extension installed");
-});
+import { composeClipboardAlarmHandler } from "./clipboard-alarm-runtime";
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  console.log("Message received:", request);
-  console.log("Sender:", sender);
-  sendResponse({ status: "received" });
-});
+const handleClipboardAlarm = composeClipboardAlarmHandler();
 
-// Hot reload helper for development
-if (import.meta.hot) {
-  import.meta.hot.accept(() => {
-    console.log("Background script hot reloaded");
-  });
-}
+chrome.alarms.onAlarm.addListener((alarm) => {
+  void handleClipboardAlarm(alarm).catch(() => undefined);
+});

--- a/apps/extension/src/extension/background/clipboard-alarm-runtime.ts
+++ b/apps/extension/src/extension/background/clipboard-alarm-runtime.ts
@@ -1,0 +1,109 @@
+import type { ClockPort, ScheduledTaskPort } from "@lfspm/core";
+import { ClearClipboardTaskUseCase } from "@lfspm/core";
+import { ClipboardClearService } from "@lfspm/core/services";
+import {
+  OffscreenClipboard,
+  WebCryptoClipboardSecretHash,
+  WebLocksClipboardOperationCoordinator,
+} from "../../adapters/clipboard";
+import { ChromeClipboardClearTaskRepository } from "../../adapters/storage";
+import {
+  ChromeAlarmsScheduledTask,
+  parseScheduledTask,
+} from "../../adapters/system";
+
+export const CLIPBOARD_CLEAR_RETRY_DELAY_MS = 60_000;
+
+type ClearClipboardTaskExecutor = Pick<ClearClipboardTaskUseCase, "execute">;
+type ClipboardAlarmHandler = (alarm: {
+  readonly name: string;
+}) => Promise<void>;
+
+export function createClipboardAlarmHandler(
+  clearClipboardTask: ClearClipboardTaskExecutor,
+  scheduledTasks: ScheduledTaskPort,
+  clock: ClockPort,
+): ClipboardAlarmHandler {
+  return async (alarm) => {
+    const task = parseScheduledTask(alarm.name);
+
+    if (task?.name !== "clearClipboard") {
+      return;
+    }
+
+    const retry = {
+      task,
+      runAt: clock.now() + CLIPBOARD_CLEAR_RETRY_DELAY_MS,
+    };
+    let retryScheduleError: unknown;
+    let retryScheduled = false;
+
+    try {
+      await scheduledTasks.scheduleTask(retry);
+      retryScheduled = true;
+    } catch (error) {
+      retryScheduleError = error;
+    }
+
+    const executeClear = (requireExpired: boolean) =>
+      clearClipboardTask.execute({
+        actionId: task.actionId,
+        requireExpired,
+      });
+    let result: Awaited<ReturnType<ClearClipboardTaskExecutor["execute"]>>;
+
+    try {
+      result = await executeClear(true);
+    } catch (error) {
+      if (!retryScheduled) {
+        try {
+          await scheduledTasks.scheduleTask(retry);
+        } catch {
+          // Preserve the first alarm scheduling or clipboard failure.
+        }
+      }
+
+      throw retryScheduleError ?? error;
+    }
+
+    if (!result.cleared && result.reason === "notExpired") {
+      if (!retryScheduled) {
+        try {
+          await scheduledTasks.scheduleTask(retry);
+        } catch {
+          try {
+            await executeClear(false);
+          } catch (error) {
+            throw retryScheduleError ?? error;
+          }
+        }
+      }
+
+      return;
+    }
+
+    if (retryScheduled) {
+      await scheduledTasks.cancelTask(task);
+    }
+  };
+}
+
+export function composeClipboardAlarmHandler(): ClipboardAlarmHandler {
+  const clock: ClockPort = { now: () => Date.now() };
+  const clipboard = new OffscreenClipboard();
+  const clipboardClearTasks = new ChromeClipboardClearTaskRepository();
+  const clipboardOperations = new WebLocksClipboardOperationCoordinator();
+  const scheduledTasks = new ChromeAlarmsScheduledTask();
+  const clipboardClear = new ClipboardClearService(
+    clipboard,
+    clipboardClearTasks,
+    clock,
+    new WebCryptoClipboardSecretHash(),
+  );
+  const clearClipboardTask = new ClearClipboardTaskUseCase(
+    clipboardClear,
+    clipboardOperations,
+  );
+
+  return createClipboardAlarmHandler(clearClipboardTask, scheduledTasks, clock);
+}

--- a/apps/extension/src/extension/background/manifest-runtime.test.ts
+++ b/apps/extension/src/extension/background/manifest-runtime.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type ExtensionManifest = {
+  readonly minimum_chrome_version?: string;
+  readonly background?: {
+    readonly service_worker?: string;
+    readonly type?: string;
+  };
+};
+
+describe("extension runtime manifest", () => {
+  it("registers the bundled background worker as an ES module", () => {
+    const manifest = JSON.parse(
+      readFileSync(
+        new URL("../../../config/manifest.json", import.meta.url),
+        "utf8",
+      ),
+    ) as ExtensionManifest;
+
+    expect(manifest.background).toEqual({
+      service_worker: "background.js",
+      type: "module",
+    });
+    expect(Number(manifest.minimum_chrome_version)).toBeGreaterThanOrEqual(120);
+  });
+});

--- a/apps/extension/src/extension/offscreen/clipboard-document.test.ts
+++ b/apps/extension/src/extension/offscreen/clipboard-document.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClipboardCommandExecutor,
+  type ClipboardTransferControl,
+  readClipboardText,
+  writeClipboardText,
+} from "./clipboard-document";
+
+function createControl(): ClipboardTransferControl {
+  return {
+    value: "",
+    focus: vi.fn(),
+    select: vi.fn(),
+  };
+}
+
+describe("offscreen clipboard document", () => {
+  it("reads through the selected transfer control and clears plaintext", () => {
+    const transferControl = createControl();
+    const commandExecutor: ClipboardCommandExecutor = {
+      execCommand: vi.fn((command) => {
+        if (command === "paste") {
+          transferControl.value = "clipboard-value";
+        }
+
+        return true;
+      }),
+    };
+
+    expect(readClipboardText(commandExecutor, transferControl)).toBe(
+      "clipboard-value",
+    );
+    expect(commandExecutor.execCommand).toHaveBeenCalledWith("paste");
+    expect(transferControl.focus).toHaveBeenCalledOnce();
+    expect(transferControl.select).toHaveBeenCalledOnce();
+    expect(transferControl.value).toBe("");
+  });
+
+  it("writes through the selected transfer control and clears plaintext", () => {
+    const transferControl = createControl();
+    const observedValues: string[] = [];
+    const commandExecutor: ClipboardCommandExecutor = {
+      execCommand: vi.fn(() => {
+        observedValues.push(transferControl.value);
+        return true;
+      }),
+    };
+
+    writeClipboardText(commandExecutor, transferControl, "password");
+
+    expect(observedValues).toEqual(["password"]);
+    expect(commandExecutor.execCommand).toHaveBeenCalledWith("copy");
+    expect(transferControl.value).toBe("");
+  });
+
+  it("clears plaintext when the browser rejects a clipboard command", () => {
+    const transferControl = createControl();
+    const commandExecutor: ClipboardCommandExecutor = {
+      execCommand: vi.fn(() => false),
+    };
+
+    expect(() =>
+      writeClipboardText(commandExecutor, transferControl, "password"),
+    ).toThrow("Clipboard copy command failed.");
+    expect(transferControl.value).toBe("");
+  });
+});

--- a/apps/extension/src/extension/offscreen/clipboard-document.ts
+++ b/apps/extension/src/extension/offscreen/clipboard-document.ts
@@ -1,0 +1,50 @@
+export interface ClipboardTransferControl {
+  value: string;
+  focus(): void;
+  select(): void;
+}
+
+export interface ClipboardCommandExecutor {
+  execCommand(command: "copy" | "paste"): boolean;
+}
+
+function executeClipboardCommand(
+  commandExecutor: ClipboardCommandExecutor,
+  transferControl: ClipboardTransferControl,
+  command: "copy" | "paste",
+): void {
+  transferControl.focus();
+  transferControl.select();
+
+  if (!commandExecutor.execCommand(command)) {
+    throw new Error(`Clipboard ${command} command failed.`);
+  }
+}
+
+export function readClipboardText(
+  commandExecutor: ClipboardCommandExecutor,
+  transferControl: ClipboardTransferControl,
+): string {
+  transferControl.value = "";
+
+  try {
+    executeClipboardCommand(commandExecutor, transferControl, "paste");
+    return transferControl.value;
+  } finally {
+    transferControl.value = "";
+  }
+}
+
+export function writeClipboardText(
+  commandExecutor: ClipboardCommandExecutor,
+  transferControl: ClipboardTransferControl,
+  value: string,
+): void {
+  transferControl.value = value;
+
+  try {
+    executeClipboardCommand(commandExecutor, transferControl, "copy");
+  } finally {
+    transferControl.value = "";
+  }
+}

--- a/apps/extension/src/extension/offscreen/offscreen.test.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  OFFSCREEN_CLIPBOARD_DOCUMENT_PATH,
+  OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+} from "../../adapters/clipboard/offscreen-clipboard";
+
+class FakeTextAreaElement {
+  value = "";
+  readonly focus = vi.fn();
+  readonly select = vi.fn();
+}
+
+describe("offscreen clipboard bridge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("routes a service-worker clipboard request through the production listener", async () => {
+    const transferControl = new FakeTextAreaElement();
+    const execCommand = vi.fn(() => true);
+    let offscreenListener: ((event: MessageEvent) => void) | undefined;
+    let responsePort: MessagePort | undefined;
+    const addEventListener = vi.fn(
+      (eventName: string, listener: (event: MessageEvent) => void) => {
+        expect(eventName).toBe("message");
+        offscreenListener = listener;
+      },
+    );
+    const documentUrl = `chrome-extension://extension-id/${OFFSCREEN_CLIPBOARD_DOCUMENT_PATH}`;
+    const clientPostMessage = vi.fn(
+      (message: unknown, transfer: Transferable[]) => {
+        const transferredPort = transfer[0];
+
+        if (!(transferredPort instanceof MessagePort)) {
+          throw new Error("Expected an offscreen response port.");
+        }
+
+        responsePort = transferredPort;
+        offscreenListener?.({
+          data: message,
+          ports: [transferredPort],
+        } as unknown as MessageEvent);
+      },
+    );
+    const matchAll = vi.fn(async () => [
+      { url: documentUrl, postMessage: clientPostMessage },
+    ]);
+    const getContexts = vi.fn(async () => [
+      { contextType: "OFFSCREEN_DOCUMENT" },
+    ]);
+
+    vi.stubGlobal("HTMLTextAreaElement", FakeTextAreaElement);
+    vi.stubGlobal("document", {
+      getElementById: vi.fn(() => transferControl),
+      execCommand,
+    });
+    vi.stubGlobal("navigator", {
+      serviceWorker: { addEventListener },
+    });
+    vi.stubGlobal("clients", { matchAll });
+    vi.stubGlobal("chrome", {
+      offscreen: { createDocument: vi.fn(async () => undefined) },
+      runtime: {
+        getContexts,
+        getURL: vi.fn(() => documentUrl),
+      },
+    });
+
+    await import("./offscreen");
+    const { OffscreenClipboard } =
+      await import("../../adapters/clipboard/offscreen-clipboard");
+    const clipboard = new OffscreenClipboard();
+
+    await expect(clipboard.writeText("bridge-value")).resolves.toBeUndefined();
+
+    expect(addEventListener).toHaveBeenCalledOnce();
+    expect(matchAll).toHaveBeenCalledWith({
+      includeUncontrolled: true,
+      type: "window",
+    });
+    expect(clientPostMessage).toHaveBeenCalledWith(
+      {
+        target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+        operation: "write",
+        value: "bridge-value",
+      },
+      [expect.any(MessagePort)],
+    );
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(transferControl.value).toBe("");
+
+    responsePort?.close();
+  });
+});

--- a/apps/extension/src/extension/offscreen/offscreen.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.ts
@@ -1,0 +1,62 @@
+import {
+  OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+  type OffscreenClipboardRequest,
+} from "../../adapters/clipboard";
+import { readClipboardText, writeClipboardText } from "./clipboard-document";
+
+function getTransferControl(): HTMLTextAreaElement {
+  const element = document.getElementById("clipboard-transfer");
+
+  if (!(element instanceof HTMLTextAreaElement)) {
+    throw new Error("Clipboard transfer control is unavailable.");
+  }
+
+  return element;
+}
+
+const transferControl = getTransferControl();
+
+function isOffscreenClipboardRequest(
+  request: unknown,
+): request is OffscreenClipboardRequest {
+  if (typeof request !== "object" || request === null) {
+    return false;
+  }
+
+  const record = request as Record<string, unknown>;
+
+  return (
+    record.target === OFFSCREEN_CLIPBOARD_MESSAGE_TARGET &&
+    (record.operation === "read" ||
+      (record.operation === "write" && typeof record.value === "string"))
+  );
+}
+
+function handleClipboardRequest(request: OffscreenClipboardRequest) {
+  if (request.operation === "read") {
+    return {
+      ok: true as const,
+      value: readClipboardText(document, transferControl),
+    };
+  }
+
+  writeClipboardText(document, transferControl, request.value);
+  return { ok: true as const };
+}
+
+navigator.serviceWorker.addEventListener("message", (event) => {
+  const responsePort = event.ports[0];
+
+  if (responsePort === undefined || !isOffscreenClipboardRequest(event.data)) {
+    return;
+  }
+
+  try {
+    responsePort.postMessage(handleClipboardRequest(event.data));
+  } catch {
+    responsePort.postMessage({
+      ok: false,
+      error: "Clipboard operation failed.",
+    });
+  }
+});

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -27,6 +27,7 @@ import type {
 import type { Vault } from "../../domain/vault/vault";
 import type { Bip39Port } from "../../ports/crypto/bip39.port";
 import type { ClockPort } from "../../ports/system/clock.port";
+import type { ClipboardSecretHashPort } from "../../ports/clipboard/clipboard-secret-hash.port";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { EncryptedUnlockedVaultSessionPayloadRepositoryPort } from "../../ports/session/encrypted-unlocked-vault-session-payload-repository.port";
 import type { IdPort } from "../../ports/system/id.port";
@@ -193,8 +194,6 @@ export function createCoreTestPorts(
     generateRandomBytes: vi.fn(
       async (byteLength: number) => new ArrayBuffer(byteLength) as RandomBytes,
     ),
-    hashSecretValue: vi.fn(async (value) => `hash:${value}`),
-    compareSecretValueHash: vi.fn(async (left, right) => left === right),
     generateDeviceSignKeyPair: vi.fn(
       async (): Promise<DeviceSignKeyPair> => ({
         publicKey: freshBuffer(values.devicePublicSignKey),
@@ -207,17 +206,19 @@ export function createCoreTestPorts(
         privateKey: freshBuffer(values.devicePrivateVaultKey),
       }),
     ),
-    generateDeviceLocalProtectionKey: vi.fn(
-      async () => freshBuffer(values.deviceLocalProtectionKey),
+    generateDeviceLocalProtectionKey: vi.fn(async () =>
+      freshBuffer(values.deviceLocalProtectionKey),
     ),
-    generateVaultMasterKey: vi.fn(async () => freshBuffer(values.vaultMasterKey)),
+    generateVaultMasterKey: vi.fn(async () =>
+      freshBuffer(values.vaultMasterKey),
+    ),
     generateRecoveryKey: vi.fn(async () => {
       const recoveryKey = freshBuffer(values.recoverySecretKey);
       recoveryKeyKinds.set(recoveryKey, "current");
       return recoveryKey;
     }),
-    generateUnlockedVaultSessionPayloadKey: vi.fn(
-      async () => freshBuffer(values.unlockedVaultSessionPayloadKey),
+    generateUnlockedVaultSessionPayloadKey: vi.fn(async () =>
+      freshBuffer(values.unlockedVaultSessionPayloadKey),
     ),
     generateMasterPasswordSalt: vi
       .fn()
@@ -240,7 +241,9 @@ export function createCoreTestPorts(
     deriveLocalKeysProtectionKey: vi.fn(async (_localRootKey, salt) => {
       const isNew = salt === values.newLocalKeysProtectionSalt;
       const protectionKey = freshBuffer(
-        isNew ? values.newLocalKeysProtectionKey : values.localKeysProtectionKey,
+        isNew
+          ? values.newLocalKeysProtectionKey
+          : values.localKeysProtectionKey,
       );
       protectionKeyKinds.set(protectionKey, isNew ? "new_local" : "local");
       return protectionKey;
@@ -258,8 +261,8 @@ export function createCoreTestPorts(
       );
       return protectionKey;
     }),
-    deriveDeviceEnrollmentPrivateStateProtectionKey: vi.fn(
-      async () => freshBuffer(values.pendingEnrollmentProtectionKey),
+    deriveDeviceEnrollmentPrivateStateProtectionKey: vi.fn(async () =>
+      freshBuffer(values.pendingEnrollmentProtectionKey),
     ),
     wrapLocalKeysPayload: vi.fn(async (_localKeysPayload, protectionKey) => {
       const protectionKeyKind = protectionKeyKinds.get(protectionKey);
@@ -394,6 +397,11 @@ export function createCoreTestPorts(
     ),
   };
 
+  const clipboardSecretHash: ClipboardSecretHashPort = {
+    hashSecretValue: vi.fn(async (value) => `hash:${value}`),
+    compareSecretValueHash: vi.fn(async (left, right) => left === right),
+  };
+
   const bip39: Bip39Port = {
     recoveryKeyToMnemonic: vi.fn(async (recoveryKey) =>
       recoveryKey === values.rotatedRecoverySecretKey ||
@@ -402,7 +410,8 @@ export function createCoreTestPorts(
         : values.recoveryMnemonicKey,
     ),
     mnemonicToRecoveryKey: vi.fn(async (recoveryMnemonicKey) => {
-      const isRotated = recoveryMnemonicKey === values.rotatedRecoveryMnemonicKey;
+      const isRotated =
+        recoveryMnemonicKey === values.rotatedRecoveryMnemonicKey;
       const recoveryKey = freshBuffer(
         isRotated ? values.rotatedRecoverySecretKey : values.recoverySecretKey,
       );
@@ -922,6 +931,7 @@ export function createCoreTestPorts(
 
   return {
     crypto,
+    clipboardSecretHash,
     bip39,
     vaultLocalRepository,
     unlockedVaultSessionMaterialRepository,

--- a/packages/core/src/ports/clipboard/clipboard-clear-task-repository.port.ts
+++ b/packages/core/src/ports/clipboard/clipboard-clear-task-repository.port.ts
@@ -8,7 +8,8 @@ export type ClipboardClearTask = {
  * Stores short-lived clipboard clear metadata.
  *
  * The task must not be persisted long term and must not contain the copied
- * plaintext password value.
+ * plaintext password value. Ownership-changing sequences must run through the
+ * shared ClipboardOperationCoordinatorPort.
  */
 export interface ClipboardClearTaskRepositoryPort {
   save: (task: ClipboardClearTask) => Promise<void>;

--- a/packages/core/src/ports/clipboard/clipboard-operation-coordinator.port.ts
+++ b/packages/core/src/ports/clipboard/clipboard-operation-coordinator.port.ts
@@ -1,0 +1,7 @@
+/**
+ * Serializes clipboard ownership transitions across every runtime context that
+ * shares the clipboard clear task repository.
+ */
+export interface ClipboardOperationCoordinatorPort {
+  runExclusive: <T>(operation: () => Promise<T>) => Promise<T>;
+}

--- a/packages/core/src/ports/clipboard/clipboard-secret-hash.port.ts
+++ b/packages/core/src/ports/clipboard/clipboard-secret-hash.port.ts
@@ -1,0 +1,9 @@
+/**
+ * Produces deterministic SHA-256 digests encoded as lowercase hexadecimal.
+ * Independent extension contexts must implement this exact format so the
+ * scheduled clearer can authenticate metadata created by a copy operation.
+ */
+export interface ClipboardSecretHashPort {
+  hashSecretValue(value: string): Promise<string>;
+  compareSecretValueHash(left: string, right: string): Promise<boolean>;
+}

--- a/packages/core/src/ports/clipboard/index.ts
+++ b/packages/core/src/ports/clipboard/index.ts
@@ -1,2 +1,4 @@
 export * from "./clipboard-clear-task-repository.port";
+export * from "./clipboard-operation-coordinator.port";
+export * from "./clipboard-secret-hash.port";
 export * from "./clipboard.port";

--- a/packages/core/src/ports/crypto/crypto.port.ts
+++ b/packages/core/src/ports/crypto/crypto.port.ts
@@ -61,10 +61,6 @@ export interface CryptoPort {
   // Randomness
   generateRandomBytes: (byteLength: number) => Promise<RandomBytes>;
 
-  // Secret comparison
-  hashSecretValue: (value: string) => Promise<string>;
-  compareSecretValueHash: (left: string, right: string) => Promise<boolean>;
-
   // Key generation
   generateDeviceSignKeyPair: () => Promise<DeviceSignKeyPair>;
   generateDeviceVaultKeyPair: () => Promise<DeviceVaultKeyPair>;

--- a/packages/core/src/services/clipboard/clipboard-clear.service.ts
+++ b/packages/core/src/services/clipboard/clipboard-clear.service.ts
@@ -3,25 +3,25 @@ import type {
   ClipboardClearTaskRepositoryPort,
 } from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
+import type { ClipboardSecretHashPort } from "../../ports/clipboard/clipboard-secret-hash.port";
 import type { ClockPort } from "../../ports/system/clock.port";
-import type { CryptoPort } from "../../ports/crypto/crypto.port";
 
 export class ClipboardClearService {
   private readonly clipboard: ClipboardPort;
   private readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
   private readonly clock: ClockPort;
-  private readonly crypto: CryptoPort;
+  private readonly secretHash: ClipboardSecretHashPort;
 
   constructor(
     clipboard: ClipboardPort,
     clipboardClearTasks: ClipboardClearTaskRepositoryPort,
     clock: ClockPort,
-    crypto: CryptoPort,
+    secretHash: ClipboardSecretHashPort,
   ) {
     this.clipboard = clipboard;
     this.clipboardClearTasks = clipboardClearTasks;
     this.clock = clock;
-    this.crypto = crypto;
+    this.secretHash = secretHash;
   }
 
   async clearTask(params: {
@@ -68,14 +68,15 @@ export class ClipboardClearService {
     }
 
     const currentClipboardValue = await this.clipboard.readText();
-    const currentClipboardValueHash = await this.crypto.hashSecretValue(
+    const currentClipboardValueHash = await this.secretHash.hashSecretValue(
       currentClipboardValue,
     );
 
-    const isCopiedValueStillPresent = await this.crypto.compareSecretValueHash(
-      currentClipboardValueHash,
-      task.copiedValueHash,
-    );
+    const isCopiedValueStillPresent =
+      await this.secretHash.compareSecretValueHash(
+        currentClipboardValueHash,
+        task.copiedValueHash,
+      );
 
     if (!isCopiedValueStillPresent) {
       await this.clipboardClearTasks.remove();

--- a/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
+++ b/packages/core/src/services/session/vault-lifecycle-cleanup.service.ts
@@ -1,4 +1,5 @@
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import type { VaultLockTaskRepositoryPort } from "../../ports/vault/vault-lock-task-repository.port";
 import type { ClipboardClearService } from "../clipboard/clipboard-clear.service";
@@ -11,9 +12,17 @@ export type VaultLifecycleCleanupParams = {
   readonly requiredVaultId?: string;
 };
 
+type SessionDiscardResult =
+  | "discarded"
+  | "session_advanced"
+  | "session_replaced"
+  | "session_unavailable"
+  | "rollback_failed";
+
 export class VaultLifecycleCleanupService {
   private readonly clipboardClear: ClipboardClearService;
   private readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
+  private readonly clipboardOperations: ClipboardOperationCoordinatorPort;
   private readonly scheduledTasks: ScheduledTaskPort;
   private readonly vaultLockTasks: VaultLockTaskRepositoryPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
@@ -21,12 +30,14 @@ export class VaultLifecycleCleanupService {
   constructor(
     clipboardClear: ClipboardClearService,
     clipboardClearTasks: ClipboardClearTaskRepositoryPort,
+    clipboardOperations: ClipboardOperationCoordinatorPort,
     scheduledTasks: ScheduledTaskPort,
     vaultLockTasks: VaultLockTaskRepositoryPort,
     unlockedVaultSession: UnlockedVaultSessionService,
   ) {
     this.clipboardClear = clipboardClear;
     this.clipboardClearTasks = clipboardClearTasks;
+    this.clipboardOperations = clipboardOperations;
     this.scheduledTasks = scheduledTasks;
     this.vaultLockTasks = vaultLockTasks;
     this.unlockedVaultSession = unlockedVaultSession;
@@ -34,6 +45,31 @@ export class VaultLifecycleCleanupService {
 
   async cleanup(
     params: VaultLifecycleCleanupParams = {},
+  ): Promise<"cleaned" | "session_unavailable" | "stale_action"> {
+    return this.runWithClipboardCoordination(
+      () => this.cleanupExclusive(params),
+      (coordinationError) =>
+        this.cleanupAfterCoordinationFailure(params, coordinationError),
+    );
+  }
+
+  private async cleanupAfterCoordinationFailure(
+    params: VaultLifecycleCleanupParams,
+    coordinationError: unknown,
+  ): Promise<"cleaned" | "session_unavailable" | "stale_action"> {
+    try {
+      await this.cleanupExclusive(params, false, coordinationError);
+    } catch {
+      // The acquisition failure is still the earliest error.
+    }
+
+    throw coordinationError;
+  }
+
+  private async cleanupExclusive(
+    params: VaultLifecycleCleanupParams,
+    clipboardCleanupEnabled = true,
+    initialError?: unknown,
   ): Promise<"cleaned" | "session_unavailable" | "stale_action"> {
     let staleAction = false;
     let staleActionError: unknown;
@@ -44,6 +80,8 @@ export class VaultLifecycleCleanupService {
         const taskCleanup = await this.cleanupTasks(
           params.actionId,
           activeSession?.vaultId ?? params.requiredVaultId,
+          clipboardCleanupEnabled,
+          initialError,
         );
         if (taskCleanup.status === "stale_action") {
           staleAction = true;
@@ -73,40 +111,80 @@ export class VaultLifecycleCleanupService {
       readonly sourceSnapshotVersionVector: VersionVector;
     },
     discard: () => Promise<boolean>,
-  ): Promise<
-    | "discarded"
-    | "session_advanced"
-    | "session_replaced"
-    | "session_unavailable"
-    | "rollback_failed"
-  > {
+  ): Promise<SessionDiscardResult> {
+    return this.runWithClipboardCoordination(
+      () => this.discardExclusive(params, discard),
+      (coordinationError) =>
+        this.discardExclusive(params, discard, false, coordinationError),
+    );
+  }
+
+  private async discardExclusive(
+    params: {
+      readonly sessionId: string;
+      readonly vaultId: string;
+      readonly generation: number;
+      readonly sourceSnapshotVersionVector: VersionVector;
+    },
+    discard: () => Promise<boolean>,
+    clipboardCleanupEnabled = true,
+    initialError?: unknown,
+  ): Promise<SessionDiscardResult> {
     return this.unlockedVaultSession.discardIfSessionIsActive(
       params.sessionId,
       params.vaultId,
       params.generation,
       params.sourceSnapshotVersionVector,
       async () => {
-        await this.cleanupTasks(undefined, params.vaultId);
+        await this.cleanupTasks(
+          undefined,
+          params.vaultId,
+          clipboardCleanupEnabled,
+          initialError,
+        );
       },
       discard,
     );
   }
 
+  private async runWithClipboardCoordination<Result>(
+    operation: () => Promise<Result>,
+    onAcquisitionFailure: (error: unknown) => Promise<Result>,
+  ): Promise<Result> {
+    let operationStarted = false;
+
+    try {
+      return await this.clipboardOperations.runExclusive(() => {
+        operationStarted = true;
+        return operation();
+      });
+    } catch (error) {
+      if (operationStarted) {
+        throw error;
+      }
+
+      return onAcquisitionFailure(error);
+    }
+  }
+
   private async cleanupTasks(
     actionId: string | undefined,
     expectedVaultId: string | undefined,
+    clipboardCleanupEnabled = true,
+    initialError?: unknown,
   ): Promise<
     | { readonly status: "cleaned" }
     | { readonly status: "stale_action"; readonly error?: unknown }
   > {
-    let firstError: unknown;
+    let firstError = initialError;
     let vaultLockTask: Awaited<ReturnType<VaultLockTaskRepositoryPort["get"]>>;
     let lockMetadataRemoved = false;
+    let scheduledActionAuthenticationFailed = false;
 
     try {
       vaultLockTask = await this.vaultLockTasks.get();
     } catch (error) {
-      firstError = error;
+      firstError ??= error;
       vaultLockTask = null;
 
       if (actionId !== undefined) {
@@ -114,10 +192,10 @@ export class VaultLifecycleCleanupService {
           lockMetadataRemoved =
             await this.vaultLockTasks.removeIfActionIsActive(actionId);
         } catch {
-          return { status: "stale_action", error };
+          scheduledActionAuthenticationFailed = true;
         }
 
-        if (!lockMetadataRemoved) {
+        if (!lockMetadataRemoved && !scheduledActionAuthenticationFailed) {
           return { status: "stale_action" };
         }
       }
@@ -136,50 +214,46 @@ export class VaultLifecycleCleanupService {
     if (
       actionId !== undefined &&
       vaultLockTask === null &&
-      !lockMetadataRemoved
+      !lockMetadataRemoved &&
+      !scheduledActionAuthenticationFailed
     ) {
       return { status: "stale_action" };
     }
 
-    let clipboardClearTask: Awaited<
-      ReturnType<ClipboardClearTaskRepositoryPort["get"]>
-    >;
-    let clipboardTaskStateUnknown = false;
-
-    try {
-      clipboardClearTask = await this.clipboardClearTasks.get();
-    } catch (error) {
-      firstError ??= error;
-      clipboardClearTask = null;
-      clipboardTaskStateUnknown = true;
-    }
-
-    if (clipboardClearTask !== null) {
+    if (clipboardCleanupEnabled) {
+      let clipboardClearTask: Awaited<
+        ReturnType<ClipboardClearTaskRepositoryPort["get"]>
+      >;
       try {
-        await this.clipboardClear.clearTask({
-          task: clipboardClearTask,
-          requireExpired: false,
-        });
+        clipboardClearTask = await this.clipboardClearTasks.get();
       } catch (error) {
         firstError ??= error;
-        clipboardTaskStateUnknown = true;
+        clipboardClearTask = null;
       }
 
-      try {
-        await this.scheduledTasks.cancelTask({
-          name: "clearClipboard",
-          actionId: clipboardClearTask.actionId,
-        });
-      } catch (error) {
-        firstError ??= error;
-      }
-    }
+      if (clipboardClearTask !== null) {
+        let clipboardOwnershipReleased = false;
 
-    if (clipboardTaskStateUnknown) {
-      try {
-        await this.clipboardClearTasks.remove();
-      } catch (error) {
-        firstError ??= error;
+        try {
+          await this.clipboardClear.clearTask({
+            task: clipboardClearTask,
+            requireExpired: false,
+          });
+          clipboardOwnershipReleased = true;
+        } catch (error) {
+          firstError ??= error;
+        }
+
+        if (clipboardOwnershipReleased) {
+          try {
+            await this.scheduledTasks.cancelTask({
+              name: "clearClipboard",
+              actionId: clipboardClearTask.actionId,
+            });
+          } catch (error) {
+            firstError ??= error;
+          }
+        }
       }
     }
 
@@ -193,6 +267,20 @@ export class VaultLifecycleCleanupService {
         });
       } catch (error) {
         firstError ??= error;
+      }
+    }
+
+    if (actionId !== undefined && lockMetadataRemoved) {
+      try {
+        if ((await this.vaultLockTasks.get()) !== null) {
+          return {
+            status: "stale_action",
+            ...(firstError === undefined ? {} : { error: firstError }),
+          };
+        }
+      } catch (error) {
+        firstError ??= error;
+        scheduledActionAuthenticationFailed = true;
       }
     }
 
@@ -210,7 +298,18 @@ export class VaultLifecycleCleanupService {
         }
       } catch (error) {
         firstError ??= error;
+
+        if (actionId !== undefined) {
+          scheduledActionAuthenticationFailed = true;
+        }
       }
+    }
+
+    if (scheduledActionAuthenticationFailed) {
+      return {
+        status: "stale_action",
+        ...(firstError === undefined ? {} : { error: firstError }),
+      };
     }
 
     if (firstError !== undefined) {

--- a/packages/core/src/use-cases/clipboard/clear-clipboard-task.test.ts
+++ b/packages/core/src/use-cases/clipboard/clear-clipboard-task.test.ts
@@ -10,6 +10,7 @@ import type {
   ClipboardClearTask,
   ClipboardClearTaskRepositoryPort,
 } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
 import { ClearClipboardTaskUseCase } from "./clear-clipboard-task";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
 
@@ -34,6 +35,9 @@ function createContext(
     get: vi.fn(async () => clipboardClearTask),
     remove: vi.fn(async () => undefined),
   };
+  const clipboardOperations: ClipboardOperationCoordinatorPort = {
+    runExclusive: async (operation) => operation(),
+  };
   const clock = {
     now: vi.fn(() => 1_000),
   };
@@ -49,8 +53,9 @@ function createContext(
         clipboard,
         clipboardClearTasks,
         clock,
-        ports.crypto,
+        ports.clipboardSecretHash,
       ),
+      clipboardOperations,
     ),
   };
 }

--- a/packages/core/src/use-cases/clipboard/clear-clipboard-task.ts
+++ b/packages/core/src/use-cases/clipboard/clear-clipboard-task.ts
@@ -1,10 +1,9 @@
-import type { ClipboardClearTask } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
 import type { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
 
 export type ClearClipboardTaskCommandParams = {
   readonly actionId?: string;
   readonly requireExpired: boolean;
-  readonly task?: ClipboardClearTask | null;
 };
 
 export type ClearClipboardTaskResult =
@@ -22,14 +21,21 @@ export type ClearClipboardTaskResult =
 
 export class ClearClipboardTaskUseCase {
   private readonly clipboardClear: ClipboardClearService;
+  private readonly clipboardOperations: ClipboardOperationCoordinatorPort;
 
-  constructor(clipboardClear: ClipboardClearService) {
+  constructor(
+    clipboardClear: ClipboardClearService,
+    clipboardOperations: ClipboardOperationCoordinatorPort,
+  ) {
     this.clipboardClear = clipboardClear;
+    this.clipboardOperations = clipboardOperations;
   }
 
   async execute(
     params: ClearClipboardTaskCommandParams,
   ): Promise<ClearClipboardTaskResult> {
-    return this.clipboardClear.clearTask(params);
+    return this.clipboardOperations.runExclusive(() =>
+      this.clipboardClear.clearTask(params),
+    );
   }
 }

--- a/packages/core/src/use-cases/clipboard/clipboard-operation-coordination.test.ts
+++ b/packages/core/src/use-cases/clipboard/clipboard-operation-coordination.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
+import { createCoreTestValues } from "../../__tests__/fixtures/values";
+import {
+  saveUnlockedVaultWithEntries,
+  singlePasswordEntry,
+} from "../../__tests__/fixtures/vault-entries";
+import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
+import type {
+  ClipboardClearTask,
+  ClipboardClearTaskRepositoryPort,
+} from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
+import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
+import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
+import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import { LockVaultUseCase } from "../vault-lifecycle/lock-vault";
+import { ClearClipboardTaskUseCase } from "./clear-clipboard-task";
+import { CopyEntryPasswordUseCase } from "./copy-entry-password";
+
+class SerializedClipboardOperationCoordinator implements ClipboardOperationCoordinatorPort {
+  private tail: Promise<void> = Promise.resolve();
+
+  runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release = (): void => undefined;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    return previous.then(operation).finally(release);
+  }
+}
+
+type PausePhase =
+  | "afterTaskRead"
+  | "afterTaskSave"
+  | "beforeClipboardWrite"
+  | "beforeHashDecision"
+  | "beforeSchedule";
+
+function createDeferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createContext() {
+  const values = createCoreTestValues();
+  const ports = createCoreTestPorts(values);
+  const secondPasswordEntry = {
+    ...singlePasswordEntry,
+    id: "second-entry-id",
+    login: "second-login",
+    password: "second-password",
+  };
+
+  saveUnlockedVaultWithEntries(ports, values, [
+    singlePasswordEntry,
+    secondPasswordEntry,
+  ]);
+  vi.mocked(ports.ids.generateId).mockReset();
+  vi.mocked(ports.ids.generateId)
+    .mockResolvedValueOnce("action-a")
+    .mockResolvedValueOnce("action-b")
+    .mockResolvedValueOnce("action-c");
+
+  let clipboardValue = "";
+  let currentTask: ClipboardClearTask | null = null;
+  let pause:
+    | {
+        readonly phase: PausePhase;
+        readonly reached: ReturnType<typeof createDeferred>;
+        readonly release: ReturnType<typeof createDeferred>;
+      }
+    | undefined;
+  let nextScheduleError: Error | undefined;
+  let nextClipboardWriteError: Error | undefined;
+
+  const pauseIfRequested = async (phase: PausePhase): Promise<void> => {
+    if (pause?.phase !== phase) {
+      return;
+    }
+
+    const activePause = pause;
+    pause = undefined;
+    activePause.reached.resolve();
+    await activePause.release.promise;
+  };
+
+  const clipboard: ClipboardPort = {
+    readText: vi.fn(async () => clipboardValue),
+    writeText: vi.fn(async (value) => {
+      if (value !== "") {
+        await pauseIfRequested("beforeClipboardWrite");
+
+        if (nextClipboardWriteError !== undefined) {
+          const error = nextClipboardWriteError;
+          nextClipboardWriteError = undefined;
+          throw error;
+        }
+      }
+
+      clipboardValue = value;
+    }),
+  };
+  const clipboardClearTasks: ClipboardClearTaskRepositoryPort = {
+    save: vi.fn(async (task) => {
+      currentTask = task;
+      await pauseIfRequested("afterTaskSave");
+    }),
+    get: vi.fn(async () => {
+      const task = currentTask;
+      await pauseIfRequested("afterTaskRead");
+      return task;
+    }),
+    remove: vi.fn(async () => {
+      currentTask = null;
+    }),
+  };
+  const scheduledActionIds = new Set<string>();
+  const scheduledTasks: ScheduledTaskPort = {
+    scheduleTask: vi.fn(async ({ task }) => {
+      await pauseIfRequested("beforeSchedule");
+
+      if (nextScheduleError !== undefined) {
+        const error = nextScheduleError;
+        nextScheduleError = undefined;
+        throw error;
+      }
+
+      scheduledActionIds.add(task.actionId);
+    }),
+    cancelTask: vi.fn(async (task) => {
+      scheduledActionIds.delete(task.actionId);
+    }),
+  };
+  const clipboardOperations = new SerializedClipboardOperationCoordinator();
+  const clock = {
+    now: vi.fn(() => 1_000),
+  };
+  const compareSecretValueHash = vi.mocked(
+    ports.clipboardSecretHash.compareSecretValueHash,
+  );
+  const originalCompareSecretValueHash =
+    compareSecretValueHash.getMockImplementation();
+  compareSecretValueHash.mockImplementation(async (...params) => {
+    await pauseIfRequested("beforeHashDecision");
+
+    if (originalCompareSecretValueHash === undefined) {
+      throw new Error("Secret hash comparison fixture is missing.");
+    }
+
+    return originalCompareSecretValueHash(...params);
+  });
+  const clipboardClear = new ClipboardClearService(
+    clipboard,
+    clipboardClearTasks,
+    clock,
+    ports.clipboardSecretHash,
+  );
+
+  const createCopyUseCase = () =>
+    new CopyEntryPasswordUseCase(
+      clipboard,
+      clipboardClear,
+      clipboardOperations,
+      ports.clipboardSecretHash,
+      ports.ids,
+      clipboardClearTasks,
+      scheduledTasks,
+      clock,
+      ports.sessionServices.unlockedVaultSession,
+    );
+
+  return {
+    values,
+    ports,
+    entries: [singlePasswordEntry, secondPasswordEntry] as const,
+    clipboard,
+    clipboardClearTasks,
+    scheduledTasks,
+    copyA: createCopyUseCase(),
+    copyB: createCopyUseCase(),
+    clear: new ClearClipboardTaskUseCase(clipboardClear, clipboardOperations),
+    lock: new LockVaultUseCase(
+      new VaultLifecycleCleanupService(
+        clipboardClear,
+        clipboardClearTasks,
+        clipboardOperations,
+        scheduledTasks,
+        ports.vaultLockTasks,
+        ports.sessionServices.unlockedVaultSession,
+      ),
+    ),
+    getClipboardValue: () => clipboardValue,
+    getCurrentTask: () => currentTask,
+    getScheduledActionIds: () => new Set(scheduledActionIds),
+    pauseAt(phase: PausePhase) {
+      const requestedPause = {
+        phase,
+        reached: createDeferred(),
+        release: createDeferred(),
+      };
+      pause = requestedPause;
+      return requestedPause;
+    },
+    failNextSchedule(error: Error) {
+      nextScheduleError = error;
+    },
+    failNextClipboardWrite(error: Error) {
+      nextClipboardWriteError = error;
+    },
+  };
+}
+
+function copyParams(
+  ctx: ReturnType<typeof createContext>,
+  entry: (typeof ctx.entries)[number],
+) {
+  return {
+    vaultId: ctx.values.vaultId,
+    entryId: entry.id,
+    clearAfterMs: 60_000 as const,
+  };
+}
+
+describe("clipboard operation coordination", () => {
+  it.each(["afterTaskRead", "afterTaskSave", "beforeClipboardWrite"] as const)(
+    "serializes copies paused at %s in invocation order",
+    async (phase) => {
+      const ctx = createContext();
+      const pause = ctx.pauseAt(phase);
+      const firstCopy = ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+
+      await pause.reached.promise;
+      const secondCopy = ctx.copyB.execute(copyParams(ctx, ctx.entries[1]));
+
+      expect(ctx.clipboardClearTasks.get).toHaveBeenCalledTimes(1);
+      pause.release.resolve();
+      await Promise.all([firstCopy, secondCopy]);
+
+      expect(ctx.getClipboardValue()).toBe(ctx.entries[1].password);
+      expect(ctx.getCurrentTask()).toEqual({
+        actionId: "action-b",
+        copiedValueHash: `hash:${ctx.entries[1].password}`,
+        expiresAt: 61_000,
+      });
+      expect(ctx.getScheduledActionIds()).toEqual(new Set(["action-b"]));
+    },
+  );
+
+  it.each(["afterTaskRead", "afterTaskSave", "beforeClipboardWrite"] as const)(
+    "serializes copies paused at %s in reverse order",
+    async (phase) => {
+      const ctx = createContext();
+      const pause = ctx.pauseAt(phase);
+      const firstCopy = ctx.copyA.execute(copyParams(ctx, ctx.entries[1]));
+
+      await pause.reached.promise;
+      const secondCopy = ctx.copyB.execute(copyParams(ctx, ctx.entries[0]));
+
+      expect(ctx.clipboardClearTasks.get).toHaveBeenCalledTimes(1);
+      pause.release.resolve();
+      await Promise.all([firstCopy, secondCopy]);
+
+      expect(ctx.getClipboardValue()).toBe(ctx.entries[0].password);
+      expect(ctx.getCurrentTask()).toEqual({
+        actionId: "action-b",
+        copiedValueHash: `hash:${ctx.entries[0].password}`,
+        expiresAt: 61_000,
+      });
+      expect(ctx.getScheduledActionIds()).toEqual(new Set(["action-b"]));
+    },
+  );
+
+  it("keeps newer ownership when a stale alarm waits for a copy", async () => {
+    const ctx = createContext();
+
+    await ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+    const pause = ctx.pauseAt("afterTaskSave");
+    const newerCopy = ctx.copyB.execute(copyParams(ctx, ctx.entries[1]));
+    await pause.reached.promise;
+    const staleClear = ctx.clear.execute({
+      actionId: "action-a",
+      requireExpired: false,
+    });
+
+    pause.release.resolve();
+    await expect(newerCopy).resolves.toEqual({ copied: true });
+    await expect(staleClear).resolves.toEqual({
+      cleared: false,
+      reason: "staleAction",
+    });
+    expect(ctx.getClipboardValue()).toBe(ctx.entries[1].password);
+    expect(ctx.getCurrentTask()?.actionId).toBe("action-b");
+    expect(ctx.getScheduledActionIds()).toEqual(new Set(["action-b"]));
+  });
+
+  it("finishes a hash-mismatch clear before a newer copy can store ownership", async () => {
+    const ctx = createContext();
+
+    await ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+    vi.mocked(ctx.clipboard.readText).mockResolvedValueOnce("other-value");
+    const pause = ctx.pauseAt("beforeHashDecision");
+    const clear = ctx.clear.execute({
+      actionId: "action-a",
+      requireExpired: false,
+    });
+    await pause.reached.promise;
+    const newerCopy = ctx.copyB.execute(copyParams(ctx, ctx.entries[1]));
+
+    pause.release.resolve();
+    await expect(clear).resolves.toEqual({
+      cleared: false,
+      reason: "clipboardChanged",
+    });
+    await expect(newerCopy).resolves.toEqual({ copied: true });
+    expect(ctx.getClipboardValue()).toBe(ctx.entries[1].password);
+    expect(ctx.getCurrentTask()?.actionId).toBe("action-b");
+  });
+
+  it.each(["schedule", "clipboardWrite"] as const)(
+    "finishes %s failure cleanup before a newer copy enters",
+    async (failure) => {
+      const ctx = createContext();
+      const error = new Error(`${failure} failed`);
+      const pause = ctx.pauseAt(
+        failure === "schedule" ? "beforeSchedule" : "beforeClipboardWrite",
+      );
+
+      if (failure === "schedule") {
+        ctx.failNextSchedule(error);
+      } else {
+        ctx.failNextClipboardWrite(error);
+      }
+
+      const failedCopy = ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+      await pause.reached.promise;
+      const newerCopy = ctx.copyB.execute(copyParams(ctx, ctx.entries[1]));
+
+      pause.release.resolve();
+      await expect(failedCopy).rejects.toBe(error);
+      await expect(newerCopy).resolves.toEqual({ copied: true });
+      expect(ctx.getClipboardValue()).toBe(ctx.entries[1].password);
+      expect(ctx.getCurrentTask()?.actionId).toBe("action-b");
+      expect(ctx.getScheduledActionIds()).toEqual(new Set(["action-b"]));
+    },
+  );
+
+  it("clears a copy when lock waits for the in-flight operation", async () => {
+    const ctx = createContext();
+    const pause = ctx.pauseAt("beforeClipboardWrite");
+    const copy = ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+    await pause.reached.promise;
+    const lock = ctx.lock.execute();
+
+    pause.release.resolve();
+    await expect(copy).resolves.toEqual({ copied: true });
+    await expect(lock).resolves.toBeUndefined();
+    expect(ctx.getClipboardValue()).toBe("");
+    expect(ctx.getCurrentTask()).toBeNull();
+    expect(ctx.getScheduledActionIds()).toEqual(new Set());
+  });
+
+  it("rejects a copy that waits for an in-flight lock", async () => {
+    const ctx = createContext();
+    const pause = ctx.pauseAt("afterTaskRead");
+    const lock = ctx.lock.execute();
+    await pause.reached.promise;
+    const copy = ctx.copyA.execute(copyParams(ctx, ctx.entries[0]));
+
+    pause.release.resolve();
+    await expect(lock).resolves.toBeUndefined();
+    await expect(copy).rejects.toBeInstanceOf(VaultMustBeUnlockedError);
+    expect(ctx.getClipboardValue()).toBe("");
+    expect(ctx.getCurrentTask()).toBeNull();
+    expect(ctx.getScheduledActionIds()).toEqual(new Set());
+  });
+});

--- a/packages/core/src/use-cases/clipboard/copy-entry-password.test.ts
+++ b/packages/core/src/use-cases/clipboard/copy-entry-password.test.ts
@@ -10,6 +10,7 @@ import type {
   ClipboardClearTask,
   ClipboardClearTaskRepositoryPort,
 } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { InvalidClipboardClearDelayError } from "../../errors/clipboard.errors";
 import { PasswordEntryNotFoundError } from "../../errors/vault-entry.errors";
@@ -47,6 +48,9 @@ function createContext() {
       activeClipboardClearTask = null;
     }),
   };
+  const clipboardOperations: ClipboardOperationCoordinatorPort = {
+    runExclusive: async (operation) => operation(),
+  };
   const scheduledTasks: ScheduledTaskPort = {
     scheduleTask: vi.fn(async () => undefined),
     cancelTask: vi.fn(async () => undefined),
@@ -58,7 +62,7 @@ function createContext() {
     clipboard,
     clipboardClearTasks,
     clock,
-    ports.crypto,
+    ports.clipboardSecretHash,
   );
 
   return {
@@ -67,13 +71,15 @@ function createContext() {
     clipboard,
     clipboardClear,
     clipboardClearTasks,
+    clipboardOperations,
     getClipboardText: () => clipboardText,
     scheduledTasks,
     clock,
     useCase: new CopyEntryPasswordUseCase(
       clipboard,
       clipboardClear,
-      ports.crypto,
+      clipboardOperations,
+      ports.clipboardSecretHash,
       ports.ids,
       clipboardClearTasks,
       scheduledTasks,
@@ -87,6 +93,7 @@ function createLockVaultUseCase(ctx: ReturnType<typeof createContext>) {
   const lifecycleCleanup = new VaultLifecycleCleanupService(
     ctx.clipboardClear,
     ctx.clipboardClearTasks,
+    ctx.clipboardOperations,
     ctx.scheduledTasks,
     ctx.ports.vaultLockTasks,
     ctx.ports.sessionServices.unlockedVaultSession,
@@ -342,10 +349,20 @@ describe("CopyEntryPasswordUseCase", () => {
     expect(ctx.clipboard.writeText).not.toHaveBeenCalled();
   });
 
-  it("removes pending clipboard clear and cancels scheduled clear when clipboard write fails", async () => {
+  it("retains ownership when clipboard write commits before rejecting", async () => {
     const ctx = createContext();
     const error = new Error("clipboard failed");
-    vi.mocked(ctx.clipboard.writeText).mockRejectedValueOnce(error);
+    const writeText = vi.mocked(ctx.clipboard.writeText);
+    const writeTextImplementation = writeText.getMockImplementation();
+
+    if (writeTextImplementation === undefined) {
+      throw new Error("Expected clipboard write fixture implementation.");
+    }
+
+    writeText.mockImplementationOnce(async (value) => {
+      await writeTextImplementation(value);
+      throw error;
+    });
 
     await expect(
       ctx.useCase.execute({
@@ -355,33 +372,17 @@ describe("CopyEntryPasswordUseCase", () => {
       }),
     ).rejects.toThrow(error);
 
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "clearClipboard",
-      actionId: "clipboard-action-id",
-    });
-    expect(ctx.clipboardClearTasks.remove).toHaveBeenCalledTimes(1);
-  });
-
-  it("removes pending clipboard clear when canceling scheduled clear fails", async () => {
-    const ctx = createContext();
-    const clipboardError = new Error("clipboard failed");
-    const cancelError = new Error("cancel failed");
-
-    vi.mocked(ctx.clipboard.writeText).mockRejectedValueOnce(clipboardError);
-    vi.mocked(ctx.scheduledTasks.cancelTask).mockRejectedValueOnce(cancelError);
+    expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalled();
+    expect(ctx.clipboardClearTasks.remove).not.toHaveBeenCalled();
+    expect(ctx.getClipboardText()).toBe(singlePasswordEntry.password);
 
     await expect(
-      ctx.useCase.execute({
-        vaultId: ctx.values.vaultId,
-        entryId: singlePasswordEntry.id,
-        clearAfterMs: 60_000,
+      ctx.clipboardClear.clearTask({
+        actionId: "clipboard-action-id",
+        requireExpired: false,
       }),
-    ).rejects.toThrow(clipboardError);
-
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "clearClipboard",
-      actionId: "clipboard-action-id",
-    });
+    ).resolves.toEqual({ cleared: true });
+    expect(ctx.getClipboardText()).toBe("");
     expect(ctx.clipboardClearTasks.remove).toHaveBeenCalledTimes(1);
   });
 
@@ -422,7 +423,7 @@ describe("CopyEntryPasswordUseCase", () => {
     );
   });
 
-  it("cancels previous scheduled clear when previous clipboard cleanup fails", async () => {
+  it("preserves previous scheduled clear when clipboard cleanup fails", async () => {
     const ctx = createContext();
     const error = new Error("clipboard unavailable");
     const previousClipboardClearTask = {
@@ -444,10 +445,7 @@ describe("CopyEntryPasswordUseCase", () => {
       }),
     ).rejects.toThrow(error);
 
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
-      name: "clearClipboard",
-      actionId: "previous-action-id",
-    });
+    expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalled();
     expect(ctx.clipboardClearTasks.save).not.toHaveBeenCalled();
     expect(ctx.clipboard.writeText).not.toHaveBeenCalledWith(
       singlePasswordEntry.password,

--- a/packages/core/src/use-cases/clipboard/copy-entry-password.ts
+++ b/packages/core/src/use-cases/clipboard/copy-entry-password.ts
@@ -2,9 +2,10 @@ import { clipboardClearDelayMsSchema } from "../../domain/scheduled-task/schedul
 import type { ClipboardClearDelayMs } from "../../domain/scheduled-task/scheduled-task-delay.type";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import type { ClockPort } from "../../ports/system/clock.port";
-import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { IdPort } from "../../ports/system/id.port";
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
+import type { ClipboardSecretHashPort } from "../../ports/clipboard/clipboard-secret-hash.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { InvalidClipboardClearDelayError } from "../../errors/clipboard.errors";
 import { PasswordEntryNotFoundError } from "../../errors/vault-entry.errors";
@@ -24,7 +25,8 @@ export type CopyEntryPasswordResult = {
 export class CopyEntryPasswordUseCase {
   private readonly clipboard: ClipboardPort;
   private readonly clipboardClear: ClipboardClearService;
-  private readonly crypto: CryptoPort;
+  private readonly clipboardOperations: ClipboardOperationCoordinatorPort;
+  private readonly clipboardSecretHash: ClipboardSecretHashPort;
   private readonly ids: IdPort;
   private readonly clipboardClearTasks: ClipboardClearTaskRepositoryPort;
   private readonly scheduledTasks: ScheduledTaskPort;
@@ -34,7 +36,8 @@ export class CopyEntryPasswordUseCase {
   constructor(
     clipboard: ClipboardPort,
     clipboardClear: ClipboardClearService,
-    crypto: CryptoPort,
+    clipboardOperations: ClipboardOperationCoordinatorPort,
+    clipboardSecretHash: ClipboardSecretHashPort,
     ids: IdPort,
     clipboardClearTasks: ClipboardClearTaskRepositoryPort,
     scheduledTasks: ScheduledTaskPort,
@@ -43,7 +46,8 @@ export class CopyEntryPasswordUseCase {
   ) {
     this.clipboard = clipboard;
     this.clipboardClear = clipboardClear;
-    this.crypto = crypto;
+    this.clipboardOperations = clipboardOperations;
+    this.clipboardSecretHash = clipboardSecretHash;
     this.ids = ids;
     this.clipboardClearTasks = clipboardClearTasks;
     this.scheduledTasks = scheduledTasks;
@@ -62,101 +66,75 @@ export class CopyEntryPasswordUseCase {
       throw new InvalidClipboardClearDelayError(clearDelayResult.error);
     }
 
-    return this.unlockedVaultSession.runWithUnlockedVaultContext(
-      params.vaultId,
-      "copy entry password",
-      async ({ unlockedVault }) => {
-        const entry = unlockedVault.vault.entries.find(
-          (candidate) => candidate.id === params.entryId,
-        );
+    return this.clipboardOperations.runExclusive(() =>
+      this.unlockedVaultSession.runWithUnlockedVaultContext(
+        params.vaultId,
+        "copy entry password",
+        async ({ unlockedVault }) => {
+          const entry = unlockedVault.vault.entries.find(
+            (candidate) => candidate.id === params.entryId,
+          );
 
-        if (entry === undefined) {
-          throw new PasswordEntryNotFoundError(params.vaultId, params.entryId);
-        }
+          if (entry === undefined) {
+            throw new PasswordEntryNotFoundError(
+              params.vaultId,
+              params.entryId,
+            );
+          }
 
-        const clearScheduledAt = this.clock.now() + params.clearAfterMs;
-        const previousClipboardClearTask = await this.clipboardClearTasks.get();
+          const clearScheduledAt = this.clock.now() + params.clearAfterMs;
+          const previousClipboardClearTask =
+            await this.clipboardClearTasks.get();
 
-        if (previousClipboardClearTask !== null) {
-          let previousClearError: unknown;
-
-          try {
+          if (previousClipboardClearTask !== null) {
             await this.clipboardClear.clearTask({
               task: previousClipboardClearTask,
               requireExpired: false,
             });
-          } catch (error) {
-            previousClearError = error;
-          }
-
-          try {
             await this.scheduledTasks.cancelTask({
               name: "clearClipboard",
               actionId: previousClipboardClearTask.actionId,
             });
-          } catch (error) {
-            if (previousClearError === undefined) {
-              throw error;
-            }
           }
 
-          if (previousClearError !== undefined) {
-            throw previousClearError;
-          }
-        }
+          const actionId = await this.ids.generateId();
+          const copiedValueHash =
+            await this.clipboardSecretHash.hashSecretValue(entry.password);
 
-        const actionId = await this.ids.generateId();
-        const copiedValueHash = await this.crypto.hashSecretValue(
-          entry.password,
-        );
-
-        await this.clipboardClearTasks.save({
-          actionId,
-          copiedValueHash,
-          expiresAt: clearScheduledAt,
-        });
-
-        try {
-          await this.scheduledTasks.scheduleTask({
-            task: {
-              name: "clearClipboard",
-              actionId,
-            },
-            runAt: clearScheduledAt,
+          await this.clipboardClearTasks.save({
+            actionId,
+            copiedValueHash,
+            expiresAt: clearScheduledAt,
           });
-        } catch (error) {
-          try {
-            await this.clipboardClearTasks.remove();
-          } catch {
-            // Preserve the schedule failure as the root cause.
-          }
 
-          throw error;
-        }
-
-        try {
-          await this.clipboard.writeText(entry.password);
-        } catch (error) {
           try {
-            await this.scheduledTasks.cancelTask({
-              name: "clearClipboard",
-              actionId,
+            await this.scheduledTasks.scheduleTask({
+              task: {
+                name: "clearClipboard",
+                actionId,
+              },
+              runAt: clearScheduledAt,
             });
-          } catch {
-            // Preserve the clipboard write failure; repository cleanup still needs to run.
-          }
-          try {
-            await this.clipboardClearTasks.remove();
-          } catch {
-            // Preserve the clipboard write failure.
-          }
-          throw error;
-        }
+          } catch (error) {
+            try {
+              await this.clipboardClearTasks.remove();
+            } catch {
+              // Preserve the schedule failure as the root cause.
+            }
 
-        return {
-          copied: true,
-        };
-      },
+            throw error;
+          }
+
+          // The OS write may commit before the adapter observes a response
+          // failure. Retain ownership so the alarm can clear a committed value
+          // or discard metadata after a hash mismatch.
+          await this.clipboard.writeText(entry.password);
+
+          return {
+            copied: true,
+          };
+        },
+      ),
     );
   }
 }

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -132,11 +132,16 @@ function createContext(synced = false) {
     clipboard,
     clipboardClearTasks,
     ports.clock,
-    ports.crypto,
+    ports.clipboardSecretHash,
   );
+  const clipboardOperations = {
+    runExclusive: async <Result>(operation: () => Promise<Result>) =>
+      operation(),
+  };
   const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     clipboardClearTasks,
+    clipboardOperations,
     ports.scheduledTasks,
     ports.vaultLockTasks,
     ports.sessionServices.unlockedVaultSession,
@@ -168,6 +173,7 @@ function createContext(synced = false) {
     clipboard,
     clipboardClear,
     clipboardClearTasks,
+    clipboardOperations,
     lifecycleCleanup,
     useCase,
   };
@@ -912,6 +918,53 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+  });
+
+  it("removes the hot session but retains local enrollment when rollback coordination is unavailable", async () => {
+    const ctx = createContext(true);
+    const coordinationError = new Error("clipboard coordination unavailable");
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    );
+    vi.spyOn(ctx.clipboardOperations, "runExclusive").mockRejectedValueOnce(
+      coordinationError,
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        enrollmentResponse: ctx.response,
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "New laptop",
+        lockAfterMs: 60_000,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).rejects.toMatchObject({
+      name: "DeviceEnrollmentRollbackIncompleteError",
+      cause: expect.objectContaining({
+        name: "DeviceEnrollmentRemoteSnapshotChangedError",
+      }),
+    });
+
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(ctx.ports.vaultLockTasks.get).toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledOnce();
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledOnce();
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+    await expectEnrollmentOwnedBuffersWiped(ctx);
   });
 
   it("rolls back local state after a definitive compare-and-set rejection", async () => {

--- a/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/delete-local-vault.test.ts
@@ -29,11 +29,16 @@ function createContext() {
     clipboard,
     clipboardClearTasks,
     ports.clock,
-    ports.crypto,
+    ports.clipboardSecretHash,
   );
+  const clipboardOperations = {
+    runExclusive: async <Result>(operation: () => Promise<Result>) =>
+      operation(),
+  };
   const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     clipboardClearTasks,
+    clipboardOperations,
     scheduledTasks,
     ports.vaultLockTasks,
     ports.sessionServices.unlockedVaultSession,
@@ -69,6 +74,7 @@ function createContext() {
     ports,
     clipboard,
     clipboardClearTasks,
+    clipboardOperations,
     scheduledTasks,
     lifecycleCleanup,
     useCase,
@@ -131,6 +137,28 @@ describe("DeleteLocalVaultUseCase", () => {
     expect(
       ctx.ports.vaultLockTasks.removeIfActionIsActive,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes hot session state but preserves the vault when clipboard coordination cannot start", async () => {
+    const ctx = createContext();
+    const error = new Error("clipboard coordination unavailable");
+    vi.spyOn(ctx.clipboardOperations, "runExclusive").mockRejectedValueOnce(
+      error,
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(error);
+
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVault,
+    ).not.toHaveBeenCalled();
   });
 
   it("fails when no vault is unlocked", async () => {
@@ -353,7 +381,7 @@ describe("DeleteLocalVaultUseCase", () => {
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).rejects.toBe(error);
 
-    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+    expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalledWith({
       name: "clearClipboard",
       actionId: "clipboard-action-id",
     });
@@ -361,7 +389,7 @@ describe("DeleteLocalVaultUseCase", () => {
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,
     });
-    expect(ctx.clipboardClearTasks.remove).toHaveBeenCalledTimes(1);
+    expect(ctx.clipboardClearTasks.remove).not.toHaveBeenCalled();
     expect(
       ctx.ports.vaultLockTasks.removeIfActionIsActive,
     ).toHaveBeenCalledTimes(1);

--- a/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/lock-vault.test.ts
@@ -6,6 +6,7 @@ import {
   singlePasswordEntry,
 } from "../../__tests__/fixtures/vault-entries";
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
+import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/clipboard-operation-coordinator.port";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
@@ -28,6 +29,9 @@ function createContext() {
     get: vi.fn(async () => null),
     remove: vi.fn(async () => undefined),
   };
+  const clipboardOperations: ClipboardOperationCoordinatorPort = {
+    runExclusive: async (operation) => operation(),
+  };
   const clock = {
     now: vi.fn(() => values.timestamp),
   };
@@ -39,11 +43,12 @@ function createContext() {
     clipboard,
     clipboardClearTasks,
     clock,
-    ports.crypto,
+    ports.clipboardSecretHash,
   );
   const lifecycleCleanup = new VaultLifecycleCleanupService(
     clipboardClear,
     clipboardClearTasks,
+    clipboardOperations,
     scheduledTasks,
     ports.vaultLockTasks,
     ports.sessionServices.unlockedVaultSession,
@@ -55,6 +60,7 @@ function createContext() {
     ports,
     clipboard,
     clipboardClearTasks,
+    clipboardOperations,
     scheduledTasks,
     useCase,
   };
@@ -69,6 +75,73 @@ describe("LockVaultUseCase", () => {
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes hot session state when clipboard coordination cannot start", async () => {
+    const ctx = createContext();
+    const error = new Error("clipboard coordination unavailable");
+    vi.spyOn(ctx.clipboardOperations, "runExclusive").mockRejectedValueOnce(
+      error,
+    );
+
+    await expect(ctx.useCase.execute()).rejects.toBe(error);
+
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(ctx.ports.vaultLockTasks.get).toHaveBeenCalledTimes(1);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the coordination error when session material reading also fails", async () => {
+    const ctx = createContext();
+    const coordinationError = new Error("clipboard coordination unavailable");
+    const sessionReadError = new Error("session material unavailable");
+    vi.spyOn(ctx.clipboardOperations, "runExclusive").mockRejectedValueOnce(
+      coordinationError,
+    );
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .getUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(sessionReadError);
+
+    await expect(ctx.useCase.execute()).rejects.toBe(coordinationError);
+
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the coordination error when a scheduled action is stale", async () => {
+    const ctx = createContext();
+    const coordinationError = new Error("clipboard coordination unavailable");
+    vi.spyOn(ctx.clipboardOperations, "runExclusive").mockRejectedValueOnce(
+      coordinationError,
+    );
+    await ctx.ports.vaultLockTasks.save({
+      actionId: "newer-lock-action-id",
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(coordinationError);
+
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    expect(ctx.clipboardClearTasks.get).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
   });
 
   it("cancels pending scheduled vault lock on manual lock", async () => {
@@ -168,6 +241,42 @@ describe("LockVaultUseCase", () => {
     ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
     await expect(ctx.ports.vaultLockTasks.get()).resolves.toBe(newerLockTask);
     expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+  });
+
+  it("preserves the session when final scheduled lock authentication fails", async () => {
+    const ctx = createContext();
+    const authenticationError = new Error("lock metadata CAS failed");
+    const newerLockTask = {
+      actionId: "newer-lock-action-id",
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 120_000,
+    };
+    await ctx.ports.vaultLockTasks.save({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.scheduledTasks.cancelTask).mockImplementation(
+      async (task) => {
+        if (task.name === "lockVault") {
+          await ctx.ports.vaultLockTasks.save(newerLockTask);
+        }
+      },
+    );
+    vi.mocked(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).mockRejectedValueOnce(authenticationError);
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(authenticationError);
+
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    await expect(ctx.ports.vaultLockTasks.get()).resolves.toBe(newerLockTask);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
   });
 
   it("ignores scheduled vault lock when metadata is missing", async () => {
@@ -377,6 +486,11 @@ describe("LockVaultUseCase", () => {
 
     await expect(ctx.useCase.execute()).rejects.toThrow(error);
 
+    expect(ctx.scheduledTasks.cancelTask).not.toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.clipboardClearTasks.remove).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
@@ -387,6 +501,11 @@ describe("LockVaultUseCase", () => {
     const error = new Error("lock task metadata unavailable");
 
     vi.mocked(ctx.ports.vaultLockTasks.get).mockRejectedValueOnce(error);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
 
     await expect(ctx.useCase.execute()).rejects.toBe(error);
 
@@ -530,14 +649,97 @@ describe("LockVaultUseCase", () => {
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
   });
 
-  it("removes unlocked vault state when reading clipboard task metadata fails", async () => {
+  it("preserves the session when lock metadata advances after read-failure authentication", async () => {
+    const ctx = createContext();
+    const readError = new Error("lock task metadata unavailable");
+    const newerLockTask = {
+      actionId: "newer-lock-action-id",
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 120_000,
+    };
+    await ctx.ports.vaultLockTasks.save({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockRejectedValueOnce(readError);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.scheduledTasks.cancelTask).mockImplementation(
+      async (task) => {
+        if (task.name === "lockVault") {
+          await ctx.ports.vaultLockTasks.save(newerLockTask);
+        }
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(readError);
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    await expect(ctx.ports.vaultLockTasks.get()).resolves.toBe(newerLockTask);
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("clears clipboard but preserves the session when scheduled lock authentication fails", async () => {
+    const ctx = createContext();
+    const readError = new Error("lock task metadata unavailable");
+    const authenticationError = new Error("lock task authentication failed");
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockRejectedValueOnce(readError);
+    vi.mocked(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).mockRejectedValueOnce(authenticationError);
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+
+    await expect(
+      ctx.useCase.execute({ actionId: ctx.values.vaultLockActionId }),
+    ).rejects.toBe(readError);
+
+    expect(ctx.clipboard.writeText).toHaveBeenCalledWith("");
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "clearClipboard",
+      actionId: "clipboard-action-id",
+    });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeDefined();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("preserves unknown clipboard ownership when reading its metadata fails", async () => {
     const ctx = createContext();
     const error = new Error("clipboard task metadata unavailable");
 
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
     vi.mocked(ctx.clipboardClearTasks.get).mockRejectedValueOnce(error);
 
     await expect(ctx.useCase.execute()).rejects.toBe(error);
 
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(ctx.clipboardClearTasks.remove).not.toHaveBeenCalled();
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
     ).toHaveBeenCalledTimes(1);
@@ -563,6 +765,56 @@ describe("LockVaultUseCase", () => {
 
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.cleanupActiveSession,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the first cleanup error while attempting every later phase", async () => {
+    const ctx = createContext();
+    const clipboardError = new Error("clipboard unavailable");
+    const lockCancelError = new Error("lock cancel failed");
+    const lockRemoveError = new Error("lock metadata remove failed");
+    const sessionRemoveError = new Error("session removal failed");
+
+    vi.mocked(ctx.ports.vaultLockTasks.get).mockResolvedValueOnce({
+      actionId: ctx.values.vaultLockActionId,
+      vaultId: ctx.values.vaultId,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboardClearTasks.get).mockResolvedValueOnce({
+      actionId: "clipboard-action-id",
+      copiedValueHash: `hash:${singlePasswordEntry.password}`,
+      expiresAt: ctx.values.timestamp + 60_000,
+    });
+    vi.mocked(ctx.clipboard.readText).mockRejectedValueOnce(clipboardError);
+    vi.mocked(ctx.scheduledTasks.cancelTask).mockRejectedValueOnce(
+      lockCancelError,
+    );
+    vi.mocked(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).mockRejectedValueOnce(lockRemoveError);
+    vi.mocked(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).mockRejectedValueOnce(sessionRemoveError);
+
+    await expect(ctx.useCase.execute()).rejects.toBe(clipboardError);
+
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledTimes(1);
+    expect(ctx.scheduledTasks.cancelTask).toHaveBeenCalledWith({
+      name: "lockVault",
+      actionId: ctx.values.vaultLockActionId,
+    });
+    expect(ctx.clipboardClearTasks.remove).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLockTasks.removeIfActionIsActive,
+    ).toHaveBeenCalledWith(ctx.values.vaultLockActionId);
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .removeUnlockedVaultSessionMaterial,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .removeEncryptedUnlockedVaultSessionPayload,
     ).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- Resolve LFSPM work item 13 in required order: Finding 14 failure isolation, then Finding 13 atomic clipboard ownership.
- Run vault-lock and clipboard cleanup as independent best-effort phases while preserving deterministic first-error precedence and stale scheduled-action safety.
- Serialize copy, scheduled clear, lock, delete, and enrollment rollback through one clipboard-operation coordinator.
- Add real Chrome Web Locks, trusted `storage.session`, alarms, WebCrypto hashing, and offscreen clipboard adapters with production background wiring.
- Retain scheduled ownership when clipboard writes have an ambiguous committed-then-rejected outcome.
- Keep clipboard ownership metadata volatile and never perform an unverified clipboard overwrite after a cold browser restart.

## Security behavior

- Clipboard contents are cleared only when the current action and SHA-256 verifier still authenticate ownership.
- Plaintext clipboard values and reusable password verifiers are not persisted durably.
- A stale alarm without volatile ownership metadata leaves the user clipboard untouched.
- This follows the OWASP shortest-exposure principle and addresses the NIST APP-35 clipboard disclosure threat without risking destruction of unrelated clipboard contents.

## Testing

- Core TypeScript type-check passed.
- Extension TypeScript type-check passed.
- Core Vitest configuration: 64 files, 633 tests passed.
- Extension Vitest configuration: 64 files, 633 tests passed.
- Focused real-adapter/runtime suite: 7 files, 31 tests passed.
- Extension production build passed; 4,900 modules transformed.
- Changed extension files passed ESLint.
- Changed files passed Prettier and `git diff --cached --check`.
- Two consecutive independent clean review rounds passed after the final simplification.

## Known baseline

The full extension lint command still reports the existing `react-refresh/only-export-components` violation in unchanged `apps/extension/src/ui/components/primitives/button.tsx:56`.