### PR TITLE
feat: secure multi-device vault sync

### DIFF
--- a/apps/extension/src/adapters/codecs/sync-credential.codec.ts
+++ b/apps/extension/src/adapters/codecs/sync-credential.codec.ts
@@ -11,6 +11,7 @@ import {
   safeInteger,
   stringArray,
 } from "./artifact-codec.primitives";
+import { decodeVaultSnapshotIdentity } from "./vault-snapshot.codec";
 
 export class InvalidSyncCredentialRecordError extends StaticArtifactError {
   constructor() {
@@ -66,28 +67,61 @@ export function decodeDeviceSyncCredentialState(
     const record = exactRecord(
       value,
       ["currentCredentials"],
-      ["previousCredentials"],
+      ["pendingSnapshotUpload", "previousCredentials"],
     );
     const currentCredentials = decodeSyncCredentials(record.currentCredentials);
-    if (record.previousCredentials === undefined) {
-      return { currentCredentials };
-    }
-    const previous = exactRecord(record.previousCredentials, [
-      "credentials",
-      "revokedDeviceIds",
-      "vaultKeyGeneration",
-    ]);
+    const pendingSnapshotUpload =
+      record.pendingSnapshotUpload === undefined
+        ? undefined
+        : decodePendingSnapshotUpload(record.pendingSnapshotUpload);
+    const previousCredentials =
+      record.previousCredentials === undefined
+        ? undefined
+        : decodePreviousCredentials(record.previousCredentials);
+
     return {
       currentCredentials,
-      previousCredentials: {
-        credentials: decodeSyncCredentials(previous.credentials),
-        revokedDeviceIds: stringArray(previous.revokedDeviceIds, true),
-        vaultKeyGeneration: safeInteger(previous.vaultKeyGeneration, 1),
-      },
+      ...(pendingSnapshotUpload === undefined ? {} : { pendingSnapshotUpload }),
+      ...(previousCredentials === undefined ? {} : { previousCredentials }),
     };
   } catch {
     throw new InvalidDeviceSyncCredentialStateError();
   }
+}
+
+function decodePendingSnapshotUpload(
+  value: unknown,
+): NonNullable<DeviceSyncCredentialState["pendingSnapshotUpload"]> {
+  const record = exactRecord(value, [
+    "candidateSnapshotIdentity",
+    "expectedRemoteSnapshotIdentity",
+  ]);
+
+  return {
+    candidateSnapshotIdentity: decodeVaultSnapshotIdentity(
+      record.candidateSnapshotIdentity,
+    ),
+    expectedRemoteSnapshotIdentity:
+      record.expectedRemoteSnapshotIdentity === null
+        ? null
+        : decodeVaultSnapshotIdentity(record.expectedRemoteSnapshotIdentity),
+  };
+}
+
+function decodePreviousCredentials(
+  value: unknown,
+): NonNullable<DeviceSyncCredentialState["previousCredentials"]> {
+  const previous = exactRecord(value, [
+    "credentials",
+    "revokedDeviceIds",
+    "vaultKeyGeneration",
+  ]);
+
+  return {
+    credentials: decodeSyncCredentials(previous.credentials),
+    revokedDeviceIds: stringArray(previous.revokedDeviceIds, true),
+    vaultKeyGeneration: safeInteger(previous.vaultKeyGeneration, 1),
+  };
 }
 
 export function encodeDeviceSyncCredentialState(

--- a/apps/extension/src/adapters/codecs/vault-snapshot.codec.ts
+++ b/apps/extension/src/adapters/codecs/vault-snapshot.codec.ts
@@ -14,6 +14,7 @@ import {
   type Vault,
   type VaultSnapshot,
   type VaultSnapshotDescriptor,
+  type VaultSnapshotIdentity,
   type VaultTrustCertificate,
 } from "@lfspm/core";
 import { passwordEntryInputSchema, tagSchema } from "@lfspm/core";
@@ -250,16 +251,20 @@ export function decodeVaultSnapshot(
       "content",
       "signature",
     ]);
-    const metadata = exactRecord(record.metadata, [
-      "id",
-      "schemaVersion",
-      "vaultCreationTimestamp",
-      "revisionTimestamp",
-      "snapshotVersionVector",
-      "algorithmSuiteId",
-      "createdByDeviceId",
-      "vaultKeyGeneration",
-    ]);
+    const metadata = exactRecord(
+      record.metadata,
+      [
+        "id",
+        "schemaVersion",
+        "vaultCreationTimestamp",
+        "revisionTimestamp",
+        "snapshotVersionVector",
+        "algorithmSuiteId",
+        "createdByDeviceId",
+        "vaultKeyGeneration",
+      ],
+      ["uploadExpectedRemoteSnapshotIdentity"],
+    );
     if (metadata.schemaVersion !== 1) {
       throw new Error("version");
     }
@@ -293,6 +298,16 @@ export function decodeVaultSnapshot(
         algorithmSuiteId: nonBlankString(metadata.algorithmSuiteId),
         createdByDeviceId: nonBlankString(metadata.createdByDeviceId),
         vaultKeyGeneration: safeInteger(metadata.vaultKeyGeneration, 1),
+        ...(metadata.uploadExpectedRemoteSnapshotIdentity === undefined
+          ? {}
+          : {
+              uploadExpectedRemoteSnapshotIdentity:
+                metadata.uploadExpectedRemoteSnapshotIdentity === null
+                  ? null
+                  : decodeVaultSnapshotIdentity(
+                      metadata.uploadExpectedRemoteSnapshotIdentity,
+                    ),
+            }),
       },
       trustChain: { certificates },
       keySlots: { deviceSlots },
@@ -311,6 +326,16 @@ export function encodeVaultSnapshot(snapshot: VaultSnapshot): unknown {
       snapshotVersionVector: encodeVersionVector(
         snapshot.metadata.snapshotVersionVector,
       ),
+      ...(snapshot.metadata.uploadExpectedRemoteSnapshotIdentity === undefined
+        ? {}
+        : {
+            uploadExpectedRemoteSnapshotIdentity:
+              snapshot.metadata.uploadExpectedRemoteSnapshotIdentity === null
+                ? null
+                : encodeVaultSnapshotIdentity(
+                    snapshot.metadata.uploadExpectedRemoteSnapshotIdentity,
+                  ),
+          }),
     },
     trustChain: {
       certificates: snapshot.trustChain.certificates.map(
@@ -353,6 +378,26 @@ export function encodeVaultSnapshotDescriptor(
       descriptor.snapshotVersionVector,
     ),
     revisionTimestamp: descriptor.revisionTimestamp,
+  };
+}
+
+export function decodeVaultSnapshotIdentity(
+  value: unknown,
+): VaultSnapshotIdentity {
+  const record = exactRecord(value, ["descriptor", "snapshotDigest"]);
+
+  return {
+    descriptor: decodeVaultSnapshotDescriptor(record.descriptor),
+    snapshotDigest: canonicalDigest(record.snapshotDigest),
+  };
+}
+
+export function encodeVaultSnapshotIdentity(
+  identity: VaultSnapshotIdentity,
+): unknown {
+  return {
+    descriptor: encodeVaultSnapshotDescriptor(identity.descriptor),
+    snapshotDigest: identity.snapshotDigest,
   };
 }
 
@@ -513,15 +558,15 @@ export function decodeVault(value: unknown): Vault {
     }
     if (record.syncRemovalPending !== undefined) {
       const pending = exactRecord(record.syncRemovalPending, [
-        "expectedRemoteSnapshotDescriptor",
+        "expectedRemoteSnapshotIdentity",
         "rollbackSnapshot",
       ]);
       result.syncRemovalPending = {
-        expectedRemoteSnapshotDescriptor:
-          pending.expectedRemoteSnapshotDescriptor === null
+        expectedRemoteSnapshotIdentity:
+          pending.expectedRemoteSnapshotIdentity === null
             ? null
-            : decodeVaultSnapshotDescriptor(
-                pending.expectedRemoteSnapshotDescriptor,
+            : decodeVaultSnapshotIdentity(
+                pending.expectedRemoteSnapshotIdentity,
               ),
         rollbackSnapshot: decodeVaultSnapshot(
           pending.rollbackSnapshot,
@@ -569,11 +614,11 @@ export function encodeVault(vault: Vault): unknown {
       ? {}
       : {
           syncRemovalPending: {
-            expectedRemoteSnapshotDescriptor:
-              vault.syncRemovalPending.expectedRemoteSnapshotDescriptor === null
+            expectedRemoteSnapshotIdentity:
+              vault.syncRemovalPending.expectedRemoteSnapshotIdentity === null
                 ? null
-                : encodeVaultSnapshotDescriptor(
-                    vault.syncRemovalPending.expectedRemoteSnapshotDescriptor,
+                : encodeVaultSnapshotIdentity(
+                    vault.syncRemovalPending.expectedRemoteSnapshotIdentity,
                   ),
             rollbackSnapshot: encodeVaultSnapshot(
               vault.syncRemovalPending.rollbackSnapshot,

--- a/apps/extension/src/adapters/crypto/web-crypto.device-sync-credential-state-boundary.test.ts
+++ b/apps/extension/src/adapters/crypto/web-crypto.device-sync-credential-state-boundary.test.ts
@@ -25,6 +25,10 @@ import {
 import { InvalidDeviceSyncCredentialStateError } from "./index";
 import { WebCryptoPort } from "./web-crypto.port";
 
+const candidateSnapshotDigest = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const expectedRemoteSnapshotDigest =
+  "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA";
+
 const textEncoder = new TextEncoder();
 const syncContext: DeviceSyncCredentialEncryptionContext = {
   vaultId: "vault-id",
@@ -92,6 +96,34 @@ describe("WebCrypto device sync credential state boundary", () => {
         credentialsConfig: { region: "eu-west-1" },
       },
     });
+  });
+
+  it("round-trips the exact pending snapshot upload reconciliation intent", () => {
+    const state: DeviceSyncCredentialState = {
+      ...validCredentialState(),
+      pendingSnapshotUpload: {
+        candidateSnapshotIdentity: {
+          descriptor: {
+            vaultId: "vault-id",
+            snapshotVersionVector: { "device-id": 2 },
+            revisionTimestamp: 20,
+          },
+          snapshotDigest: candidateSnapshotDigest,
+        },
+        expectedRemoteSnapshotIdentity: {
+          descriptor: {
+            vaultId: "vault-id",
+            snapshotVersionVector: { "device-id": 1 },
+            revisionTimestamp: 10,
+          },
+          snapshotDigest: expectedRemoteSnapshotDigest,
+        },
+      },
+    };
+
+    expect(
+      decodeDeviceSyncCredentialState(encodeDeviceSyncCredentialState(state)),
+    ).toEqual(state);
   });
 
   it("rejects a non-JSON credentials configuration object", () => {
@@ -177,6 +209,75 @@ describe("WebCrypto device sync credential state boundary", () => {
         currentCredentials: {
           ...validCredentialState().currentCredentials,
           futureField: true,
+        },
+      },
+    ],
+    [
+      "extra pending upload field",
+      {
+        ...validCredentialState(),
+        pendingSnapshotUpload: {
+          candidateSnapshotIdentity: {
+            descriptor: {
+              vaultId: "vault-id",
+              snapshotVersionVector: { "device-id": 2 },
+              revisionTimestamp: 20,
+            },
+            snapshotDigest: candidateSnapshotDigest,
+          },
+          expectedRemoteSnapshotIdentity: null,
+          futureField: true,
+        },
+      },
+    ],
+    [
+      "blank pending upload candidate digest",
+      {
+        ...validCredentialState(),
+        pendingSnapshotUpload: {
+          candidateSnapshotIdentity: {
+            descriptor: {
+              vaultId: "vault-id",
+              snapshotVersionVector: { "device-id": 2 },
+              revisionTimestamp: 20,
+            },
+            snapshotDigest: "   ",
+          },
+          expectedRemoteSnapshotIdentity: null,
+        },
+      },
+    ],
+    [
+      "wrong-length pending upload candidate digest",
+      {
+        ...validCredentialState(),
+        pendingSnapshotUpload: {
+          candidateSnapshotIdentity: {
+            descriptor: {
+              vaultId: "vault-id",
+              snapshotVersionVector: { "device-id": 2 },
+              revisionTimestamp: 20,
+            },
+            snapshotDigest: "AAAA",
+          },
+          expectedRemoteSnapshotIdentity: null,
+        },
+      },
+    ],
+    [
+      "noncanonical pending upload candidate digest",
+      {
+        ...validCredentialState(),
+        pendingSnapshotUpload: {
+          candidateSnapshotIdentity: {
+            descriptor: {
+              vaultId: "vault-id",
+              snapshotVersionVector: { "device-id": 2 },
+              revisionTimestamp: 20,
+            },
+            snapshotDigest: `${candidateSnapshotDigest}=`,
+          },
+          expectedRemoteSnapshotIdentity: null,
         },
       },
     ],

--- a/apps/extension/src/adapters/crypto/web-crypto.port.test.ts
+++ b/apps/extension/src/adapters/crypto/web-crypto.port.test.ts
@@ -704,7 +704,7 @@ describe("WebCryptoPort", () => {
       {
         ...createVault(),
         syncRemovalPending: {
-          expectedRemoteSnapshotDescriptor: null,
+          expectedRemoteSnapshotIdentity: null,
           rollbackSnapshot: invalidRollback,
         },
       },

--- a/apps/extension/src/adapters/storage/indexeddb-vault-local.repository.test.ts
+++ b/apps/extension/src/adapters/storage/indexeddb-vault-local.repository.test.ts
@@ -26,7 +26,10 @@ import {
 import type { AsymmetricKeyValidator } from "../crypto";
 import { IndexedDbVaultLocalRepository } from "./indexeddb-vault-local.repository";
 import { InvalidDeviceEnrollmentArtifactError } from "../codecs/device-enrollment-artifact.codec";
-import { InvalidLocalVaultSecurityRecordError } from "../codecs/local-vault-security.codec";
+import {
+  encodeLocalVaultTrustCheckpoint,
+  InvalidLocalVaultSecurityRecordError,
+} from "../codecs/local-vault-security.codec";
 import { InvalidSyncCredentialRecordError } from "../codecs/sync-credential.codec";
 import { encodeVaultSnapshot } from "../codecs/vault-snapshot.codec";
 
@@ -52,6 +55,20 @@ function createContext() {
       createNoOpAsymmetricKeyValidator(),
       snapshotDigester,
     ),
+  };
+}
+
+function initializedVaultRemovalExpectation(
+  artifacts: ReturnType<typeof createArtifacts>,
+) {
+  return {
+    vaultId: artifacts.descriptor.vaultId,
+    expectedDescriptor: artifacts.descriptor,
+    expectedDeviceAccessMaterial: artifacts.deviceAccessMaterial,
+    expectedDeviceAccessRecoveryBackup: artifacts.deviceAccessRecoveryBackup,
+    expectedSnapshotDigest: snapshotDigest(1),
+    expectedCheckpoint: artifacts.checkpoint,
+    expectedSyncCredentialState: artifacts.syncCredentialState,
   };
 }
 
@@ -240,6 +257,8 @@ describe("IndexedDbVaultLocalRepository", () => {
 
     await ctx.repository.saveVaultSnapshotWithCheckpoint({
       expectedSnapshotDigest: snapshotDigest(1),
+      expectedCheckpoint: ctx.artifacts.checkpoint,
+      expectedSyncCredentialState: ctx.artifacts.syncCredentialState,
       snapshot: nextSnapshot,
       checkpoint: nextCheckpoint,
       syncCredentialState: null,
@@ -262,6 +281,7 @@ describe("IndexedDbVaultLocalRepository", () => {
     await expect(
       ctx.repository.saveVaultSnapshotWithCheckpoint({
         expectedSnapshotDigest: snapshotDigest(1),
+        expectedCheckpoint: ctx.artifacts.checkpoint,
         snapshot: createNextSnapshot(ctx.artifacts.snapshot, 3),
         checkpoint: createNextCheckpoint(ctx.artifacts.checkpoint, 3),
       }),
@@ -276,22 +296,92 @@ describe("IndexedDbVaultLocalRepository", () => {
     ).resolves.toEqual(nextCheckpoint);
   });
 
+  it("repairs an exact stale checkpoint independently of the newer snapshot digest", async () => {
+    const ctx = createContext();
+    await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
+    const newerSnapshot = createNextSnapshot(ctx.artifacts.snapshot, 2);
+    const newerCheckpoint = createNextCheckpoint(ctx.artifacts.checkpoint, 2);
+
+    await ctx.repository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: snapshotDigest(1),
+      expectedCheckpoint: ctx.artifacts.checkpoint,
+      snapshot: newerSnapshot,
+      checkpoint: ctx.artifacts.checkpoint,
+    });
+
+    await ctx.repository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: snapshotDigest(2),
+      expectedCheckpoint: ctx.artifacts.checkpoint,
+      snapshot: newerSnapshot,
+      checkpoint: newerCheckpoint,
+    });
+
+    await expect(
+      ctx.repository.getVaultSnapshot(ctx.artifacts.descriptor.vaultId),
+    ).resolves.toEqual(newerSnapshot);
+    await expect(
+      ctx.repository.getLocalVaultTrustCheckpoint(
+        ctx.artifacts.descriptor.vaultId,
+      ),
+    ).resolves.toEqual(newerCheckpoint);
+  });
+
+  it("does not erase a newer credential marker when a stale credential write races", async () => {
+    const ctx = createContext();
+    await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
+    const staleCredentialState = ctx.artifacts.syncCredentialState;
+    const installedCredentialMarker = serializedEncrypted(70);
+
+    await ctx.repository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: snapshotDigest(1),
+      expectedCheckpoint: ctx.artifacts.checkpoint,
+      expectedSyncCredentialState: staleCredentialState,
+      snapshot: ctx.artifacts.snapshot,
+      checkpoint: ctx.artifacts.checkpoint,
+      syncCredentialState: installedCredentialMarker,
+    });
+
+    await expect(
+      ctx.repository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: snapshotDigest(1),
+        expectedCheckpoint: ctx.artifacts.checkpoint,
+        expectedSyncCredentialState: staleCredentialState,
+        snapshot: ctx.artifacts.snapshot,
+        checkpoint: ctx.artifacts.checkpoint,
+        syncCredentialState: null,
+      }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotChangedError);
+
+    await expect(
+      ctx.repository.getDeviceSyncCredentialState(
+        ctx.artifacts.descriptor.vaultId,
+      ),
+    ).resolves.toEqual(installedCredentialMarker);
+    await expect(
+      ctx.repository.getVaultSnapshot(ctx.artifacts.descriptor.vaultId),
+    ).resolves.toEqual(ctx.artifacts.snapshot);
+    await expect(
+      ctx.repository.getLocalVaultTrustCheckpoint(
+        ctx.artifacts.descriptor.vaultId,
+      ),
+    ).resolves.toEqual(ctx.artifacts.checkpoint);
+  });
+
   it("conditionally removes all vault records only for the current checkpoint digest", async () => {
     const ctx = createContext();
     await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
 
     await expect(
-      ctx.repository.removePersistedLocalVaultIfSnapshotMatches(
-        ctx.artifacts.descriptor.vaultId,
-        snapshotDigest(99),
-      ),
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch({
+        ...initializedVaultRemovalExpectation(ctx.artifacts),
+        expectedSnapshotDigest: snapshotDigest(99),
+      }),
     ).resolves.toBe(false);
     await expect(ctx.database.vaultSnapshots.count()).resolves.toBe(1);
 
     await expect(
-      ctx.repository.removePersistedLocalVaultIfSnapshotMatches(
-        ctx.artifacts.descriptor.vaultId,
-        snapshotDigest(1),
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch(
+        initializedVaultRemovalExpectation(ctx.artifacts),
       ),
     ).resolves.toBe(true);
     await expect(ctx.database.localVaultDescriptors.count()).resolves.toBe(0);
@@ -308,6 +398,64 @@ describe("IndexedDbVaultLocalRepository", () => {
     );
   });
 
+  it("does not remove when the encrypted sync credential artifact changed", async () => {
+    const ctx = createContext();
+    const installedCredentialMarker = serializedEncrypted(71);
+    await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
+    await ctx.repository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: snapshotDigest(1),
+      expectedCheckpoint: ctx.artifacts.checkpoint,
+      expectedSyncCredentialState: ctx.artifacts.syncCredentialState,
+      snapshot: ctx.artifacts.snapshot,
+      checkpoint: ctx.artifacts.checkpoint,
+      syncCredentialState: installedCredentialMarker,
+    });
+
+    await expect(
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch(
+        initializedVaultRemovalExpectation(ctx.artifacts),
+      ),
+    ).resolves.toBe(false);
+
+    await expect(ctx.database.vaultSnapshots.count()).resolves.toBe(1);
+    await expect(
+      ctx.repository.getDeviceSyncCredentialState(
+        ctx.artifacts.descriptor.vaultId,
+      ),
+    ).resolves.toEqual(installedCredentialMarker);
+  });
+
+  it("does not remove any vault record when the access-material pair changed", async () => {
+    const ctx = createContext();
+    await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
+    const replacement = createReplacementAccessRecords(ctx.artifacts, 2);
+    await ctx.repository.saveDeviceAccessRecords({
+      expectedDeviceAccessMaterialRevision: 1,
+      expectedDeviceAccessMaterialGenerationId: "generation-1",
+      expectedDeviceAccessRecoveryBackupRevision: 1,
+      expectedDeviceAccessRecoveryBackupGenerationId: "generation-1",
+      ...replacement,
+    });
+
+    await expect(
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch(
+        initializedVaultRemovalExpectation(ctx.artifacts),
+      ),
+    ).resolves.toBe(false);
+
+    await expect(
+      ctx.repository.getDeviceAccessRecords(ctx.artifacts.descriptor.vaultId),
+    ).resolves.toEqual(replacement);
+    await expect(ctx.database.localVaultDescriptors.count()).resolves.toBe(1);
+    await expect(ctx.database.vaultSnapshots.count()).resolves.toBe(1);
+    await expect(ctx.database.localVaultTrustCheckpoints.count()).resolves.toBe(
+      1,
+    );
+    await expect(ctx.database.deviceSyncCredentialStates.count()).resolves.toBe(
+      1,
+    );
+  });
+
   it("does not remove when the snapshot changed but the checkpoint claim did not", async () => {
     const ctx = createContext();
     await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
@@ -318,9 +466,8 @@ describe("IndexedDbVaultLocalRepository", () => {
     });
 
     await expect(
-      ctx.repository.removePersistedLocalVaultIfSnapshotMatches(
-        ctx.artifacts.descriptor.vaultId,
-        snapshotDigest(1),
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch(
+        initializedVaultRemovalExpectation(ctx.artifacts),
       ),
     ).resolves.toBe(false);
     await expect(ctx.database.vaultSnapshots.count()).resolves.toBe(1);
@@ -339,6 +486,7 @@ describe("IndexedDbVaultLocalRepository", () => {
     await expect(
       ctx.repository.saveVaultSnapshotWithCheckpoint({
         expectedSnapshotDigest: snapshotDigest(1),
+        expectedCheckpoint: ctx.artifacts.checkpoint,
         snapshot: createNextSnapshot(ctx.artifacts.snapshot, 2),
         checkpoint: createNextCheckpoint(ctx.artifacts.checkpoint, 2),
       }),
@@ -351,6 +499,36 @@ describe("IndexedDbVaultLocalRepository", () => {
         ctx.artifacts.descriptor.vaultId,
       ),
     ).resolves.toEqual(ctx.artifacts.checkpoint);
+  });
+
+  it("does not overwrite or remove when the exact checkpoint artifact changed", async () => {
+    const ctx = createContext();
+    await ctx.repository.saveInitializedLocalVault(ctx.artifacts);
+    const substitutedCheckpoint = {
+      ...ctx.artifacts.checkpoint,
+      signature: {
+        signature: encodeBase64Url(new Uint8Array(64).fill(7)),
+      },
+    };
+    await ctx.database.localVaultTrustCheckpoints.put({
+      vaultId: ctx.artifacts.descriptor.vaultId,
+      artifact: encodeLocalVaultTrustCheckpoint(substitutedCheckpoint),
+    });
+
+    await expect(
+      ctx.repository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: snapshotDigest(1),
+        expectedCheckpoint: ctx.artifacts.checkpoint,
+        snapshot: createNextSnapshot(ctx.artifacts.snapshot, 2),
+        checkpoint: createNextCheckpoint(ctx.artifacts.checkpoint, 2),
+      }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotChangedError);
+    await expect(
+      ctx.repository.removePersistedLocalVaultIfArtifactsMatch(
+        initializedVaultRemovalExpectation(ctx.artifacts),
+      ),
+    ).resolves.toBe(false);
+    await expect(ctx.database.vaultSnapshots.count()).resolves.toBe(1);
   });
 
   it("exposes all individual save, read, and idempotent remove operations", async () => {

--- a/apps/extension/src/adapters/storage/indexeddb-vault-local.repository.ts
+++ b/apps/extension/src/adapters/storage/indexeddb-vault-local.repository.ts
@@ -10,6 +10,7 @@ import type {
   CryptoPort,
 } from "@lfspm/core";
 import {
+  areJsonEqual,
   DeviceAccessMaterialChangedError,
   LocalVaultAlreadyInitializedError,
   LocalVaultSnapshotChangedError,
@@ -55,6 +56,20 @@ import {
 } from "../codecs/vault-snapshot.codec";
 
 const INITIAL_DEVICE_ACCESS_REVISION = 1;
+
+function areEncryptedSyncCredentialStatesEqual(
+  left: EncryptedDeviceSyncCredentialState | null,
+  right: EncryptedDeviceSyncCredentialState | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === null && right === null;
+  }
+
+  return (
+    left.ciphertext === right.ciphertext &&
+    left.encryptionNonce === right.encryptionNonce
+  );
+}
 
 type ErrorConstructor = new () => Error;
 
@@ -196,10 +211,22 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
     );
   }
 
-  async removePersistedLocalVaultIfSnapshotMatches(
-    vaultId: string,
-    expectedSnapshotDigest: string,
+  async removePersistedLocalVaultIfArtifactsMatch(
+    params: Parameters<
+      VaultLocalRepositoryPort["removePersistedLocalVaultIfArtifactsMatch"]
+    >[0],
   ): Promise<boolean> {
+    const { vaultId } = params;
+    const expectedDescriptorArtifact = encodeLocalVaultDescriptor(
+      params.expectedDescriptor,
+    );
+    const expectedMaterialArtifact = encodeDeviceAccessMaterial(
+      params.expectedDeviceAccessMaterial,
+    );
+    const expectedBackupArtifact = encodeDeviceAccessRecoveryBackup(
+      params.expectedDeviceAccessRecoveryBackup,
+    );
+
     return this.database.transaction(
       "rw",
       [
@@ -211,14 +238,47 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
         this.database.deviceSyncCredentialStates,
       ],
       async () => {
-        const [snapshotRecord, checkpointRecord] = await Promise.all([
+        const [
+          descriptorRecord,
+          materialRecord,
+          backupRecord,
+          snapshotRecord,
+          checkpointRecord,
+          syncCredentialRecord,
+        ] = await Promise.all([
+          this.database.localVaultDescriptors.get(vaultId),
+          this.database.deviceAccessMaterials.get(vaultId),
+          this.database.deviceAccessRecoveryBackups.get(vaultId),
           this.database.vaultSnapshots.get(vaultId),
           this.database.localVaultTrustCheckpoints.get(vaultId),
+          this.database.deviceSyncCredentialStates.get(vaultId),
         ]);
 
-        if (snapshotRecord === undefined || checkpointRecord === undefined) {
+        if (
+          descriptorRecord === undefined ||
+          materialRecord === undefined ||
+          backupRecord === undefined ||
+          snapshotRecord === undefined ||
+          checkpointRecord === undefined
+        ) {
           return false;
         }
+
+        const descriptorArtifact = storedVaultArtifactValue(
+          descriptorRecord,
+          vaultId,
+          InvalidLocalVaultSecurityRecordError,
+        );
+        const materialArtifact = storedVaultArtifactValue(
+          materialRecord,
+          vaultId,
+          InvalidLocalVaultSecurityRecordError,
+        );
+        const backupArtifact = storedVaultArtifactValue(
+          backupRecord,
+          vaultId,
+          InvalidLocalVaultSecurityRecordError,
+        );
 
         const snapshot = await this.decodeAndValidateVaultSnapshot(
           storedVaultArtifactValue(
@@ -237,12 +297,30 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
         const currentSnapshotDigest = await Dexie.waitFor(
           this.snapshotDigester.digestVaultSnapshot(snapshot),
         );
+        const currentSyncCredentialState =
+          syncCredentialRecord === undefined
+            ? null
+            : decodeEncryptedDeviceSyncCredentialState(
+                storedVaultArtifactValue(
+                  syncCredentialRecord,
+                  vaultId,
+                  InvalidSyncCredentialRecordError,
+                ),
+              );
 
         if (
           snapshot.metadata.id !== vaultId ||
           checkpoint.payload.vaultId !== vaultId ||
-          currentSnapshotDigest !== expectedSnapshotDigest ||
-          checkpoint.payload.snapshotDigest !== expectedSnapshotDigest
+          !areJsonEqual(descriptorArtifact, expectedDescriptorArtifact) ||
+          !areJsonEqual(materialArtifact, expectedMaterialArtifact) ||
+          !areJsonEqual(backupArtifact, expectedBackupArtifact) ||
+          currentSnapshotDigest !== params.expectedSnapshotDigest ||
+          checkpoint.payload.snapshotDigest !== params.expectedSnapshotDigest ||
+          !areJsonEqual(checkpoint, params.expectedCheckpoint) ||
+          !areEncryptedSyncCredentialStatesEqual(
+            currentSyncCredentialState,
+            params.expectedSyncCredentialState,
+          )
         ) {
           return false;
         }
@@ -474,12 +552,11 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
     await this.database.vaultSnapshots.delete(vaultId);
   }
 
-  async saveVaultSnapshotWithCheckpoint(params: {
-    readonly expectedSnapshotDigest: string;
-    readonly snapshot: VaultSnapshot;
-    readonly checkpoint: LocalVaultTrustCheckpoint;
-    readonly syncCredentialState?: EncryptedDeviceSyncCredentialState | null;
-  }): Promise<void> {
+  async saveVaultSnapshotWithCheckpoint(
+    params: Parameters<
+      VaultLocalRepositoryPort["saveVaultSnapshotWithCheckpoint"]
+    >[0],
+  ): Promise<void> {
     const vaultId = params.snapshot.metadata.id;
 
     if (params.checkpoint.payload.vaultId !== vaultId) {
@@ -495,6 +572,22 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
       params.syncCredentialState === null
         ? params.syncCredentialState
         : encodeEncryptedDeviceSyncCredentialState(params.syncCredentialState);
+    const replacesSyncCredentialState =
+      params.syncCredentialState !== undefined;
+    const hasSyncCredentialState = Object.hasOwn(params, "syncCredentialState");
+    const hasExpectedSyncCredentialState = Object.hasOwn(
+      params,
+      "expectedSyncCredentialState",
+    );
+
+    if (
+      hasSyncCredentialState !== replacesSyncCredentialState ||
+      hasExpectedSyncCredentialState !== replacesSyncCredentialState ||
+      (replacesSyncCredentialState &&
+        params.expectedSyncCredentialState === undefined)
+    ) {
+      throw new InvalidLocalVaultSecurityRecordError();
+    }
 
     await this.database.transaction(
       "rw",
@@ -502,10 +595,14 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
       this.database.localVaultTrustCheckpoints,
       this.database.deviceSyncCredentialStates,
       async () => {
-        const [snapshotRecord, checkpointRecord] = await Promise.all([
-          this.database.vaultSnapshots.get(vaultId),
-          this.database.localVaultTrustCheckpoints.get(vaultId),
-        ]);
+        const [snapshotRecord, checkpointRecord, syncCredentialRecord] =
+          await Promise.all([
+            this.database.vaultSnapshots.get(vaultId),
+            this.database.localVaultTrustCheckpoints.get(vaultId),
+            replacesSyncCredentialState
+              ? this.database.deviceSyncCredentialStates.get(vaultId)
+              : Promise.resolve(undefined),
+          ]);
 
         if (snapshotRecord === undefined || checkpointRecord === undefined) {
           throw new LocalVaultSnapshotChangedError(vaultId);
@@ -528,13 +625,27 @@ export class IndexedDbVaultLocalRepository implements VaultLocalRepositoryPort {
         const currentSnapshotDigest = await Dexie.waitFor(
           this.snapshotDigester.digestVaultSnapshot(currentSnapshot),
         );
+        const currentSyncCredentialState =
+          syncCredentialRecord === undefined
+            ? null
+            : decodeEncryptedDeviceSyncCredentialState(
+                storedVaultArtifactValue(
+                  syncCredentialRecord,
+                  vaultId,
+                  InvalidSyncCredentialRecordError,
+                ),
+              );
 
         if (
           currentSnapshot.metadata.id !== vaultId ||
           currentCheckpoint.payload.vaultId !== vaultId ||
           currentSnapshotDigest !== params.expectedSnapshotDigest ||
-          currentCheckpoint.payload.snapshotDigest !==
-            params.expectedSnapshotDigest
+          !areJsonEqual(currentCheckpoint, params.expectedCheckpoint) ||
+          (replacesSyncCredentialState &&
+            !areEncryptedSyncCredentialStatesEqual(
+              currentSyncCredentialState,
+              params.expectedSyncCredentialState ?? null,
+            ))
         ) {
           throw new LocalVaultSnapshotChangedError(vaultId);
         }

--- a/apps/extension/src/adapters/storage/vault-artifact.codec.test.ts
+++ b/apps/extension/src/adapters/storage/vault-artifact.codec.test.ts
@@ -4,6 +4,7 @@ import {
   type Vault,
   type VaultSnapshot,
   type VaultSnapshotDescriptor,
+  type VaultSnapshotIdentity,
 } from "@lfspm/core";
 import { WebCryptoPort } from "../crypto/web-crypto.port";
 import { encodeVersionVector } from "../codecs/artifact-codec.primitives";
@@ -17,6 +18,8 @@ import {
   encodeVaultSnapshot,
   encodeVaultSnapshotDescriptor,
 } from "../codecs/vault-snapshot.codec";
+
+const canonicalSnapshotDigest = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
 describe("vault snapshot artifact codec", () => {
   it("encodes version-vector keys in locale-independent code-unit order", () => {
@@ -82,6 +85,38 @@ describe("vault snapshot artifact codec", () => {
   });
 
   it.each([
+    null,
+    {
+      descriptor: {
+        vaultId: "vault-id",
+        snapshotVersionVector: { "device-id": 1 },
+        revisionTimestamp: 1,
+      },
+      snapshotDigest: canonicalSnapshotDigest,
+    },
+  ] satisfies readonly (VaultSnapshotIdentity | null)[])(
+    "round-trips the nullable signed upload expectation %#",
+    async (uploadExpectedRemoteSnapshotIdentity) => {
+      const snapshot = await createSnapshot();
+      const snapshotWithExpectation: VaultSnapshot = {
+        ...snapshot,
+        metadata: {
+          ...snapshot.metadata,
+          uploadExpectedRemoteSnapshotIdentity,
+        },
+      };
+      const encoded = encodeVaultSnapshot(snapshotWithExpectation);
+
+      expect(decodeVaultSnapshot(encoded, "local").metadata).toEqual(
+        snapshotWithExpectation.metadata,
+      );
+      expect(
+        encodeVaultSnapshot(decodeVaultSnapshot(encoded, "local")),
+      ).toEqual(encoded);
+    },
+  );
+
+  it.each([
     "older schema",
     "future schema",
     "missing field",
@@ -92,6 +127,9 @@ describe("vault snapshot artifact codec", () => {
     "malformed ciphertext",
     "duplicate trusted device",
     "duplicate key slot",
+    "malformed upload expectation",
+    "wrong-length upload digest",
+    "noncanonical upload digest",
   ])("rejects %s before returning a local snapshot", async (variant) => {
     const artifact = cloneArtifact(encodeVaultSnapshot(await createSnapshot()));
     const metadata = record(artifact.metadata);
@@ -138,6 +176,37 @@ describe("vault snapshot artifact codec", () => {
         break;
       case "duplicate key slot":
         slots.push(structuredClone(slots[0]));
+        break;
+      case "malformed upload expectation":
+        metadata.uploadExpectedRemoteSnapshotIdentity = {
+          descriptor: {
+            vaultId: "vault-id",
+            snapshotVersionVector: { "device-id": 1 },
+            revisionTimestamp: 1,
+          },
+          snapshotDigest: canonicalSnapshotDigest,
+          futureField: true,
+        };
+        break;
+      case "wrong-length upload digest":
+        metadata.uploadExpectedRemoteSnapshotIdentity = {
+          descriptor: {
+            vaultId: "vault-id",
+            snapshotVersionVector: { "device-id": 1 },
+            revisionTimestamp: 1,
+          },
+          snapshotDigest: "AAAA",
+        };
+        break;
+      case "noncanonical upload digest":
+        metadata.uploadExpectedRemoteSnapshotIdentity = {
+          descriptor: {
+            vaultId: "vault-id",
+            snapshotVersionVector: { "device-id": 1 },
+            revisionTimestamp: 1,
+          },
+          snapshotDigest: `${canonicalSnapshotDigest}=`,
+        };
         break;
     }
 

--- a/apps/extension/src/adapters/sync/aws-s3-sync-provider.test.ts
+++ b/apps/extension/src/adapters/sync/aws-s3-sync-provider.test.ts
@@ -11,6 +11,7 @@ import type {
   SyncSetupInput,
   VaultSnapshot,
   VaultSnapshotDescriptor,
+  VaultSnapshotIdentity,
 } from "@lfspm/core";
 import type { Base64URLString } from "@lfspm/core/lib";
 import type { AsymmetricKeyValidator } from "../crypto";
@@ -44,6 +45,11 @@ const descriptor: VaultSnapshotDescriptor = {
   vaultId: "vault/id",
   snapshotVersionVector: { "device-id": 3 },
   revisionTimestamp: 47,
+};
+const snapshotDigest = "snapshot-digest";
+const expectedRemoteSnapshotIdentity: VaultSnapshotIdentity = {
+  descriptor,
+  snapshotDigest,
 };
 
 const b64 = (value: string) => value as Base64URLString;
@@ -132,6 +138,42 @@ const syncAccess: SyncAccess = {
     },
   },
 };
+
+async function uploadVaultSnapshot(
+  provider: AwsS3SyncProvider,
+  access: SyncAccess,
+  candidate: VaultSnapshot,
+  expectedRemoteIdentity: VaultSnapshotIdentity | null,
+) {
+  const prepared = await provider.prepareVaultSnapshotUpload(
+    access,
+    candidate,
+    expectedRemoteIdentity,
+  );
+
+  if (prepared.status === "not_started") {
+    return prepared.outcome;
+  }
+
+  return prepared.start().outcome;
+}
+
+async function removeVaultSnapshots(
+  provider: AwsS3SyncProvider,
+  access: SyncAccess,
+  vaultId: string,
+  expectedRemoteIdentity: VaultSnapshotIdentity | null,
+): Promise<void> {
+  const prepared = await provider.prepareVaultSnapshotRemoval(
+    access,
+    vaultId,
+    expectedRemoteIdentity,
+  );
+
+  if (prepared.status === "ready") {
+    await prepared.start().outcome;
+  }
+}
 
 class HostileSetupInput {
   readonly provider = "aws-s3-v1" as const;
@@ -665,7 +707,9 @@ describe("AwsS3SyncProvider", () => {
     const client = createClient();
     const provider = createTestProvider(client);
 
-    await provider.uploadVaultSnapshot(syncAccess, snapshot, null);
+    await expect(
+      uploadVaultSnapshot(provider, syncAccess, snapshot, null),
+    ).resolves.toEqual({ status: "committed" });
 
     expect(client.getObject).not.toHaveBeenCalled();
     expect(client.putObject).toHaveBeenCalledWith({
@@ -684,11 +728,69 @@ describe("AwsS3SyncProvider", () => {
     );
     const provider = createTestProvider(client);
 
-    await provider.uploadVaultSnapshot(syncAccess, snapshot, descriptor);
+    const prepared = await provider.prepareVaultSnapshotUpload(
+      syncAccess,
+      snapshot,
+      expectedRemoteSnapshotIdentity,
+    );
+
+    expect(client.getObject).toHaveBeenCalledOnce();
+    expect(client.putObject).not.toHaveBeenCalled();
+    expect(prepared.status).toBe("ready");
+
+    if (prepared.status !== "ready") {
+      throw new Error("Expected a prepared conditional upload.");
+    }
+
+    const started = prepared.start();
+    expect(client.putObject).toHaveBeenCalledOnce();
+    await expect(started.outcome).resolves.toEqual({ status: "committed" });
 
     expect(client.putObject).toHaveBeenCalledWith(
       expect.objectContaining({ IfMatch: '"remote-etag"' }),
     );
+  });
+
+  it("does not replace a same-descriptor object with a different digest", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor, '"remote-etag"'),
+    );
+    const provider = createTestProvider(client, "substituted-snapshot-digest");
+
+    await expect(
+      uploadVaultSnapshot(
+        provider,
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).resolves.toEqual({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
+    expect(client.putObject).not.toHaveBeenCalled();
+  });
+
+  it("classifies a mismatched upload before requiring an ETag", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor),
+    );
+    const provider = createTestProvider(client, "substituted-snapshot-digest");
+
+    await expect(
+      uploadVaultSnapshot(
+        provider,
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).resolves.toEqual({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
+    expect(client.putObject).not.toHaveBeenCalled();
   });
 
   it("rejects a matching upload record without an ETag before writing", async () => {
@@ -699,24 +801,261 @@ describe("AwsS3SyncProvider", () => {
     const provider = createTestProvider(client);
 
     await expect(
-      provider.uploadVaultSnapshot(syncAccess, snapshot, descriptor),
+      provider.prepareVaultSnapshotUpload(
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
     ).rejects.toBeInstanceOf(codec.InvalidRemoteVaultSnapshotRecordError);
     expect(client.putObject).not.toHaveBeenCalled();
   });
 
-  it("maps conditional put conflicts to the core conflict error", async () => {
+  it("reports a mismatched expected vault as definitely not committed before remote access", async () => {
+    const client = createClient();
+    const provider = createTestProvider(client);
+
+    await expect(
+      uploadVaultSnapshot(provider, syncAccess, snapshot, {
+        ...expectedRemoteSnapshotIdentity,
+        descriptor: {
+          ...descriptor,
+          vaultId: "other-vault",
+        },
+      }),
+    ).resolves.toEqual({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
+    expect(client.getObject).not.toHaveBeenCalled();
+    expect(client.putObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["precondition failure", "PreconditionFailed", 412],
+    ["conditional conflict", "ConditionalRequestConflict", 409],
+    ["concurrent removal", "NoSuchKey", 404],
+  ])(
+    "maps a single-attempt %s to a definite non-commit",
+    async (_case, name, status) => {
+      const client = createClient();
+      vi.mocked(client.getObject).mockResolvedValueOnce(
+        remoteResponse(descriptor, '"remote-etag"'),
+      );
+      vi.mocked(client.putObject).mockRejectedValueOnce(
+        awsError(name, status, 1),
+      );
+      const provider = createTestProvider(client);
+
+      await expect(
+        uploadVaultSnapshot(
+          provider,
+          syncAccess,
+          snapshot,
+          expectedRemoteSnapshotIdentity,
+        ),
+      ).resolves.toEqual({
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      });
+    },
+  );
+
+  it.each([
+    ["missing bucket", "NoSuchBucket", 404],
+    ["authorization rejection", "AccessDenied", 403],
+    ["invalid request", "InvalidRequest", 400],
+  ])(
+    "maps a single-attempt %s to a definite provider rejection",
+    async (_case, name, status) => {
+      const client = createClient();
+      vi.mocked(client.getObject).mockResolvedValueOnce(
+        remoteResponse(descriptor, '"remote-etag"'),
+      );
+      vi.mocked(client.putObject).mockRejectedValueOnce(
+        awsError(name, status, 1),
+      );
+      const provider = createTestProvider(client);
+
+      await expect(
+        uploadVaultSnapshot(
+          provider,
+          syncAccess,
+          snapshot,
+          expectedRemoteSnapshotIdentity,
+        ),
+      ).resolves.toEqual({
+        status: "definitely_not_committed",
+        reason: "provider_rejected",
+      });
+    },
+  );
+
+  it.each([
+    ["missing attempt metadata", undefined],
+    ["multiple attempts", 2],
+  ])(
+    "keeps a conditional failure outcome unknown with %s",
+    async (_case, attempts) => {
+      const client = createClient();
+      vi.mocked(client.getObject).mockResolvedValueOnce(
+        remoteResponse(descriptor, '"remote-etag"'),
+      );
+      vi.mocked(client.putObject).mockRejectedValueOnce(
+        awsError("PreconditionFailed", 412, attempts),
+      );
+      const provider = createTestProvider(client);
+
+      await expect(
+        uploadVaultSnapshot(
+          provider,
+          syncAccess,
+          snapshot,
+          expectedRemoteSnapshotIdentity,
+        ),
+      ).resolves.toEqual({ status: "outcome_unknown" });
+    },
+  );
+
+  it("keeps a generic put failure outcome unknown", async () => {
     const client = createClient();
     vi.mocked(client.getObject).mockResolvedValueOnce(
       remoteResponse(descriptor, '"remote-etag"'),
     );
     vi.mocked(client.putObject).mockRejectedValueOnce(
-      awsError("PreconditionFailed", 412),
+      new Error("network unavailable"),
     );
     const provider = createTestProvider(client);
 
     await expect(
-      provider.uploadVaultSnapshot(syncAccess, snapshot, descriptor),
-    ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+      uploadVaultSnapshot(
+        provider,
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).resolves.toEqual({ status: "outcome_unknown" });
+  });
+
+  it.each([
+    ["status-only conflict", 409],
+    ["status-only not found", 404],
+  ])(
+    "maps a single-attempt conditional %s to a remote change",
+    async (_case, status) => {
+      const client = createClient();
+      vi.mocked(client.getObject).mockResolvedValueOnce(
+        remoteResponse(descriptor, '"remote-etag"'),
+      );
+      vi.mocked(client.putObject).mockRejectedValueOnce({
+        $metadata: { httpStatusCode: status, attempts: 1 },
+      });
+      const provider = createTestProvider(client);
+
+      await expect(
+        uploadVaultSnapshot(
+          provider,
+          syncAccess,
+          snapshot,
+          expectedRemoteSnapshotIdentity,
+        ),
+      ).resolves.toEqual({
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      });
+    },
+  );
+
+  it.each([
+    ["request timeout", "RequestTimeout", 400],
+    ["rate limit", "TooManyRequests", 429],
+  ])(
+    "keeps a single-attempt %s outcome unknown",
+    async (_case, name, status) => {
+      const client = createClient();
+      vi.mocked(client.getObject).mockResolvedValueOnce(
+        remoteResponse(descriptor, '"remote-etag"'),
+      );
+      vi.mocked(client.putObject).mockRejectedValueOnce(
+        awsError(name, status, 1),
+      );
+      const provider = createTestProvider(client);
+
+      await expect(
+        uploadVaultSnapshot(
+          provider,
+          syncAccess,
+          snapshot,
+          expectedRemoteSnapshotIdentity,
+        ),
+      ).resolves.toEqual({ status: "outcome_unknown" });
+    },
+  );
+
+  it("keeps a retried provider rejection outcome unknown", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor, '"remote-etag"'),
+    );
+    vi.mocked(client.putObject).mockRejectedValueOnce(
+      awsError("NoSuchBucket", 404, 2),
+    );
+    const provider = createTestProvider(client);
+
+    await expect(
+      uploadVaultSnapshot(
+        provider,
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).resolves.toEqual({ status: "outcome_unknown" });
+  });
+
+  it("keeps the outcome unknown when a hostile put rejection cannot be inspected", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor, '"remote-etag"'),
+    );
+    const hostileError = Object.defineProperty({}, "$metadata", {
+      get() {
+        throw new Error("metadata access denied");
+      },
+    });
+    vi.mocked(client.putObject).mockRejectedValueOnce(hostileError);
+    const provider = createTestProvider(client);
+
+    await expect(
+      uploadVaultSnapshot(
+        provider,
+        syncAccess,
+        snapshot,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).resolves.toEqual({ status: "outcome_unknown" });
+  });
+
+  it("reports outcome unknown when the remote commit succeeds before the local response fails", async () => {
+    const client = createClient();
+    let remoteCommitted = false;
+    vi.mocked(client.putObject).mockImplementationOnce(async () => {
+      remoteCommitted = true;
+      throw new Error("response lost after commit");
+    });
+    vi.mocked(client.getObject).mockImplementationOnce(async () => {
+      if (!remoteCommitted) {
+        throw awsError("NoSuchKey", 404, 1);
+      }
+
+      return remoteResponse(descriptor, '"committed-etag"');
+    });
+    const provider = createTestProvider(client);
+
+    await expect(
+      uploadVaultSnapshot(provider, syncAccess, snapshot, null),
+    ).resolves.toEqual({ status: "outcome_unknown" });
+    await expect(
+      provider.getLatestVaultSnapshotDescriptor(syncAccess, descriptor.vaultId),
+    ).resolves.toEqual(descriptor);
   });
 
   it("conditionally removes matching state and treats absence as success", async () => {
@@ -726,15 +1065,28 @@ describe("AwsS3SyncProvider", () => {
       .mockRejectedValueOnce(awsError("NoSuchKey", 404));
     const provider = createTestProvider(client);
 
-    await provider.removeVaultSnapshots(
+    const prepared = await provider.prepareVaultSnapshotRemoval(
       syncAccess,
       descriptor.vaultId,
-      descriptor,
+      expectedRemoteSnapshotIdentity,
     );
-    await provider.removeVaultSnapshots(
+
+    expect(client.getObject).toHaveBeenCalledOnce();
+    expect(client.deleteObject).not.toHaveBeenCalled();
+    expect(prepared.status).toBe("ready");
+
+    if (prepared.status !== "ready") {
+      throw new Error("Expected a prepared conditional removal.");
+    }
+
+    const started = prepared.start();
+    expect(client.deleteObject).toHaveBeenCalledOnce();
+    await started.outcome;
+    await removeVaultSnapshots(
+      provider,
       syncAccess,
       descriptor.vaultId,
-      descriptor,
+      expectedRemoteSnapshotIdentity,
     );
 
     expect(client.deleteObject).toHaveBeenCalledOnce();
@@ -753,7 +1105,11 @@ describe("AwsS3SyncProvider", () => {
     const provider = createTestProvider(client);
 
     await expect(
-      provider.removeVaultSnapshots(syncAccess, descriptor.vaultId, descriptor),
+      provider.prepareVaultSnapshotRemoval(
+        syncAccess,
+        descriptor.vaultId,
+        expectedRemoteSnapshotIdentity,
+      ),
     ).rejects.toBeInstanceOf(codec.InvalidRemoteVaultSnapshotRecordError);
     expect(client.deleteObject).not.toHaveBeenCalled();
   });
@@ -766,7 +1122,43 @@ describe("AwsS3SyncProvider", () => {
     const provider = createTestProvider(client);
 
     await expect(
-      provider.removeVaultSnapshots(syncAccess, descriptor.vaultId, null),
+      removeVaultSnapshots(provider, syncAccess, descriptor.vaultId, null),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    expect(client.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("does not delete same-descriptor state with a different digest", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor, '"remote-etag"'),
+    );
+    const provider = createTestProvider(client, "different-snapshot-digest");
+
+    await expect(
+      removeVaultSnapshots(
+        provider,
+        syncAccess,
+        descriptor.vaultId,
+        expectedRemoteSnapshotIdentity,
+      ),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    expect(client.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("classifies a mismatched removal before requiring an ETag", async () => {
+    const client = createClient();
+    vi.mocked(client.getObject).mockResolvedValueOnce(
+      remoteResponse(descriptor),
+    );
+    const provider = createTestProvider(client, "different-snapshot-digest");
+
+    await expect(
+      removeVaultSnapshots(
+        provider,
+        syncAccess,
+        descriptor.vaultId,
+        expectedRemoteSnapshotIdentity,
+      ),
     ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
     expect(client.deleteObject).not.toHaveBeenCalled();
   });
@@ -779,7 +1171,12 @@ describe("AwsS3SyncProvider", () => {
     const provider = createTestProvider(client);
 
     await expect(
-      provider.removeVaultSnapshots(syncAccess, "other-vault", descriptor),
+      removeVaultSnapshots(
+        provider,
+        syncAccess,
+        "other-vault",
+        expectedRemoteSnapshotIdentity,
+      ),
     ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
     expect(client.deleteObject).not.toHaveBeenCalled();
   });
@@ -853,10 +1250,14 @@ function createClientFactory(client: S3SyncClient): S3SyncClientFactory {
   return vi.fn(() => client);
 }
 
-function createTestProvider(client: S3SyncClient): AwsS3SyncProvider {
+function createTestProvider(
+  client: S3SyncClient,
+  remoteSnapshotDigest = snapshotDigest,
+): AwsS3SyncProvider {
   return new AwsS3SyncProvider(
     createClientFactory(client),
     asymmetricKeyValidator,
+    { digestVaultSnapshot: vi.fn(async () => remoteSnapshotDigest) },
   );
 }
 
@@ -925,9 +1326,12 @@ function remoteResponse(
   );
 }
 
-function awsError(name: string, httpStatusCode: number) {
+function awsError(name: string, httpStatusCode: number, attempts?: number) {
   return Object.assign(new Error(name), {
     name,
-    $metadata: { httpStatusCode },
+    $metadata: {
+      httpStatusCode,
+      ...(attempts === undefined ? {} : { attempts }),
+    },
   });
 }

--- a/apps/extension/src/adapters/sync/aws-s3-sync-provider.ts
+++ b/apps/extension/src/adapters/sync/aws-s3-sync-provider.ts
@@ -11,14 +11,21 @@ import {
   toVaultSnapshotDescriptor,
 } from "@lfspm/core";
 import type {
+  DefiniteSyncUploadNonCommit,
   SyncAccess,
+  PreparedSyncRemoval,
+  PreparedSyncUpload,
   SyncProviderPort,
   SyncSetupInput,
+  SyncUploadOutcome,
+  CryptoPort,
   VaultSnapshot,
   VaultSnapshotDescriptor,
+  VaultSnapshotIdentity,
 } from "@lfspm/core";
 import {
   WebCryptoAsymmetricKeyValidator,
+  WebCryptoPort,
   validateVaultSnapshotPublicKeys,
   type AsymmetricKeyValidator,
 } from "../crypto";
@@ -97,7 +104,17 @@ const DEFINITIVE_CREDENTIAL_REJECTION_CODES = new Set([
 const NOT_FOUND_ERROR_CODES = new Set(["NoSuchKey", "NotFound"]);
 const CONDITIONAL_CONFLICT_ERROR_CODES = new Set([
   "ConditionalRequestConflict",
+  "OperationAborted",
   "PreconditionFailed",
+]);
+const DEFINITIVE_UPLOAD_REJECTION_CODES = new Set([
+  "AccessDenied",
+  "AuthorizationHeaderMalformed",
+  "InvalidAccessKeyId",
+  "InvalidBucketName",
+  "InvalidRequest",
+  "NoSuchBucket",
+  "SignatureDoesNotMatch",
 ]);
 
 export class InvalidSyncProviderResponseError extends Error {
@@ -111,13 +128,19 @@ export class InvalidSyncProviderResponseError extends Error {
 export class AwsS3SyncProvider implements SyncProviderPort {
   private readonly createClient: S3SyncClientFactory;
   private readonly asymmetricKeyValidator: AsymmetricKeyValidator;
+  private readonly snapshotDigester: Pick<CryptoPort, "digestVaultSnapshot">;
 
   constructor(
     createClient: S3SyncClientFactory = createAwsS3Client,
     asymmetricKeyValidator: AsymmetricKeyValidator = new WebCryptoAsymmetricKeyValidator(),
+    snapshotDigester: Pick<
+      CryptoPort,
+      "digestVaultSnapshot"
+    > = new WebCryptoPort(),
   ) {
     this.createClient = createClient;
     this.asymmetricKeyValidator = asymmetricKeyValidator;
+    this.snapshotDigester = snapshotDigester;
   }
 
   async setup(syncConfig: SyncSetupInput): Promise<SyncAccess> {
@@ -152,11 +175,11 @@ export class AwsS3SyncProvider implements SyncProviderPort {
     return remote.snapshot;
   }
 
-  async uploadVaultSnapshot(
+  async prepareVaultSnapshotUpload(
     syncAccess: SyncAccess,
     vaultSnapshot: VaultSnapshot,
-    expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
-  ): Promise<void> {
+    expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
+  ): Promise<PreparedSyncUpload> {
     const vaultId = vaultSnapshot.metadata.id;
     const { client, location } = createOperationContext(
       syncAccess,
@@ -168,57 +191,67 @@ export class AwsS3SyncProvider implements SyncProviderPort {
       snapshot: vaultSnapshot,
     });
 
-    try {
-      if (expectedRemoteSnapshotDescriptor === null) {
-        await client.putObject({
+    if (expectedRemoteSnapshotIdentity === null) {
+      return {
+        status: "ready",
+        start: () => ({
+          outcome: uploadRemoteVaultSnapshot(client, {
+            ...location,
+            Body: body,
+            ContentType: JSON_CONTENT_TYPE,
+            IfNoneMatch: "*",
+          }),
+        }),
+      };
+    }
+
+    if (expectedRemoteSnapshotIdentity.descriptor.vaultId !== vaultId) {
+      return {
+        status: "not_started",
+        outcome: remoteSnapshotChangedUploadOutcome(),
+      };
+    }
+
+    const current = await getRemoteVaultSnapshotObject(
+      client,
+      location,
+      this.asymmetricKeyValidator,
+    );
+
+    if (
+      current === null ||
+      !areVaultSnapshotDescriptorsEqual(
+        current.descriptor,
+        expectedRemoteSnapshotIdentity.descriptor,
+      ) ||
+      (await this.snapshotDigester.digestVaultSnapshot(current.snapshot)) !==
+        expectedRemoteSnapshotIdentity.snapshotDigest
+    ) {
+      return {
+        status: "not_started",
+        outcome: remoteSnapshotChangedUploadOutcome(),
+      };
+    }
+    const currentEtag = requireEtag(current);
+
+    return {
+      status: "ready",
+      start: () => ({
+        outcome: uploadRemoteVaultSnapshot(client, {
           ...location,
           Body: body,
           ContentType: JSON_CONTENT_TYPE,
-          IfNoneMatch: "*",
-        });
-        return;
-      }
-
-      if (expectedRemoteSnapshotDescriptor.vaultId !== vaultId) {
-        throw new RemoteVaultSnapshotChangedError(vaultId);
-      }
-
-      const current = await getRemoteVaultSnapshotObject(
-        client,
-        location,
-        this.asymmetricKeyValidator,
-      );
-
-      if (
-        current === null ||
-        !areVaultSnapshotDescriptorsEqual(
-          current.descriptor,
-          expectedRemoteSnapshotDescriptor,
-        )
-      ) {
-        throw new RemoteVaultSnapshotChangedError(vaultId);
-      }
-
-      await client.putObject({
-        ...location,
-        Body: body,
-        ContentType: JSON_CONTENT_TYPE,
-        IfMatch: requireEtag(current),
-      });
-    } catch (error) {
-      if (isConditionalConflict(error)) {
-        throw new RemoteVaultSnapshotChangedError(vaultId);
-      }
-
-      throw error;
-    }
+          IfMatch: currentEtag,
+        }),
+      }),
+    };
   }
 
-  async removeVaultSnapshots(
+  async prepareVaultSnapshotRemoval(
     syncAccess: SyncAccess,
     vaultId: string,
-    expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
-  ): Promise<void> {
+    expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
+  ): Promise<PreparedSyncRemoval> {
     const { client, location } = createOperationContext(
       syncAccess,
       this.createClient,
@@ -230,37 +263,33 @@ export class AwsS3SyncProvider implements SyncProviderPort {
     );
 
     if (current === null) {
-      return;
+      return { status: "already_absent" };
     }
 
     if (
-      expectedRemoteSnapshotDescriptor === null ||
-      expectedRemoteSnapshotDescriptor.vaultId !== vaultId ||
+      expectedRemoteSnapshotIdentity === null ||
+      expectedRemoteSnapshotIdentity.descriptor.vaultId !== vaultId ||
       current.descriptor.vaultId !== vaultId ||
       !areVaultSnapshotDescriptorsEqual(
         current.descriptor,
-        expectedRemoteSnapshotDescriptor,
-      )
+        expectedRemoteSnapshotIdentity.descriptor,
+      ) ||
+      (await this.snapshotDigester.digestVaultSnapshot(current.snapshot)) !==
+        expectedRemoteSnapshotIdentity.snapshotDigest
     ) {
       throw new RemoteVaultSnapshotChangedError(vaultId);
     }
+    const currentEtag = requireEtag(current);
 
-    try {
-      await client.deleteObject({
-        ...location,
-        IfMatch: requireEtag(current),
-      });
-    } catch (error) {
-      if (isNotFound(error)) {
-        return;
-      }
-
-      if (isConditionalConflict(error)) {
-        throw new RemoteVaultSnapshotChangedError(vaultId);
-      }
-
-      throw error;
-    }
+    return {
+      status: "ready",
+      start: () => ({
+        outcome: removeRemoteVaultSnapshot(client, vaultId, {
+          ...location,
+          IfMatch: currentEtag,
+        }),
+      }),
+    };
   }
 
   async checkVaultAccess(
@@ -316,6 +345,102 @@ export class AwsS3SyncProvider implements SyncProviderPort {
 
     return remote;
   }
+}
+
+async function uploadRemoteVaultSnapshot(
+  client: S3SyncClient,
+  input: Parameters<S3SyncClient["putObject"]>[0],
+): Promise<SyncUploadOutcome> {
+  try {
+    await client.putObject(input);
+    return { status: "committed" };
+  } catch (error) {
+    return classifyRemoteUploadFailure(error, input);
+  }
+}
+
+async function removeRemoteVaultSnapshot(
+  client: S3SyncClient,
+  vaultId: string,
+  input: Parameters<S3SyncClient["deleteObject"]>[0],
+): Promise<void> {
+  try {
+    await client.deleteObject(input);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return;
+    }
+
+    if (isConditionalConflict(error)) {
+      throw new RemoteVaultSnapshotChangedError(vaultId);
+    }
+
+    throw error;
+  }
+}
+
+function classifyRemoteUploadFailure(
+  error: unknown,
+  input: Parameters<S3SyncClient["putObject"]>[0],
+): SyncUploadOutcome {
+  try {
+    if (isDefiniteConditionalUploadNonCommit(error, input)) {
+      return remoteSnapshotChangedUploadOutcome();
+    }
+
+    if (isDefiniteProviderUploadRejection(error)) {
+      return providerRejectedUploadOutcome();
+    }
+  } catch {
+    // Provider rejection objects are untrusted. Inspection failure cannot prove
+    // that an initiated write did not commit.
+  }
+
+  return { status: "outcome_unknown" };
+}
+
+function isDefiniteProviderUploadRejection(error: unknown): boolean {
+  return (
+    getRequestAttempts(error) === 1 &&
+    DEFINITIVE_UPLOAD_REJECTION_CODES.has(getErrorCode(error) ?? "")
+  );
+}
+
+function isDefiniteConditionalUploadNonCommit(
+  error: unknown,
+  input: Parameters<S3SyncClient["putObject"]>[0],
+): boolean {
+  if (getRequestAttempts(error) !== 1) {
+    return false;
+  }
+
+  const errorCode = getErrorCode(error);
+  const status = getHttpStatusCode(error);
+  return (
+    status === 409 ||
+    status === 412 ||
+    (status === 404 &&
+      input.IfMatch !== undefined &&
+      (errorCode === undefined || NOT_FOUND_ERROR_CODES.has(errorCode))) ||
+    errorCode === "PreconditionFailed" ||
+    errorCode === "ConditionalRequestConflict" ||
+    errorCode === "OperationAborted" ||
+    (errorCode === "NoSuchKey" && input.IfMatch !== undefined)
+  );
+}
+
+function remoteSnapshotChangedUploadOutcome(): DefiniteSyncUploadNonCommit {
+  return {
+    status: "definitely_not_committed",
+    reason: "remote_snapshot_changed",
+  };
+}
+
+function providerRejectedUploadOutcome(): SyncUploadOutcome {
+  return {
+    status: "definitely_not_committed",
+    reason: "provider_rejected",
+  };
 }
 
 function createAwsS3Client(
@@ -593,6 +718,21 @@ function getHttpStatusCode(error: unknown): number | undefined {
 
   const status = (metadata as Record<string, unknown>).httpStatusCode;
   return typeof status === "number" ? status : undefined;
+}
+
+function getRequestAttempts(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const metadata = (error as Record<string, unknown>).$metadata;
+
+  if (typeof metadata !== "object" || metadata === null) {
+    return undefined;
+  }
+
+  const attempts = (metadata as Record<string, unknown>).attempts;
+  return typeof attempts === "number" ? attempts : undefined;
 }
 
 function getErrorCode(error: unknown): string | undefined {

--- a/docs/design/multi-device-setup.md
+++ b/docs/design/multi-device-setup.md
@@ -89,22 +89,29 @@ The target persists its access material, recovery backup, snapshot, trust
 checkpoint, and encrypted local credential state as one initialization step.
 Pending request state is removed only after that step succeeds.
 If session activation fails after initialization, those new local vault records
-are removed while the pending request remains available for a safe retry.
+are removed on a best-effort basis only while the complete initialized artifact
+set still matches; the pending request remains available for a safe retry.
 Completion also rejects a retained response when that vault is already
 initialized locally, so retrying stale pending state cannot replace newer local
 vault records.
-After a definitive remote compare-and-set rejection, rollback removes the
-newly initialized records only if the active session version and persisted
-snapshot digest still match the enrollment snapshot. If either has advanced,
-or cleanup otherwise fails, completion preserves the local records and reports
-an incomplete rollback instead of claiming that the retained request is
-immediately retryable.
+After a definite upload non-commit—either a remote compare-and-set change or a
+recognized provider rejection—rollback removes the newly initialized records
+only if the active session version and every initialized local artifact still
+match the enrollment attempt: exact descriptor, device access material,
+recovery backup, persisted snapshot digest, signed trust checkpoint, and
+encrypted upload intent. The repository compares that deletion set atomically
+before removing any record. A
+reconciler refreshes or clears that artifact before acting, so a stale
+enrollment failure cannot delete state another attempt has reconciled. If any
+expectation has advanced, or cleanup otherwise fails, completion preserves the
+local records and reports an incomplete rollback instead of claiming that the
+retained request is immediately retryable.
 
 If the provider cannot confirm whether the completed snapshot upload succeeded,
 local enrollment still completes and returns the recovery mnemonic with sync
 upload marked pending. The next normal sync reconciles the signed local
-snapshot. A definite remote compare-and-set rejection rolls local enrollment
-back instead.
+snapshot. A definite non-commit, whether caused by a remote compare-and-set
+change or a recognized provider rejection, rolls local enrollment back instead.
 
 Existing devices learn about the new identity through a dedicated
 enrollment-consumption review. The workflow verifies an addition-only trust

--- a/docs/design/sync-strategy.md
+++ b/docs/design/sync-strategy.md
@@ -7,7 +7,8 @@
 
 A vault without sync configured operates locally and permits offline mutations.
 Once sync is configured, every mutation requires network access and an exact
-match between the verified local snapshot and the current remote descriptor.
+match between the verified local snapshot and the current remote snapshot
+identity (descriptor plus cryptographic digest).
 This synchronized mode assumes one user operates one device at a time.
 
 The remote object coordinates synchronized state but remains hostile storage.
@@ -16,13 +17,13 @@ and read behavior is unchanged by the mutation gate.
 
 Before a synchronized mutation, descriptor relations are handled as follows:
 
-| Relation                    | Behavior                                                         |
-| --------------------------- | ---------------------------------------------------------------- |
-| Exact descriptor equality   | Permit the mutation                                              |
-| `remote_ahead`              | Block and require explicit verified download and review          |
-| `local_ahead`               | Block and require explicit upload of the existing local snapshot |
-| `broken` or crossed vectors | Reject as an integrity failure or unsupported concurrency        |
-| Remote snapshot missing     | Reject because synchronized state cannot be confirmed            |
+| Relation                    | Behavior                                                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| Exact descriptor equality   | Download, authenticate, and require the exact snapshot digest before permitting the mutation |
+| `remote_ahead`              | Block and require explicit verified download and review                                      |
+| `local_ahead`               | Block and require explicit upload of the existing local snapshot                             |
+| `broken` or crossed vectors | Reject as an integrity failure or unsupported concurrency                                    |
+| Remote snapshot missing     | Reject because synchronized state cannot be confirmed                                        |
 
 A local-ahead snapshot is a recovery state, not a valid base for another
 mutation. The normal upload workflow must synchronize it before the mutation is
@@ -85,9 +86,14 @@ resolution. An enrollment that is still pending may remain profile-less until
 the target completes it. Other accompanying entry, tag, or device-profile
 changes use the normal review and resolution model.
 
-Remote and local writes use snapshot descriptors for compare-and-set checks.
-This prevents a reviewed snapshot from overwriting a newer remote or local
-snapshot.
+Remote writes use a descriptor plus cryptographic snapshot digest as their
+exact compare-and-set identity. Local writes compare the snapshot digest, the
+exact signed trust checkpoint, and (when applicable) the exact encrypted
+credential artifact. Every snapshot prepared for upload signs the original
+nullable remote identity into `metadata.uploadExpectedRemoteSnapshotIdentity`.
+That historical identity is the only remote state the candidate may replace. A
+later upload may observe that the remote already equals the candidate, but it
+must never adopt a newly observed remote object as the candidate's expectation.
 
 ## Initial setup
 
@@ -96,8 +102,75 @@ credentials. The target is persisted through the encrypted vault snapshot. The
 credentials are encrypted with the device-local protection key and persisted
 only in the local vault repository.
 
-If setup, snapshot persistence, or upload fails, the local credential record and
-vault state are restored to their prior state.
+If setup or snapshot persistence fails, the local credential record and vault
+state are restored to their prior state. A definite upload non-commit restores
+them as well. An indeterminate upload preserves the newly signed local snapshot,
+commits the matching session, and reports sync as pending so normal upload can
+reconcile it.
+
+## Upload outcomes
+
+The sync-provider boundary distinguishes a committed write, a definite
+non-commit, and an outcome-unknown write. Definite non-commits distinguish a
+remote compare-and-set change from a static provider rejection such as invalid
+authorization, configuration, or request input. Read-only provider preparation
+may reject before a remote write is initiated. Once the synchronous start
+operation is invoked, rejected or malformed results are treated as outcome
+unknown; recognized single-attempt provider rejections resolve as definite
+non-commits. Automatic
+provider retries mean a later rejection is not proof that an earlier attempt
+failed.
+
+A definite remote change is surfaced as a sync conflict, while a definite
+provider rejection retains its provider-rejection error; both restore the prior
+local snapshot, checkpoint, credential state, and matching session. An unknown
+outcome instead retains and commits the candidate as pending because rollback
+could diverge local state from a write that actually committed remotely.
+
+For an unknown outcome, workflows keep the candidate local snapshot and commit
+the corresponding unlocked session with `syncUpload` marked `pending`. Before
+the remote write begins, a local compare-and-set transaction stores an encrypted
+device-local reconciliation intent alongside the candidate snapshot. The intent
+binds the exact candidate descriptor and digest to the original nullable remote
+descriptor-and-digest identity used for compare-and-set; the signed candidate
+metadata carries the same historical expectation.
+
+Every synchronized snapshot mutation compares the snapshot digest, the exact
+signed checkpoint artifact, and the exact current encrypted credential
+artifact—ciphertext and nonce, or record absence—even when that credential
+artifact remains unchanged.
+Intent staging, clearing, rollback, and credential replacement use the same
+transaction. A stale writer therefore cannot persist over or remove a newer
+reconciliation intent. If intent cleanup loses that compare-and-set race, the
+workflow remains pending instead of claiming completion.
+Secret-dependent intent staging and restaging and their local compare-and-set
+writes are serialized against the originating active session. Provider
+preflight may run outside that boundary, but it returns a synchronous start
+operation; the conditional upload or removal is started only after the
+originating session is revalidated, and its network response is awaited outside
+the session boundary. A concurrent lock therefore cannot wipe the protection
+key during an intent write or allow a later remote mutation to start from revoked session authority;
+if the session disappears before post-commit cleanup, the exact encrypted
+intent remains pending for reconciliation.
+
+Each reconciliation retry first compare-and-set refreshes the encrypted intent
+artifact before invoking the provider. This makes that attempt's exact
+ciphertext and nonce its local ownership token: a definite non-commit restores
+the prior intent only while the refreshed artifact is still current, while an
+unknown outcome retains it. A fresh upload similarly clears only the exact
+intent artifact that it staged after a definite pre-write failure.
+
+The next normal upload downloads and verifies the remote before clearing an
+intent whose remote identity equals the candidate. It retries only when the
+downloaded remote still equals the recorded historical descriptor and digest,
+and reports a conflict without overwriting when the remote is
+absent, rolled back, or otherwise changed. Because IndexedDB is hostile storage,
+the signed snapshot expectation remains authoritative if the encrypted intent
+record is removed or replayed: an intent that disagrees with the signed metadata
+is an integrity failure, and an absent intent does not authorize adopting the
+fresh remote observation as a new expectation. Until reconciliation completes,
+fresh vault mutations and sync removal are blocked; only an already-persisted
+removal transition may resume its recorded compare-and-set cleanup.
 
 ## Enrollment
 
@@ -110,7 +183,7 @@ same target and current snapshot before completing local initialization.
 
 Synchronized revocation requires replacement credentials. The revoking device:
 
-1. confirms its local snapshot exactly matches the current remote descriptor;
+1. confirms its local snapshot exactly matches the current remote identity;
 2. validates and normalizes the replacement credential;
 3. confirms the normalized target is unchanged and sees the same remote
    snapshot;
@@ -120,9 +193,12 @@ Synchronized revocation requires replacement credentials. The revoking device:
 
 The rotated snapshot, trust checkpoint, and staged credential state are written
 by one local compare-and-set transaction. Failed local persistence changes none
-of them; failed upload restores all three together. If
-the remote upload succeeds but session commit fails, the local session is
-invalidated and the replacement credential is retained so a later unlock can
+of them; a definite upload non-commit restores all three together. An unknown
+upload outcome retains all three and reports sync pending for reconciliation.
+If the originating session was removed or replaced while the upload was in
+flight, finalization leaves that newer session untouched and reports the durable
+result; if persistence into the still-current session fails, that session is
+invalidated. The replacement credential remains available so a later unlock can
 recover the rotated snapshot.
 
 No other enrollment, revocation, or sync removal may bypass a pending provider
@@ -163,8 +239,9 @@ Apply repeats all remote, trust, envelope, and vault checks. If no later content
 changed, it persists the authenticated remote snapshot directly. Otherwise it
 creates and uploads a resolved snapshot using the final trust chain,
 generation, survivor slots, and rotated vault key. Local snapshot, checkpoint,
-and credential state use compare-and-set and the session receives the new key
-only after any required upload succeeds.
+and credential state use compare-and-set. The session receives the new key after
+a committed upload or an outcome-unknown upload retained for reconciliation; a
+definite non-commit restores the prior state instead.
 
 ## Completing provider revocation
 

--- a/docs/security/security-specification.md
+++ b/docs/security/security-specification.md
@@ -267,7 +267,14 @@ behalf.
 The encrypted shared vault stores only the provider and non-secret target
 configuration. Every device stores its credential in a separate local encrypted
 record. A device-local symmetric key protects that record, and AAD binds it to
-the vault ID, local device ID, provider, and canonical target.
+the vault ID, local device ID, provider, and canonical target. Every
+synchronized snapshot transition must compare the exact expected encrypted
+artifact—ciphertext and nonce, or record absence—together with the snapshot
+digest and exact signed checkpoint artifact, even when the credential record
+remains unchanged.
+Reconciliation-intent stage and clear operations use the same local
+compare-and-set boundary, so stale work cannot persist over or erase a newer
+pending marker.
 
 The security boundary is therefore:
 
@@ -355,8 +362,48 @@ work authorized under the replaced identity therefore cannot persist or commit
 after reactivation. Ordinary snapshot commits retain the active identity while
 advancing its generation.
 Persisted-state rollback is likewise authenticated against its originating
-session ID and source snapshot vector before it runs, so an upload failure from
-stale work cannot roll back or wipe a replacement or advanced session. A
+session ID and source snapshot vector before it runs, so a definite upload
+non-commit from stale work cannot roll back or wipe a replacement or advanced
+session. An upload whose remote outcome is unknown never restores the prior
+snapshot: it retains the signed candidate, commits the matching session, and
+reports sync pending. Provider preparation may reject before initiation, but a
+synchronous start exception, rejected result, or malformed result after start
+is conservatively treated as outcome unknown. Before invoking the provider,
+the local snapshot owner
+atomically stores an encrypted device-local reconciliation intent that binds
+the candidate descriptor and digest to the original nullable remote
+descriptor-and-digest compare-and-set identity. The candidate snapshot signs
+that same historical identity in its metadata. Reconciliation downloads and
+verifies the remote before clearing an apparent candidate match, retries only
+against the exact recorded identity, and rejects
+an absent, rolled-back, or otherwise changed remote without overwriting it.
+Every intent stage, clear, credential replacement, and rollback compares the
+exact expected encrypted credential ciphertext and nonce (or expected absence)
+alongside the snapshot digest and exact signed checkpoint artifact. Losing this local compare-and-set
+leaves reconciliation pending rather than allowing stale cleanup to erase a
+newer intent.
+Intent encryption, restaging, and local intent compare-and-set writes are
+serialized against the originating active session. Provider preflight returns
+a synchronous start operation; the conditional upload or removal starts only
+after revalidating the originating session, while its network result is awaited
+after releasing that local boundary. Session removal
+therefore cannot wipe the device-local protection key during an intent write,
+and a continuation cannot initiate a provider mutation after its session was
+revoked. If the session disappears before committed-intent cleanup, the exact
+pending artifact is retained for a later authenticated reconciliation.
+
+Every reconciliation retry compare-and-set refreshes that encrypted intent
+before provider access. The refreshed ciphertext and nonce are the attempt's
+ownership token: definite failure may restore the previous intent only while
+that token remains current, and an unknown outcome retains it. A fresh attempt
+may likewise clear only the exact intent artifact it staged.
+
+Because local storage is attacker-modifiable, the signed metadata is the
+fail-closed authority if the encrypted intent record is removed or replayed. A
+replayed intent must agree with the signed candidate descriptor, digest, and
+historical expectation; disagreement is an integrity failure. With no intent,
+normal upload still uses the signed historical expectation and never promotes a
+fresh remote observation into an overwrite authorization. A
 rollback with no active material advances the generation before persistence is
 restored, invalidating activation leases that may have read the replaced state.
 Before each fallible remote upload, the snapshot owner signs and retains the
@@ -369,7 +416,13 @@ preserve potentially active secret buffers and surface an explicit incomplete-
 rollback error. If a conditional restore fails for the known matching session,
 the session owner invalidates and wipes that session before callers surface the
 same explicit error. Neither case masks uncertain local state with only the
-upload error.
+upload error. Provider adapters may reject only before initiating a write; after
+initiation they return committed, definite-non-commit, or outcome-unknown.
+Definite non-commits distinguish snapshot compare-and-set changes from
+recognized static provider rejections, so both restore local state without
+misreporting configuration or authorization failure as concurrency. Any error
+after an automatic retry remains outcome unknown because an earlier attempt may
+have committed before its response was lost.
 
 Password copy revalidates its session and performs clipboard task replacement,
 scheduling, and the plaintext write inside that same serialized boundary. A
@@ -512,21 +565,27 @@ A new device joins through a two-file, asynchronous exchange:
     optional local credentials are initialized together. Pending request state
     is removed only after success. If session activation fails, the initialized
     local records are conditionally removed inside the serialized activation
-    boundary and the pending request remains retryable. A
-    later remote compare-and-set rollback may remove those records only while
-    both the active session version and persisted snapshot digest still match
-    the enrollment snapshot. That rollback uses the shared lifecycle owner to
-    clear clipboard and auto-lock state before invalidating the matching
-    session, and wipes the enrollment operation's original secret buffers when
-    their ownership is no longer transferred to a live session.
+    boundary and the pending request remains retryable. A later definite upload
+    non-commit rollback, whether caused by a remote compare-and-set change or a
+    recognized provider rejection, may remove those records only while the
+    active session version and every initialized local artifact still match the
+    enrollment attempt: descriptor, device access material, recovery backup,
+    persisted snapshot digest, exact signed checkpoint, and exact staged
+    encrypted upload-intent artifact. The repository compares that complete
+    deletion set atomically before removing any record.
+    That rollback uses the shared lifecycle owner to clear clipboard and
+    auto-lock state before invalidating the matching session, and wipes the
+    enrollment operation's original secret buffers when their ownership is no
+    longer transferred to a live session.
 
 The devices never need to be connected simultaneously. Neither transported
 artifact contains private device keys or provider credentials.
 
 An indeterminate completion-upload result preserves local enrollment and
 returns the recovery mnemonic with sync marked pending. A later normal sync can
-reconcile the signed local snapshot. Only a definite remote compare-and-set
-rejection rolls local enrollment back.
+reconcile the signed local snapshot. Only a definite non-commit—either a remote
+compare-and-set change or a recognized provider rejection—rolls local
+enrollment back.
 
 An already-enrolled survivor advances through a separate verified
 enrollment-consumption flow. Every skipped certificate must add exactly one

--- a/docs/v1/use-case/device-trust/device-lifecycle.state-machine.puml
+++ b/docs/v1/use-case/device-trust/device-lifecycle.state-machine.puml
@@ -12,27 +12,42 @@ skinparam state {
 [*] --> SingleTrustedDevice : InitializeVaultUseCase
 
 SingleTrustedDevice --> SyncedTrustedDevice : SetupSyncUseCase
-SyncedTrustedDevice --> EnrollmentPending : InitializeDeviceEnrollmentUseCase\nadds enrollmentKeySlot and uploads it
-EnrollmentPending --> NewDeviceTrustedRemotely : PerformDeviceEnrollmentUseCase\nadds device slot and completed proof remotely
-NewDeviceTrustedRemotely --> SyncedTrustedDevice : ApplySyncResolutionUseCase\naccepts exact completed enrollment trust change
+SyncedTrustedDevice --> EnrollmentAuthorized : InitializeDeviceEnrollmentUseCase\nverifies signed request, adds trusted identity + device slot, and uploads
+EnrollmentAuthorized --> AuthorizationUploadPending : authorization upload outcome unknown or\ncommitted-intent cleanup incomplete; retain candidate and encrypted reconciliation intent
+AuthorizationUploadPending --> EnrollmentAuthorized : SyncUploadUseCase reconciles exact candidate
+EnrollmentAuthorized --> EnrollmentCompletedRemotely : PerformDeviceEnrollmentUseCase\ntarget adds active profile and uploads completion snapshot
+EnrollmentCompletedRemotely --> CompletionUploadPending : completion upload outcome unknown or\ncommitted-intent cleanup incomplete; target retains initialized local state and exact pending intent
+CompletionUploadPending --> EnrollmentCompletedRemotely : SyncUploadUseCase reconciles exact candidate
+EnrollmentCompletedRemotely --> SyncedTrustedDevice : Prepare + ConsumeDeviceEnrollmentUseCase\nverify and consume dedicated enrollment transition
 
 SyncedTrustedDevice --> DeviceRevoked : RevokeDeviceUseCase\nremoves target slot and tombstones profile
-DeviceRevoked --> SyncedTrustedDevice : upload and session commit complete
+DeviceRevoked --> ProviderCredentialRevocationPending : revocation upload and intent cleanup complete;\nold provider credential still requires external deletion
+DeviceRevoked --> RevocationUploadPending : upload outcome unknown or committed-intent cleanup incomplete;\nretain rotated candidate and reconciliation intent
+RevocationUploadPending --> ProviderCredentialRevocationPending : SyncUploadUseCase reconciles revocation upload
+ProviderCredentialRevocationPending --> SyncedTrustedDevice : CompleteProviderCredentialRevocationUseCase\nverifies external deletion, clears marker, and completes upload
+ProviderCredentialRevocationPending --> CredentialCompletionUploadPending : marker-clear upload is pending
+CredentialCompletionUploadPending --> SyncedTrustedDevice : SyncUploadUseCase reconciles marker-clear upload
 
-SyncedTrustedDevice --> LocalOnlyCurrentDevice : DisableSyncUseCase\nremoves syncConfig, remote snapshots,\nother device profiles, and other device slots
+SyncedTrustedDevice --> LocalOnlyCurrentDevice : DisableSyncUseCase\nremoves syncTarget, local encrypted credentials, remote snapshots,\nother device profiles, and other device slots
 LocalOnlyCurrentDevice --> SyncedTrustedDevice : SetupSyncUseCase may configure sync again
 
 SingleTrustedDevice --> SingleTrustedDevice : RecoverDeviceAccessUseCase\nrewraps local material and replaces current recovery backup
 SyncedTrustedDevice --> SyncedTrustedDevice : RecoverDeviceAccessUseCase\nlocal-only recovery, no snapshot mutation or sync upload
 LocalOnlyCurrentDevice --> LocalOnlyCurrentDevice : RecoverDeviceAccessUseCase\nrewraps local material and replaces current recovery backup
 
-EnrollmentPending --> SyncedTrustedDevice : initialization upload fails\nrollback to previous snapshot/session
-EnrollmentPending --> SyncedTrustedDevice : enrollment is superseded\nfuture mutation must resolve state
+EnrollmentAuthorized --> SyncedTrustedDevice : definite authorization upload non-commit;\nrestore prior registered-device state
+EnrollmentAuthorized --> EnrollmentAuthorized : definite target completion upload non-commit;\nconditionally remove target local initialization
 
-note right of EnrollmentPending
-Pending enrollment data lives in snapshot keySlots.enrollmentKeySlot.
-The enrollment bundle carries syncConfig, descriptor data,
-enrollment secret, and pending private signing key.
+note right of EnrollmentAuthorized
+Snapshots use ordinary trusted identities and deviceSlots only.
+The target retains its signed request and encrypted private request state locally.
+Generic ApplySyncResolutionUseCase rejects trust and key-slot changes;
+existing devices use the dedicated enrollment-consumption workflow.
+end note
+
+note right of AuthorizationUploadPending
+Fresh vault mutations and sync removal remain blocked
+until explicit upload reconciliation completes.
 end note
 
 note right of SingleTrustedDevice

--- a/docs/v1/use-case/device-trust/initialize-device-enrollment.activity.puml
+++ b/docs/v1/use-case/device-trust/initialize-device-enrollment.activity.puml
@@ -10,71 +10,70 @@ skinparam activity {
 }
 
 start
-:Input:\nvaultId, remoteSnapshotDescriptor;
+:Input:\nvaultId, signed DeviceEnrollmentRequest;
 :Source:\npackages/core/src/use-cases/device-trust/initialize-device-enrollment.ts;
-:Require unlocked vault context for "initialize device enrollment";
-if (syncConfig missing?) then (yes)
-  :Throw SyncNotConfiguredError;
+:Validate request version, vault ID, and algorithm suite;
+if (request identity or suite invalid?) then (yes)
+  :Throw DeviceEnrollmentIntegrityError or UnsupportedAlgorithmSuiteError;
   stop
 endif
-
-:Require vault ready for local mutation via VaultSyncGuardService;
-:Build local snapshot descriptor;
-if (local descriptor does not equal provided remote descriptor?) then (yes)
-  :Throw DeviceEnrollmentVaultNotSynchronizedError;
-  stop
-endif
-
-:Find snapshot signing device in device slots;
-if (signer missing?) then (yes)
-  :Throw VaultSnapshotSignerNotTrustedError;
-  stop
-endif
-:Verify current snapshot signature;
+:Verify request self-signature;
 if (signature invalid?) then (yes)
-  :Throw VaultSnapshotSignatureVerificationFailedError;
+  :Throw DeviceEnrollmentIntegrityError;
   stop
 endif
-:Find current device slot;
-if (current device not trusted?) then (yes)
-  :Throw SnapshotSigningDeviceNotTrustedError;
-  stop
-endif
-
-:Get revisionTimestamp from ClockPort;
-:Generate enrollmentSecret, enrollmentId, pendingDeviceId;
-:Generate pending device signing key pair;
-:Digest pending public signing key;
-:Derive enrollment vault-master-key protection key;
-:Wrap vaultMasterKey for enrollment;
-:Digest protected enrollment vaultMasterKey;
-:Build enrollment authorization payload;
-:Sign authorization with current device private signing key;
-:Build unsigned snapshot with enrollmentKeySlot;
-:Encrypt unchanged vault content;
-:Sign enrollment snapshot with current device private signing key;
-:Save enrollment snapshot locally;
-
-if (commit session to enrollment snapshot vector succeeds?) then (yes)
-  :Continue;
-else (no)
-  :Best effort restore previous local snapshot;
-  :Throw original session commit error;
-  stop
-endif
-
-if (upload enrollment snapshot succeeds?) then (yes)
-  :Return enrollmentBundle,\nsnapshotVersionVector,\nrevisionTimestamp;
-  stop
-else (no)
-  :Best effort restore previous local snapshot;
-  :Best effort commit session back to source vector;
-  if (failure is RemoteVaultSnapshotChangedError?) then (yes)
-    :Throw SyncConflictDetectedError;
-    stop
-  else (no)
-    :Throw original upload error;
+:Require unlocked vault context for "authorize device enrollment";
+:Prepare local mutation through VaultSyncGuardService;
+:Require request genesis digest to match the pinned trust anchor;
+if (requested device is already currently trusted?) then (yes)
+  :Digest and compare both requested public keys;
+  :Require exactly one current-generation vault-key envelope;
+  if (keys or envelope differ?) then (yes)
+    :Throw DeviceEnrollmentIntegrityError;
     stop
   endif
+  :Return response with current snapshot and syncUpload complete;
+  stop
 endif
+
+if (requested device identity appears in trust history?) then (yes)
+  :Reject reuse of a previously revoked identity;
+  :Throw DeviceEnrollmentIntegrityError;
+  stop
+endif
+
+:Require any provider credential revocation to be complete;
+:Append signed trust transition adding the requested identity;
+:Create a current-generation vault-key envelope for the requested device;
+:Enter active-session persistence boundary;
+:Prepare exact restore state for the current snapshot and checkpoint;
+:Persist signed snapshot with added trust certificate and device slot;
+if (sync is configured?) then (yes)
+  :Bind candidate to prepared remote exact identity
+and exact encrypted credential state;
+endif
+:Upload persisted local mutation through VaultSyncGuardService;
+if (upload is definitely not committed?) then (yes)
+  :Restore the exact prior local snapshot,
+checkpoint, and credential artifact;
+  :Throw mapped sync/provider error;
+  stop
+endif
+if (upload outcome is unknown or committed intent cleanup is incomplete?) then (yes)
+  :Retain new snapshot and pending upload intent;
+  :Set syncUpload pending;
+else (committed and cleared, or local-only)
+  :Set syncUpload complete;
+endif
+if (sync is configured?) then (yes)
+  :Conditionally commit only if the originating session remains active;
+  note right
+  Leave an expired or replaced session untouched and return the durable result.
+  A failure committing the still-current session invalidates it and propagates.
+  end note
+else (local-only)
+  :Strictly commit the session to the enrollment snapshot vector;
+endif
+:Return signed enrollmentResponse and syncUpload status;
+stop
 @enduml

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.activity.puml
@@ -61,22 +61,27 @@ endif
 if (scheduling or activation fails?) then (yes)
   :Best effort cancel the matching scheduled lock;
   :Best effort remove matching lock metadata;
-  :Best effort remove prepared local state\nonly if the snapshot digest still matches;
+  :Best effort remove prepared local state only if the exact descriptor,
+access material, recovery backup, snapshot digest, signed checkpoint,
+and encrypted sync artifact or absence all still match;
   :Throw the original failure;
   stop
 endif
 :Activate a fresh session identity and transfer session-key custody;
 
 if (sync access exists?) then (yes)
-  :Upload registered snapshot against the authorized descriptor;
-  if (remote snapshot changed?) then (yes)
+  :Persist pending upload intent binding registered
+candidate to the authorized descriptor-and-digest identity;
+  :Upload registered snapshot against the authorized identity;
+  if (upload is definitely not committed?) then (yes)
     :Enter shared lifecycle cleanup and conditional-discard owner;
     :Authenticate session ID, activation generation,\nvault ID, and source version;
     if (originating session is current and cleanup succeeds?) then (yes)
       :Clear clipboard/task state, wipe and remove session records;
-      :Remove local state by snapshot-digest CAS;
+      :Remove local state only by exact descriptor, access-material pair,
+snapshot digest, checkpoint, and staged encrypted-intent CAS;
       if (local discard completed?) then (yes)
-        :Throw DeviceEnrollmentRemoteSnapshotChangedError;
+        :Throw mapped remote-change or provider-rejection error;
         stop
       else (no)
         :Wipe original enrollment session buffers\nafter session custody ended;
@@ -94,8 +99,16 @@ if (sync access exists?) then (yes)
         stop
       endif
     endif
-  elseif (other upload failure?) then (yes)
-    :Keep committed local enrollment and mark syncUpload pending;
+  elseif (upload outcome is unknown?) then (yes)
+    :Keep committed local enrollment and pending intent;
+    :Mark syncUpload pending;
+  else (committed)
+    :Attempt exact CAS-clear of pending intent;
+    if (intent clear succeeds?) then (yes)
+      :Mark syncUpload complete;
+    else (no)
+      :Retain reconciliation state and mark syncUpload pending;
+    endif
   endif
 endif
 

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
@@ -15,6 +15,7 @@ actor "New device caller" as Caller
 participant "PerformDeviceEnrollmentUseCase" as UC
 participant "ClipboardOperationCoordinatorPort" as Coordinator
 participant "UnlockedVaultSessionService" as Session
+participant "VaultSyncGuardService" as Guard
 participant "VaultSessionActivationService" as Activation
 participant "VaultLifecycleCleanupService" as Lifecycle
 participant "VaultTrustService" as Trust
@@ -71,11 +72,13 @@ alt scheduling or session activation fails
   UC --> Caller : throw original activation failure
 else activated with fresh session identity
   opt sync access exists
-    UC -> LocalRepo : CAS-save same snapshot + encrypted pending upload intent
-    UC -> Sync : prepareVaultSnapshotUpload(syncAccess, registeredSnapshot,\nauthorizedSnapshotIdentity { descriptor, digest })
-    Sync --> UC : synchronous start operation after provider preflight
-    UC -> Session : revalidate originating session and start conditional upload
+    UC -> Guard : uploadTrackedSnapshot(...)
+    Guard -> LocalRepo : CAS-save same snapshot + encrypted pending upload intent
+    Guard -> Sync : prepareVaultSnapshotUpload(syncAccess, registeredSnapshot,\nauthorizedSnapshotIdentity { descriptor, digest })
+    Sync --> Guard : synchronous start operation after provider preflight
+    Guard -> Session : revalidate originating session and start conditional upload
     alt definitely not committed
+      Guard --> UC : throw RemoteVaultSnapshotChangedError or provider rejection
       UC -> Lifecycle : discardIfSessionIsActive(sessionId, generation, vector)
       Lifecycle -> Session : enter serialized conditional discard
       alt originating session is current
@@ -106,13 +109,13 @@ else activated with fresh session identity
         UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
       end
     else outcome unknown
-      UC -> UC : keep local enrollment and pending intent; syncUpload = pending
+      Guard --> UC : keep local enrollment and pending intent; syncUpload = pending
     else committed
-      UC -> LocalRepo : CAS-clear pending upload intent
+      Guard -> LocalRepo : CAS-clear pending upload intent
       alt clear succeeds
-        UC -> UC : syncUpload = complete
+        Guard --> UC : syncUpload = complete
       else clear races or session is no longer active
-        UC -> UC : retain reconciliation state; syncUpload = pending
+        Guard --> UC : retain reconciliation state; syncUpload = pending
       end
     end
   end

--- a/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
+++ b/docs/v1/use-case/device-trust/perform-device-enrollment.sequence.puml
@@ -67,12 +67,15 @@ alt scheduling or session activation fails
   Session -> Activation : invoke rollback callback
   Activation -> Tasks : best effort cancelTask(lockVault, actionId)
   Activation -> LockRepo : best effort removeIfActionIsActive(actionId)
-  Activation -> LocalRepo : best effort removePersistedLocalVaultIfSnapshotMatches(...)
+  Activation -> LocalRepo : best effort removePersistedLocalVaultIfArtifactsMatch(\nexact complete initialized artifact set)
   UC --> Caller : throw original activation failure
 else activated with fresh session identity
   opt sync access exists
-    UC -> Sync : uploadVaultSnapshot(syncAccess, registeredSnapshot,\nauthorizedDescriptor)
-    alt remote snapshot changed
+    UC -> LocalRepo : CAS-save same snapshot + encrypted pending upload intent
+    UC -> Sync : prepareVaultSnapshotUpload(syncAccess, registeredSnapshot,\nauthorizedSnapshotIdentity { descriptor, digest })
+    Sync --> UC : synchronous start operation after provider preflight
+    UC -> Session : revalidate originating session and start conditional upload
+    alt definitely not committed
       UC -> Lifecycle : discardIfSessionIsActive(sessionId, generation, vector)
       Lifecycle -> Session : enter serialized conditional discard
       alt originating session is current
@@ -82,9 +85,9 @@ else activated with fresh session identity
         Lifecycle -> LockRepo : removeIfActionIsActive(lockActionId)
         Session -> Session : wipe and remove matching session records
         alt cleanup and session removal completed
-          Session -> LocalRepo : removePersistedLocalVaultIfSnapshotMatches(...)
+          Session -> LocalRepo : removePersistedLocalVaultIfArtifactsMatch(\nexact complete initialized artifact set + staged intent)
           alt local discard completed
-            UC --> Caller : throw DeviceEnrollmentRemoteSnapshotChangedError
+            UC --> Caller : throw mapped remote-change or provider-rejection error
           else local discard incomplete
             UC -> UC : wipe original buffers after session custody ended
             UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
@@ -102,8 +105,15 @@ else activated with fresh session identity
         UC -> UC : wipe original buffers; preserve local state
         UC --> Caller : throw DeviceEnrollmentRollbackIncompleteError
       end
-    else other upload failure
-      UC -> UC : keep local enrollment; syncUpload = pending
+    else outcome unknown
+      UC -> UC : keep local enrollment and pending intent; syncUpload = pending
+    else committed
+      UC -> LocalRepo : CAS-clear pending upload intent
+      alt clear succeeds
+        UC -> UC : syncUpload = complete
+      else clear races or session is no longer active
+        UC -> UC : retain reconciliation state; syncUpload = pending
+      end
     end
   end
   UC -> LocalRepo : best effort removePendingDeviceEnrollment(requestId)

--- a/docs/v1/use-case/device-trust/revoke-device.activity.puml
+++ b/docs/v1/use-case/device-trust/revoke-device.activity.puml
@@ -44,13 +44,29 @@ endif
 :Get revisionTimestamp from ClockPort;
 :Tombstone revoked device profile inside encrypted vault content;
 :Remove revoked device slot from snapshot keySlots;
-:Drop pending enrollmentKeySlot if it was authorized by revoked device;
 :Encrypt revoked vault content;
 :Sign revoked snapshot with current device private signing key;
 :Save revoked snapshot locally;
 :Build updated unlocked vault;
-:Upload persisted local mutation through sync guard;
-:Commit revoked snapshot vector to unlocked session;
-:Return visible vault projection, snapshotVersionVector,\nrevisionTimestamp, providerCredentialRevocation;
+:Persist pending upload intent and upload
+persisted local mutation through sync guard;
+if (upload is definitely not committed?) then (yes)
+  :Restore prior snapshot, checkpoint, and credentials;
+  :Throw mapped upload error;
+  stop
+elseif (upload outcome is unknown or committed-intent cleanup is incomplete?) then (yes)
+  :Retain rotated state and pending intent;
+endif
+if (sync is configured?) then (yes)
+  :Conditionally commit only if the originating session remains active;
+  note right
+  Leave an expired or replaced session untouched, wipe the operation-owned
+  rotated key, and return the durable result. A failure committing the
+  still-current session invalidates it and propagates.
+  end note
+else (local-only)
+  :Strictly commit the revoked snapshot vector to the unlocked session;
+endif
+:Return visible vault projection, snapshotVersionVector,\nrevisionTimestamp, providerCredentialRevocation, and syncUpload;
 stop
 @enduml

--- a/docs/v1/use-case/sync/apply-sync-resolution.activity.puml
+++ b/docs/v1/use-case/sync/apply-sync-resolution.activity.puml
@@ -10,10 +10,10 @@ skinparam activity {
 }
 
 start
-:Input:\nvaultId, reviewedSnapshotDescriptors { local, remote },\nresolution;
+:Input:\nvaultId, reviewedSnapshotIdentities\n{ local/remote descriptor + digest }, resolution;
 :Source:\npackages/core/src/use-cases/sync/apply-sync-resolution.ts;
 :Require unlocked vault context for "apply sync resolution";
-if (syncConfig missing?) then (yes)
+if (syncTarget missing?) then (yes)
   :Throw SyncNotConfiguredError;
   stop
 endif
@@ -23,7 +23,8 @@ if (descriptor vaultId differs?) then (yes)
 endif
 
 :Require current local snapshot for unlocked vault and source vector;
-if (current local descriptor differs from reviewed descriptor?) then (yes)
+:Digest current local snapshot;
+if (current local descriptor or digest differs from reviewed local identity?) then (yes)
   :Throw LocalVaultSnapshotChangedError;
   stop
 endif
@@ -42,8 +43,15 @@ if (relation is local_ahead?) then (yes)
   :Throw LocalVaultSnapshotAheadError;
   stop
 endif
+:Download remote snapshot;
+:Digest downloaded remote snapshot;
+if (downloaded descriptor or digest differs from reviewed remote identity?) then (yes)
+  :Throw RemoteVaultSnapshotChangedError;
+  stop
+endif
+:Compare exact local and remote identities when vectors are equal;
 if (relation is equal?) then (yes)
-  if (descriptor fields exactly equal?) then (yes)
+  if (exact identities equal?) then (yes)
     :Throw SyncAlreadyResolvedError;
     stop
   else (no)
@@ -51,27 +59,16 @@ if (relation is equal?) then (yes)
     stop
   endif
 endif
-
-:Download remote snapshot;
 :Open trusted remote snapshot with trust result;
-:Verify downloaded descriptor still matches provided descriptor;
-if (descriptor changed?) then (yes)
-  :Throw RemoteVaultSnapshotChangedError;
+
+:Compare trust chain, vault-key generation, and key slots;
+if (any device-trust state changed?) then (yes)
+  :Throw SyncTrustChangeRequiresDeviceTrustFlowError;
   stop
 endif
 
-:Find key slot changes;
-if (key slots changed?) then (yes)
-  if (change is exactly one accepted completed enrollment?) then (yes)
-    :Accept remote keySlots for completed enrollment;
-  else (no)
-    :Throw SyncTrustChangeRequiresDeviceTrustFlowError;
-    stop
-  endif
-endif
-
 :Find entry, tag, and device-profile review items;
-if (no actionable changes and no accepted enrollment?) then (yes)
+if (no actionable changes?) then (yes)
   :Throw SyncAlreadyResolvedError;
   stop
 endif
@@ -88,26 +85,41 @@ if (actionable changes exist?) then (yes)
   endif
 endif
 
-if (accepted completed enrollment and enrolled profile was removed?) then (yes)
-  :Throw InvalidSyncResolutionError;
-  stop
-endif
-
 :Merge local and remote snapshot version vectors;
-:Persist resolved vault as signed local snapshot\nwith merged base vector and optional accepted keySlots;
-:Require resolved local snapshot;
-if (upload resolved snapshot succeeds?) then (yes)
-  :Commit persisted snapshot vector to unlocked session;
-  :Return snapshotVersionVector and revisionTimestamp;
+:Persist resolved vault as signed local snapshot\nwith merged base vector;
+:Persist pending upload intent bound to
+resolved candidate and reviewed remote exact identity;
+if (upload outcome is committed?) then (yes)
+  :Attempt exact CAS-clear of pending intent;
+  :Conditionally commit the candidate only if the originating session remains active;
+  if (intent clear succeeds?) then (yes)
+    :Return snapshotVersionVector, revisionTimestamp,
+and syncUpload complete;
+  else (no)
+    :Retain reconciliation state;
+    :Return snapshotVersionVector, revisionTimestamp,
+and syncUpload pending;
+  endif
   stop
 else (no)
-  :Best effort restore previous local snapshot;
-  if (failure is RemoteVaultSnapshotChangedError?) then (yes)
+  if (upload outcome is unknown?) then (yes)
+    :Retain resolved snapshot and pending intent;
+    :Conditionally commit the candidate only if the originating session remains active;
+    :Return result with syncUpload pending;
+    stop
+  endif
+  :Best effort restore previous local snapshot,
+checkpoint, and encrypted credential state by exact CAS;
+  if (definite failure is remote snapshot changed?) then (yes)
     :Throw SyncConflictDetectedError;
     stop
   else (no)
-    :Throw original upload error;
+    :Throw provider rejection error;
     stop
   endif
 endif
+note right
+After upload start, leave an expired or replaced session untouched and return
+the durable result. A failure committing the still-current session invalidates it.
+end note
 @enduml

--- a/docs/v1/use-case/sync/apply-sync-resolution.sequence.puml
+++ b/docs/v1/use-case/sync/apply-sync-resolution.sequence.puml
@@ -15,33 +15,54 @@ actor Caller
 participant "ApplySyncResolutionUseCase" as UC
 participant "UnlockedVaultSessionService" as Session
 participant "VaultSnapshotService" as Snapshot
+participant "VaultSyncGuardService" as Guard
 participant "SyncProviderPort" as Sync
 participant "Domain review/resolution utilities" as Domain
+database "VaultLocalRepositoryPort" as Local
 
-Caller -> UC : execute(vaultId, reviewedSnapshotDescriptors { local, remote }, resolution)
+Caller -> UC : execute(vaultId, reviewedSnapshotIdentities\n{ local/remote descriptor + digest }, resolution)
 UC -> Session : requireUnlockedVaultContext(vaultId, "apply sync resolution")
 UC -> Snapshot : requireCurrentSnapshotForUnlockedVault(...)
-UC -> UC : verify local descriptor has not changed since review
-UC -> Sync : getLatestVaultSnapshotDescriptor(syncConfig, vaultId)
+UC -> UC : verify local descriptor + digest exactly match reviewed identity
+UC -> Guard : requireSyncAccess(vaultId, unlockedVault)
+Guard --> UC : syncAccess { syncTarget + decrypted local credentials }
+UC -> Sync : getLatestVaultSnapshotDescriptor(syncAccess, vaultId)
 UC -> UC : verify descriptor belongs to vault and has not changed
-UC -> Sync : downloadVaultSnapshot(syncConfig, remoteDescriptor)
+UC -> Sync : downloadVaultSnapshot(syncAccess, remoteDescriptor)
+UC -> UC : verify downloaded descriptor + digest exactly match reviewed identity
 UC -> Snapshot : openTrustedVaultSnapshotWithTrustResult(...)
-UC -> Domain : findChangesInKeySlots(local.keySlots, remote.keySlots)
-UC -> UC : accept only completed enrollment trust change\nor reject trust changes
+UC -> UC : reject every trust-chain, vault-key-generation,\nor key-slot change; dedicated trust flow required
 UC -> Domain : findChangedEntries / Tags / DeviceProfiles
 UC -> Domain : applyVaultSyncResolution(...)
-UC -> Snapshot : persistUnlockedVault(..., mergedVector, optional keySlots)
-UC -> Snapshot : requireLocalVaultSnapshot(vaultId)
-UC -> Sync : uploadVaultSnapshot(syncConfig, resolvedSnapshot, remoteDescriptor)
-alt upload changed remotely
-  UC -> Snapshot : restoreLocalVaultSnapshot(previousLocalSnapshot)
+UC -> Snapshot : persistUnlockedVault(..., mergedVector)
+UC -> Local : CAS-save same resolved snapshot + encrypted pending intent
+UC -> Sync : prepareVaultSnapshotUpload(syncAccess, resolvedSnapshot,\nremoteSnapshotIdentity { descriptor, digest })
+Sync --> Guard : prepared synchronous start operation
+Guard -> Session : revalidate originating active session
+Guard -> Sync : start conditional upload while session lease is held
+alt definitely not committed: remote changed
+  UC -> Snapshot : restore prior snapshot, checkpoint, and credentials
   UC --> Caller : throw SyncConflictDetectedError
-else upload fails otherwise
-  UC -> Snapshot : restoreLocalVaultSnapshot(previousLocalSnapshot)
-  UC --> Caller : throw original upload error
-else upload succeeds
-  UC -> Session : commitPersistedSnapshot(updatedUnlockedVault, vector)
-  UC --> Caller : snapshotVersionVector, revisionTimestamp
+else definitely not committed: provider rejection
+  UC -> Snapshot : restore prior snapshot, checkpoint, and credentials
+  UC --> Caller : throw provider rejection error
+else outcome unknown
+  UC -> Session : commitPersistedSnapshotIfSessionIsActive(originating session, candidate, vector)
+  UC --> Caller : result with syncUpload pending
+else committed
+  UC -> Local : Attempt active-session exact CAS-clear of pending intent
+  UC -> Session : commitPersistedSnapshotIfSessionIsActive(originating session, candidate, vector)
+  alt intent clear succeeds
+    UC --> Caller : result with syncUpload complete
+  else clear races or session coordination fails
+    UC --> Caller : retain exact intent; result with syncUpload pending
+  end
 end
+
+note over UC, Session
+After upload start, an expired or replaced originating session is left untouched
+and the durable complete/pending result is returned. A failure committing the
+still-current session invalidates it and propagates.
+end note
 
 @enduml

--- a/docs/v1/use-case/sync/apply-sync-resolution.sequence.puml
+++ b/docs/v1/use-case/sync/apply-sync-resolution.sequence.puml
@@ -35,22 +35,25 @@ UC -> UC : reject every trust-chain, vault-key-generation,\nor key-slot change; 
 UC -> Domain : findChangedEntries / Tags / DeviceProfiles
 UC -> Domain : applyVaultSyncResolution(...)
 UC -> Snapshot : persistUnlockedVault(..., mergedVector)
-UC -> Local : CAS-save same resolved snapshot + encrypted pending intent
-UC -> Sync : prepareVaultSnapshotUpload(syncAccess, resolvedSnapshot,\nremoteSnapshotIdentity { descriptor, digest })
+UC -> Guard : uploadPersistedSnapshot(...)
+Guard -> Local : CAS-save same resolved snapshot + encrypted pending intent
+Guard -> Sync : prepareVaultSnapshotUpload(syncAccess, resolvedSnapshot,\nremoteSnapshotIdentity { descriptor, digest })
 Sync --> Guard : prepared synchronous start operation
 Guard -> Session : revalidate originating active session
 Guard -> Sync : start conditional upload while session lease is held
 alt definitely not committed: remote changed
-  UC -> Snapshot : restore prior snapshot, checkpoint, and credentials
+  Guard -> Snapshot : restore prior snapshot, checkpoint, and credentials
+  Guard --> UC : throw RemoteVaultSnapshotChangedError
   UC --> Caller : throw SyncConflictDetectedError
 else definitely not committed: provider rejection
-  UC -> Snapshot : restore prior snapshot, checkpoint, and credentials
+  Guard -> Snapshot : restore prior snapshot, checkpoint, and credentials
+  Guard --> UC : throw provider rejection error
   UC --> Caller : throw provider rejection error
 else outcome unknown
   UC -> Session : commitPersistedSnapshotIfSessionIsActive(originating session, candidate, vector)
   UC --> Caller : result with syncUpload pending
 else committed
-  UC -> Local : Attempt active-session exact CAS-clear of pending intent
+  Guard -> Local : Attempt active-session exact CAS-clear of pending intent
   UC -> Session : commitPersistedSnapshotIfSessionIsActive(originating session, candidate, vector)
   alt intent clear succeeds
     UC --> Caller : result with syncUpload complete

--- a/docs/v1/use-case/sync/disable-sync.activity.puml
+++ b/docs/v1/use-case/sync/disable-sync.activity.puml
@@ -13,38 +13,35 @@ start
 :Input:\nvaultId;
 :Source:\npackages/core/src/use-cases/sync/disable-sync.ts;
 :Require unlocked vault context for "disable sync";
-if (syncConfig missing?) then (yes)
+if (syncTarget missing?) then (yes)
   :Throw SyncNotConfiguredError;
   stop
 endif
 
-:Get revisionTimestamp from ClockPort;
-:Remove other device profiles from vault;
-:Remove syncConfig from vault;
-:Require current local snapshot using updated unlocked vault and source vector;
-:Read latest remote snapshot descriptor;
-if (remote descriptor exists?) then (yes)
-  :Build local snapshot descriptor;
-  :Compare local descriptor vs remote descriptor;
-  if (relation is remote_ahead?) then (yes)
-    :Throw RemoteVaultSnapshotAheadError;
-    stop
-  endif
-  if (relation is broken or equal-but-fields-differ?) then (yes)
-    :Throw RemoteVaultSnapshotIntegrityError;
-    stop
-  endif
+:Require provider credential revocation complete;
+:Decrypt local credentials and assemble runtime SyncAccess;
+:Reject an unresolved pending snapshot upload;
+:Require current local snapshot;
+if (signed sync-removal transition already pending?) then (yes)
+  :Resume its stored expected remote identity\n{ descriptor, digest };
+else (no)
+  :Read latest remote snapshot descriptor;
+  :Download and verify the exact remote snapshot identity;
+  :Require exact synchronized local/remote state;
+  :Persist signed sync-removal transition with\nremote identity and rollback snapshot;
+  :Commit transition snapshot to unlocked session;
 endif
 
-:Remove remote vault snapshots through SyncProviderPort;
-if (remote snapshot removal succeeds?) then (yes)
-  :Keep only current device slot in keySlots;
-  :Persist updated local-only vault as signed snapshot\nwith current device slot;
-  :Commit persisted snapshot vector to unlocked session;
-  :Return void;
-  stop
-else (no)
-  :Throw original provider failure;
+:Remove remote vault snapshots using the stored\nidentity compare-and-set expectation;
+if (remote snapshot changed?) then (yes)
+  :Restore signed rollback snapshot and clear transition;
+  :Commit restored session and throw provider conflict;
   stop
 endif
+:Remove other device profiles and sync target;
+:Rotate trust and vault key when other devices are revoked;
+:Persist final local-only snapshot and remove local sync credentials atomically;
+:Commit final snapshot to unlocked session;
+:Return void;
+stop
 @enduml

--- a/docs/v1/use-case/sync/prepare-sync-review.activity.puml
+++ b/docs/v1/use-case/sync/prepare-sync-review.activity.puml
@@ -13,12 +13,13 @@ start
 :Input:\nvaultId;
 :Source:\npackages/core/src/use-cases/sync/prepare-sync-review.ts;
 :Require unlocked vault context for "prepare sync review";
-if (syncConfig missing?) then (yes)
+if (syncTarget missing?) then (yes)
   :Throw SyncNotConfiguredError;
   stop
 endif
 
 :Require current local snapshot for unlocked vault and source vector;
+:Decrypt local credentials and assemble runtime SyncAccess;
 :Read latest remote snapshot descriptor;
 if (remote descriptor missing?) then (yes)
   :Throw RemoteVaultSnapshotNotFoundError;
@@ -37,7 +38,13 @@ if (relation is local_ahead?) then (yes)
 endif
 if (relation is equal?) then (yes)
   if (descriptor fields exactly equal?) then (yes)
-    :Return reviewedSnapshotDescriptors { local, remote },\nrelation, review = null;
+    :Download remote snapshot;
+    :Verify trust and signature, then digest remote bytes;
+    if (remote exact identity differs from local exact identity?) then (yes)
+      :Throw RemoteVaultSnapshotIntegrityError;
+      stop
+    endif
+    :Return reviewedSnapshotIdentities\n{ local/remote descriptor + digest },\nrelation, review = null;
     stop
   else (no)
     :Throw RemoteVaultSnapshotIntegrityError;
@@ -57,6 +64,6 @@ endif
 :Find changed tags;
 :Find changed device profiles;
 :Find read-only key slot changes;
-:Return reviewedSnapshotDescriptors { local, remote }, relation,\nreview { actionable changes, readOnly keySlotsChanges };
+:Return reviewedSnapshotIdentities\n{ local/remote descriptor + digest }, relation,\nreview { actionable changes, readOnly keySlotsChanges };
 stop
 @enduml

--- a/docs/v1/use-case/sync/setup-sync.activity.puml
+++ b/docs/v1/use-case/sync/setup-sync.activity.puml
@@ -13,7 +13,7 @@ start
 :Input:\nvaultId, syncConfig;
 :Source:\npackages/core/src/use-cases/sync/setup-sync.ts;
 :Require unlocked vault context for "setup sync";
-if (vault already has syncConfig?) then (yes)
+if (vault already has syncTarget?) then (yes)
   :Throw SyncAlreadyConfiguredError;
   stop
 endif
@@ -31,11 +31,29 @@ if (remote descriptor exists?) then (yes)
   stop
 endif
 
-:Build updated vault with provider-returned syncConfig;
-:Persist updated vault as signed local snapshot;
-:Require saved local snapshot;
-:Upload persisted initial sync snapshot with expected remote = null;
-:Commit persisted snapshot vector to unlocked session;
-:Return void;
+:Split provider-returned SyncAccess into nonsecret syncTarget\nand device-local credentials;
+:Persist updated vault with syncTarget, encrypted local credentials,\nand signed local snapshot;
+:Persist pending upload intent with expected remote = null;
+:Upload persisted initial sync snapshot;
+if (outcome is definitely not committed?) then (yes)
+  :Restore prior snapshot and remove local sync credentials;
+  :Throw conflict or provider rejection;
+  stop
+elseif (outcome is unknown?) then (yes)
+  :Retain candidate and pending intent;
+else (committed)
+  :Attempt active-session exact CAS-clear of pending intent;
+  if (intent clear succeeds?) then (yes)
+    :Set syncUpload complete;
+  else (race or coordination failure)
+    :Retain exact intent and set syncUpload pending;
+  endif
+endif
+:Conditionally commit the candidate only if the originating session remains active;
+note right
+Leave an expired or replaced session untouched and return the durable result.
+A failure committing the still-current session invalidates it and propagates.
+end note
+:Return syncUpload complete or pending;
 stop
 @enduml

--- a/docs/v1/use-case/sync/sync-resolution.state-machine.puml
+++ b/docs/v1/use-case/sync/sync-resolution.state-machine.puml
@@ -10,28 +10,38 @@ skinparam state {
 }
 
 [*] --> SyncNotConfigured
-SyncNotConfigured --> Configured : SetupSyncUseCase persists syncConfig and uploads initial snapshot
+SyncNotConfigured --> Configured : SetupSyncUseCase persists syncTarget,\nlocal encrypted credentials, and uploads initial snapshot
 
-Configured --> Equal : local descriptor equals remote descriptor
+Configured --> Equal : authenticated local and remote exact identities equal
 Configured --> LocalAhead : local snapshot vector ahead
 Configured --> RemoteAhead : remote snapshot vector ahead
 Configured --> Broken : crossed vectors or descriptor integrity mismatch
 Configured --> RemoteMissing : remote descriptor is null
+Configured --> UploadPending : provider upload outcome is unknown or\ncommitted-intent cleanup is incomplete
 
 Equal --> Configured : SyncUploadUseCase returns without upload
 LocalAhead --> Configured : SyncUploadUseCase uploads local snapshot
 RemoteAhead --> ReviewPrepared : PrepareSyncReviewUseCase downloads trusted remote and returns review
 Broken --> [*] : integrity error
 RemoteMissing --> Configured : SyncUploadUseCase uploads local snapshot with expected remote = null
+UploadPending --> Configured : remote equals candidate; clear local intent
+UploadPending --> Configured : remote equals stored expectation; retry succeeds
+UploadPending --> ReviewPrepared : remote differs from both; never overwrite
 
 ReviewPrepared --> Configured : ApplySyncResolutionUseCase persists resolved snapshot and uploads
 ReviewPrepared --> Broken : trust change requires device-trust flow or invalid resolution
-Configured --> LocalOnly : DisableSyncUseCase removes remote snapshots, syncConfig, and other device trust
-LocalOnly --> Configured : SetupSyncUseCase persists syncConfig and uploads initial snapshot
+Configured --> LocalOnly : DisableSyncUseCase removes remote snapshots, syncTarget,\nlocal encrypted credentials, and other device trust
+LocalOnly --> Configured : SetupSyncUseCase persists syncTarget,\nlocal encrypted credentials, and uploads initial snapshot
 
 note right of ReviewPrepared
 Review includes actionable entries, tags, device profiles,
 and read-only key slot changes.
+end note
+
+note right of UploadPending
+Encrypted device-local intent binds the exact candidate identity
+(descriptor + digest) to the original nullable remote exact identity.
+Fresh mutations and sync removal are blocked.
 end note
 
 @enduml

--- a/docs/v1/use-case/sync/sync-upload.activity.puml
+++ b/docs/v1/use-case/sync/sync-upload.activity.puml
@@ -13,45 +13,99 @@ start
 :Input:\nvaultId;
 :Source:\npackages/core/src/use-cases/sync/sync-upload.ts;
 :Require unlocked vault context for "sync upload";
-if (syncConfig missing?) then (yes)
+if (syncTarget missing?) then (yes)
   :Throw SyncNotConfiguredError;
   stop
 endif
 
 :Require current local snapshot for unlocked vault and source vector;
+:Read encrypted device sync state and optional pending upload intent;
+:Decrypt local credentials and assemble runtime SyncAccess;
 :Read latest remote snapshot descriptor;
-if (remote descriptor exists?) then (yes)
-  :Build local snapshot descriptor;
-  :Compare local descriptor vs remote descriptor;
-  if (relation is equal?) then (yes)
-    if (descriptor fields exactly equal?) then (yes)
-      :Remote already has this snapshot;
-      :Return void;
-      stop
-    else (no)
-      :Throw RemoteVaultSnapshotIntegrityError;
-      stop
-    endif
-  endif
-  if (relation is remote_ahead?) then (yes)
-    :Throw RemoteVaultSnapshotAheadError;
-    stop
-  endif
-  if (relation is broken?) then (yes)
+if (pending upload intent exists?) then (yes)
+  if (local descriptor or digest differs from stored candidate identity?) then (yes)
     :Throw RemoteVaultSnapshotIntegrityError;
     stop
   endif
+  if (remote exactly equals stored candidate?) then (yes)
+    :Download remote; verify trust/signature and exact candidate digest;
+    :Re-read current pending intent;
+    :Clear pending intent by snapshot digest/exact checkpoint
+and exact encrypted-intent CAS;
+    :Return syncUpload complete, or pending if clear races
+or session coordination fails;
+    stop
+  endif
+  :Read signed original remote expectation;
+  if (signed expectation is missing, foreign,
+  or differs from pending intent?) then (yes)
+    :Throw RemoteVaultSnapshotIntegrityError;
+    stop
+  endif
+  if (remote differs from stored original expectation?) then (yes)
+    :Retain pending intent;
+    :Throw integrity error for foreign vault,
+otherwise SyncConflictDetectedError;
+    stop
+  endif
+  :Download remote and require the exact stored
+historical descriptor-and-digest identity;
+  :Retry candidate using stored original expectation;
+else (no)
+  :Build local snapshot descriptor;
+  if (remote exactly equals local descriptor?) then (yes)
+    :Download remote; verify trust/signature and exact local digest;
+    :Re-read pending intent;
+    :Return complete only when no current intent remains;
+    stop
+  endif
+  :Read signed original remote expectation;
+  if (signed expectation is missing or foreign?) then (yes)
+    :Throw RemoteVaultSnapshotIntegrityError;
+    stop
+  endif
+  if (observed remote differs from signed expectation?) then (yes)
+    :Throw integrity error for foreign vault,
+otherwise SyncConflictDetectedError;
+    stop
+  endif
+  if (signed expectation exists?) then (yes)
+    :Download remote and require the signed
+historical descriptor-and-digest identity;
+    :Compare local descriptor vs signed expectation;
+    if (relation is equal or broken?) then (yes)
+      :Throw RemoteVaultSnapshotIntegrityError;
+      stop
+    endif
+    if (relation is remote_ahead?) then (yes)
+      :Throw RemoteVaultSnapshotAheadError;
+      stop
+    endif
+  endif
+  :Persist pending intent binding candidate
+and signed original remote expectation;
 endif
 
-if (upload local snapshot succeeds?) then (yes)
-  :Return void;
+if (upload outcome is committed?) then (yes)
+  :Clear pending intent by snapshot digest/exact checkpoint
+and exact encrypted-intent CAS;
+  :Return syncUpload complete, or pending if clear races
+or session coordination fails;
   stop
 else (no)
-  if (failure is RemoteVaultSnapshotChangedError?) then (yes)
+  if (upload outcome is unknown?) then (yes)
+    :Retain pending intent;
+    :Return syncUpload pending;
+    stop
+  elseif (definite failure is remote snapshot changed?) then (yes)
+    :CAS restore the prior retry intent
+or clear the fresh attempt's owned intent;
     :Throw SyncConflictDetectedError;
     stop
   else (no)
-    :Throw original error;
+    :CAS restore the prior retry intent
+or clear the fresh attempt's owned intent;
+    :Throw provider rejection error;
     stop
   endif
 endif

--- a/docs/v1/use-case/use-case-map.activity.puml
+++ b/docs/v1/use-case/use-case-map.activity.puml
@@ -22,7 +22,7 @@ partition "Vault lifecycle" {
 }
 
 partition "Vault entries" {
-  :add-entry / update-entry / remove-entry\nrequire unlocked vault, validate or check existence,\nmutate vault, persist signed snapshot, optional sync upload, commit session;
+  :add-entry / update-entry / remove-entry\nmutate and persist signed snapshot, stage encrypted upload intent,\nreturn complete/pending upload status, commit session;
   :read-entry / search-entries\nreturn visible fields only;
   :get-entry-password\nreturn plaintext password explicitly;
 }
@@ -33,18 +33,22 @@ partition "Clipboard" {
 }
 
 partition "Sync" {
-  :setup-sync\nvalidate provider config, require empty remote, persist sync config, upload;
-  :sync-upload\ncompare remote descriptor, upload local snapshot if allowed;
+  :setup-sync\nvalidate provider config, require empty remote, persist config and upload intent;
+  :sync-upload\nreconcile stored candidate/expectation or stage and upload local snapshot;
   :prepare-sync-review\ndownload trusted remote snapshot and produce review items;
-  :apply-sync-resolution\nvalidate descriptor, apply selected resolution, upload, commit;
-  :disable-sync\nremove sync config, prune other device trust, remove remote snapshots;
+  :apply-sync-resolution\nvalidate descriptors, persist resolution and upload intent, upload, commit;
+  :complete-provider-credential-revocation\npersist completion and tracked upload or retain pending intent;
+  :disable-sync\nblock pending upload, remove remote by signed transition, then prune local sync/trust;
 }
 
 partition "Device trust" {
-  :initialize-device-enrollment\ncreate pending enrollment slot and bundle;
+  :create-device-enrollment-request\ncreate signed request and persist its private pending bundle;
+  :initialize-device-enrollment\nverify request, add ordinary trusted identity + device slot, and upload authorization;
   :perform-device-enrollment\nnew device verifies enrollment, creates local access, uploads completed trust state;
+  :consume-device-enrollment\nresolve completed trust state and perform tracked upload;
   :recover-device-access\nuse local recovery backup to rewrap device trust material,\nreplace current local backup, no snapshot mutation;
   :revoke-device\nremove target device slot and tombstone device profile;
+  :consume-device-revocation\nresolve rotated trust state and perform tracked upload;
 }
 
 partition "Tools and session" {

--- a/docs/v1/use-case/vault-entries/add-entry.activity.puml
+++ b/docs/v1/use-case/vault-entries/add-entry.activity.puml
@@ -31,11 +31,20 @@ endif
 :Generate entryId;
 :Build updated unlocked vault with addPasswordEntryToVault;
 :Persist updated vault as signed local snapshot;
-if (syncConfig exists?) then (yes)
-  :Require saved local snapshot;
-  :Upload persisted local mutation through sync guard;
+if (syncTarget exists?) then (yes)
+  :Persist pending upload intent and upload
+persisted local mutation through sync guard;
+  :Restore prior snapshot and credential state
+only on definite non-commit;
+  :Conditionally commit the candidate only if the originating session remains active;
+else (local-only)
+  :Strictly commit the persisted snapshot vector to the unlocked session;
 endif
-:Commit persisted snapshot vector to unlocked session;
-:Return entryId, snapshotVersionVector, revisionTimestamp;
+note right
+After upload start, leave an expired or replaced session untouched and return
+the durable result. A failure committing the still-current session invalidates it.
+end note
+:Return entryId, snapshotVersionVector,
+revisionTimestamp, and syncUpload status;
 stop
 @enduml

--- a/docs/v1/use-case/vault-entries/entry-mutation.sequence.puml
+++ b/docs/v1/use-case/vault-entries/entry-mutation.sequence.puml
@@ -17,6 +17,8 @@ participant "UnlockedVaultSessionService" as Session
 participant "VaultSyncGuardService" as SyncGuard
 participant "Domain mutation" as Domain
 participant "VaultSnapshotService" as Snapshot
+database "VaultLocalRepositoryPort" as Local
+participant "SyncProviderPort" as Provider
 
 Caller -> UC : execute(command)
 UC -> Session : requireUnlockedVaultContext(vaultId, action)
@@ -27,15 +29,37 @@ Domain --> UC : updated vault
 UC -> Snapshot : persistUnlockedVault(vaultId, updatedUnlockedVault, sourceVector)
 Snapshot --> UC : snapshotVersionVector, revisionTimestamp
 alt sync configured
-  UC -> Snapshot : requireLocalVaultSnapshot(vaultId)
-  UC -> SyncGuard : uploadPersistedLocalMutation(vaultId, syncState, localSnapshot)
+  UC -> SyncGuard : uploadPersistedLocalMutation(candidate, checkpoint, prior restore)
+  SyncGuard -> Local : CAS-save same candidate + encrypted pending intent
+  SyncGuard -> Provider : prepareVaultSnapshotUpload(candidate, reviewed expectation)
+  Provider --> SyncGuard : synchronous start operation after provider preflight
+  SyncGuard -> Session : revalidate originating session and start conditional upload
+  alt committed
+    SyncGuard -> Local : Attempt active-session exact CAS-clear of pending intent
+    alt clear succeeds
+      SyncGuard --> UC : complete
+    else clear races or session coordination fails
+      SyncGuard --> UC : pending; retain exact intent
+    end
+  else outcome unknown
+    SyncGuard --> UC : pending; retain candidate and intent
+  else definitely not committed
+    SyncGuard -> Snapshot : restore prior snapshot, checkpoint, and credentials
+    SyncGuard --> UC : throw conflict or provider rejection
+  end
+  UC -> Session : commitPersistedSnapshotIfSessionIsActive(\noriginating session, updated vault, snapshot vector)
+else local-only
+  UC -> Session : commitPersistedSnapshot(updatedUnlockedVault, snapshotVersionVector)
 end
-UC -> Session : commitPersistedSnapshot(updatedUnlockedVault, snapshotVersionVector)
-UC --> Caller : mutation result
+UC --> Caller : mutation result + syncUpload status
 
 note over UC, Session
 If snapshot persistence fails, the session is not advanced.
-If session commit fails after persistence, the session service owns invalidation policy.
+An outcome-unknown upload or incomplete committed-intent cleanup
+commits the candidate only when the originating session remains active and blocks
+another mutation until explicit upload reconciliation completes.
+An expired or replaced session is left untouched and the durable result is returned.
+A failure committing the still-current session invalidates it and propagates.
 end note
 
 @enduml

--- a/docs/v1/use-case/vault-entries/remove-entry.activity.puml
+++ b/docs/v1/use-case/vault-entries/remove-entry.activity.puml
@@ -26,11 +26,20 @@ The domain mutation creates a deleted-entry tombstone
 and advances version vectors for the current device.
 end note
 :Persist updated vault as signed local snapshot;
-if (syncConfig exists?) then (yes)
-  :Require saved local snapshot;
-  :Upload persisted local mutation through sync guard;
+if (syncTarget exists?) then (yes)
+  :Persist pending upload intent and upload
+persisted local mutation through sync guard;
+  :Restore prior snapshot and credential state
+only on definite non-commit;
+  :Conditionally commit the candidate only if the originating session remains active;
+else (local-only)
+  :Strictly commit the persisted snapshot vector to the unlocked session;
 endif
-:Commit persisted snapshot vector to unlocked session;
-:Return entryId, snapshotVersionVector, revisionTimestamp;
+note right
+After upload start, leave an expired or replaced session untouched and return
+the durable result. A failure committing the still-current session invalidates it.
+end note
+:Return entryId, snapshotVersionVector,
+revisionTimestamp, and syncUpload status;
 stop
 @enduml

--- a/docs/v1/use-case/vault-entries/update-entry.activity.puml
+++ b/docs/v1/use-case/vault-entries/update-entry.activity.puml
@@ -35,11 +35,20 @@ endif
 :Prepare local mutation with VaultSyncGuardService;
 :Build updated unlocked vault with updatePasswordEntryInVault;
 :Persist updated vault as signed local snapshot;
-if (syncConfig exists?) then (yes)
-  :Require saved local snapshot;
-  :Upload persisted local mutation through sync guard;
+if (syncTarget exists?) then (yes)
+  :Persist pending upload intent and upload
+persisted local mutation through sync guard;
+  :Restore prior snapshot and credential state
+only on definite non-commit;
+  :Conditionally commit the candidate only if the originating session remains active;
+else (local-only)
+  :Strictly commit the persisted snapshot vector to the unlocked session;
 endif
-:Commit persisted snapshot vector to unlocked session;
-:Return entryId, snapshotVersionVector, revisionTimestamp;
+note right
+After upload start, leave an expired or replaced session untouched and return
+the durable result. A failure committing the still-current session invalidates it.
+end note
+:Return entryId, snapshotVersionVector,
+revisionTimestamp, and syncUpload status;
 stop
 @enduml

--- a/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
+++ b/docs/v1/use-case/vault-lifecycle/initialize-vault.activity.puml
@@ -68,7 +68,9 @@ if (schedule lock task succeeds?) then (yes)
 else (no)
   :Best effort cancel scheduled lock task;
   :Best effort remove matching lock task metadata;
-  :Best effort removePersistedLocalVaultIfSnapshotMatches(vaultId, snapshotDigest);
+  :Best effort removePersistedLocalVaultIfArtifactsMatch(
+exact descriptor, access material, recovery backup,
+snapshot digest, checkpoint, and credential absence);
   :Throw schedule failure;
   stop
 endif
@@ -79,7 +81,9 @@ if (activate unlocked session succeeds?) then (yes)
 else (no)
   :Best effort cancel scheduled lock task;
   :Best effort remove matching lock task metadata;
-  :Best effort removePersistedLocalVaultIfSnapshotMatches(vaultId, snapshotDigest);
+  :Best effort removePersistedLocalVaultIfArtifactsMatch(
+exact descriptor, access material, recovery backup,
+snapshot digest, checkpoint, and credential absence);
   :Throw original session activation error;
   stop
 endif

--- a/packages/core/src/__tests__/fixtures/ports.test.ts
+++ b/packages/core/src/__tests__/fixtures/ports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createCoreTestPorts } from "./ports";
 import { createCoreTestValues } from "./values";
+import { createVaultSnapshotServiceMock } from "./vault-entries";
 
 function expectFreshCopies(
   first: ArrayBuffer,
@@ -168,5 +169,38 @@ describe("createCoreTestPorts vault lock tasks", () => {
       ports.vaultLockTasks.removeIfActionIsActive(task.actionId),
     ).resolves.toBe(true);
     await expect(ports.vaultLockTasks.get()).resolves.toBeNull();
+  });
+});
+
+describe("createCoreTestPorts vault persistence", () => {
+  it("rejects malformed credential replacement parameter shapes", async () => {
+    const values = createCoreTestValues();
+    const ports = createCoreTestPorts(values);
+    const service = createVaultSnapshotServiceMock(values, ports);
+    const snapshot = await service.requireLocalVaultSnapshot(values.vaultId);
+    const save = ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint;
+    const baseParams = {
+      expectedSnapshotDigest: values.vaultSnapshotDigest,
+      expectedCheckpoint: values.localVaultTrustCheckpoint,
+      snapshot,
+      checkpoint: values.localVaultTrustCheckpoint,
+    };
+
+    await expect(
+      save({
+        ...baseParams,
+        expectedSyncCredentialState: values.encryptedDeviceSyncCredentialState,
+      } as unknown as Parameters<typeof save>[0]),
+    ).rejects.toThrow(
+      "Expected valid sync credential state replacement parameters.",
+    );
+    await expect(
+      save({
+        ...baseParams,
+        syncCredentialState: undefined,
+      } as unknown as Parameters<typeof save>[0]),
+    ).rejects.toThrow(
+      "Expected valid sync credential state replacement parameters.",
+    );
   });
 });

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -36,7 +36,10 @@ import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { EncryptedUnlockedVaultSessionPayloadRepositoryPort } from "../../ports/session/encrypted-unlocked-vault-session-payload-repository.port";
 import type { IdPort } from "../../ports/system/id.port";
 import type { ScheduledTaskPort } from "../../ports/system/scheduled-task.port";
-import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
+import type {
+  SyncProviderPort,
+  SyncUploadOutcome,
+} from "../../ports/sync/sync-provider.port";
 import type { VaultDisplayNamePort } from "../../ports/vault/vault-display-name.port";
 import type {
   VaultLockTask,
@@ -45,13 +48,18 @@ import type {
 import type { UnlockedVaultSessionMaterialRepositoryPort } from "../../ports/session/unlocked-vault-session-material-repository.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
-import { createCoreTestValues, type CoreTestValues } from "./values";
+import { b64, createCoreTestValues, type CoreTestValues } from "./values";
 import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
-import type { EncryptedDeviceSyncCredentialState } from "../../domain/sync";
+import type {
+  DeviceSyncCredentialState,
+  EncryptedDeviceSyncCredentialState,
+} from "../../domain/sync";
 import type { PendingDeviceEnrollment } from "../../domain/device-trust";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import { LocalVaultAlreadyInitializedError } from "../../errors/vault-lifecycle.errors";
 import { DeviceAccessMaterialChangedError } from "../../errors/vault-device.errors";
+import { areJsonEqual } from "../../domain/common";
+import { areArrayBuffersEqual } from "../../domain/common/array-buffer.utils";
 
 export type SavedCoreRecords = {
   unlockedVaultSessionEpoch: number;
@@ -73,19 +81,90 @@ export type SavedCoreRecords = {
 
 export type CoreTestPorts = ReturnType<typeof createCoreTestPorts>;
 
-function requirePersistedSnapshot(
+type TestSyncProviderPort = SyncProviderPort & {
+  readonly uploadVaultSnapshot: (
+    ...args: Parameters<SyncProviderPort["prepareVaultSnapshotUpload"]>
+  ) => Promise<SyncUploadOutcome>;
+  readonly removeVaultSnapshots: (
+    ...args: Parameters<SyncProviderPort["prepareVaultSnapshotRemoval"]>
+  ) => Promise<void>;
+};
+
+function requireCapturedSnapshot(
   snapshot: VaultSnapshot | undefined,
 ): VaultSnapshot {
   if (snapshot === undefined) {
-    throw new Error("Expected the workflow to persist a vault snapshot.");
+    throw new Error("Expected the workflow to save a vault snapshot.");
   }
 
   return snapshot;
 }
 
-export function replaceVaultSnapshotAfterNextSave(
+function areEncryptedSyncCredentialStatesEqual(
+  left: EncryptedDeviceSyncCredentialState | undefined,
+  right: EncryptedDeviceSyncCredentialState | null | undefined,
+): boolean {
+  if (left === undefined || right === undefined || right === null) {
+    return left === undefined && (right === undefined || right === null);
+  }
+
+  return (
+    left.ciphertext === right.ciphertext &&
+    left.encryptionNonce === right.encryptionNonce
+  );
+}
+
+function areDeviceAccessMaterialsEqual(
+  left: DeviceAccessMaterial | undefined,
+  right: DeviceAccessMaterial,
+): boolean {
+  return (
+    left !== undefined &&
+    left.revision === right.revision &&
+    left.localAccessGenerationId === right.localAccessGenerationId &&
+    left.vaultId === right.vaultId &&
+    left.deviceId === right.deviceId &&
+    left.algorithmSuiteId === right.algorithmSuiteId &&
+    areArrayBuffersEqual(left.masterPasswordSalt, right.masterPasswordSalt) &&
+    areArrayBuffersEqual(
+      left.localKeysProtectionSalt,
+      right.localKeysProtectionSalt,
+    ) &&
+    areArrayBuffersEqual(left.devicePublicSignKey, right.devicePublicSignKey) &&
+    areArrayBuffersEqual(
+      left.devicePublicVaultKey,
+      right.devicePublicVaultKey,
+    ) &&
+    areJsonEqual(left.protectedLocalKeys, right.protectedLocalKeys)
+  );
+}
+
+function areDeviceAccessRecoveryBackupsEqual(
+  left: DeviceAccessRecoveryBackup | undefined,
+  right: DeviceAccessRecoveryBackup,
+): boolean {
+  return (
+    left !== undefined &&
+    left.revision === right.revision &&
+    left.localAccessGenerationId === right.localAccessGenerationId &&
+    left.vaultId === right.vaultId &&
+    left.deviceId === right.deviceId &&
+    left.algorithmSuiteId === right.algorithmSuiteId &&
+    areArrayBuffersEqual(
+      left.recoveryLocalKeysProtectionSalt,
+      right.recoveryLocalKeysProtectionSalt,
+    ) &&
+    areArrayBuffersEqual(left.devicePublicSignKey, right.devicePublicSignKey) &&
+    areArrayBuffersEqual(
+      left.devicePublicVaultKey,
+      right.devicePublicVaultKey,
+    ) &&
+    areJsonEqual(left.protectedLocalKeys, right.protectedLocalKeys)
+  );
+}
+
+export function captureVaultSnapshotFromNextSave(
   ports: CoreTestPorts,
-  replacement: VaultSnapshot,
 ): () => VaultSnapshot {
   const save = vi.mocked(
     ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
@@ -100,15 +179,13 @@ export function replaceVaultSnapshotAfterNextSave(
   save.mockImplementationOnce(async (params) => {
     await saveImplementation(params);
     persistedSnapshot = params.snapshot;
-    ports.saved.vaultSnapshot = replacement;
   });
 
-  return () => requirePersistedSnapshot(persistedSnapshot);
+  return () => requireCapturedSnapshot(persistedSnapshot);
 }
 
-export function replaceVaultSnapshotAfterNextInitializedSave(
+export function captureVaultSnapshotFromNextInitializedSave(
   ports: CoreTestPorts,
-  replacement: VaultSnapshot,
 ): () => VaultSnapshot {
   const save = vi.mocked(ports.vaultLocalRepository.saveInitializedLocalVault);
   const saveImplementation = save.getMockImplementation();
@@ -123,10 +200,9 @@ export function replaceVaultSnapshotAfterNextInitializedSave(
   save.mockImplementationOnce(async (params) => {
     await saveImplementation(params);
     persistedSnapshot = params.snapshot;
-    ports.saved.vaultSnapshot = replacement;
   });
 
-  return () => requirePersistedSnapshot(persistedSnapshot);
+  return () => requireCapturedSnapshot(persistedSnapshot);
 }
 
 export function createCoreTestPorts(
@@ -137,6 +213,11 @@ export function createCoreTestPorts(
     "local" | "new_local" | "recovery" | "rotated_recovery"
   >();
   const recoveryKeyKinds = new WeakMap<ArrayBuffer, "current" | "rotated">();
+  const encryptedSyncCredentialPlaintexts = new WeakMap<
+    EncryptedDeviceSyncCredentialState,
+    DeviceSyncCredentialState
+  >();
+  let pendingSyncCredentialEncryptionSequence = 0;
   const freshBuffer = <T extends ArrayBuffer>(buffer: T): T =>
     buffer.slice(0) as T;
   const saved: SavedCoreRecords = {
@@ -385,12 +466,33 @@ export function createCoreTestPorts(
     ),
     verifyDeviceEnrollmentRequestSignature: vi.fn(async () => true),
     encryptDeviceSyncCredentialState: vi.fn(async (state) => {
-      return state.previousCredentials === undefined
-        ? values.encryptedDeviceSyncCredentialState
-        : values.replacementEncryptedDeviceSyncCredentialState;
+      const baseEncryptedState =
+        state.previousCredentials === undefined
+          ? values.encryptedDeviceSyncCredentialState
+          : values.replacementEncryptedDeviceSyncCredentialState;
+      const encrypted =
+        state.pendingSnapshotUpload === undefined
+          ? { ...baseEncryptedState }
+          : {
+              ciphertext: b64(
+                `${baseEncryptedState.ciphertext}:pending:${++pendingSyncCredentialEncryptionSequence}`,
+              ),
+              encryptionNonce: b64(
+                `${baseEncryptedState.encryptionNonce}:pending:${pendingSyncCredentialEncryptionSequence}`,
+              ),
+            };
+      encryptedSyncCredentialPlaintexts.set(encrypted, state);
+      return encrypted;
     }),
-    decryptDeviceSyncCredentialState: vi.fn(async (encryptedState) =>
-      encryptedState === values.replacementEncryptedDeviceSyncCredentialState
+    decryptDeviceSyncCredentialState: vi.fn(async (encryptedState) => {
+      const plaintext = encryptedSyncCredentialPlaintexts.get(encryptedState);
+
+      if (plaintext !== undefined) {
+        return plaintext;
+      }
+
+      return encryptedState ===
+        values.replacementEncryptedDeviceSyncCredentialState
         ? {
             currentCredentials: values.replacementSyncCredentials,
             previousCredentials: {
@@ -399,8 +501,8 @@ export function createCoreTestPorts(
               vaultKeyGeneration: 2,
             },
           }
-        : values.deviceSyncCredentialState,
-    ),
+        : values.deviceSyncCredentialState;
+    }),
   };
 
   const clipboardSecretHash: ClipboardSecretHashPort = {
@@ -493,25 +595,41 @@ export function createCoreTestPorts(
       saved.localVaultTrustCheckpoint = undefined;
       saved.deviceSyncCredentialState = undefined;
     }),
-    removePersistedLocalVaultIfSnapshotMatches: vi.fn(
-      async (vaultId, expectedSnapshotDigest) => {
-        if (
-          saved.vaultSnapshot?.metadata.id !== vaultId ||
-          saved.vaultSnapshotDigest !== expectedSnapshotDigest
-        ) {
-          return false;
-        }
+    removePersistedLocalVaultIfArtifactsMatch: vi.fn(async (params) => {
+      if (
+        saved.vaultSnapshot?.metadata.id !== params.vaultId ||
+        !areJsonEqual(saved.localVaultDescriptor, params.expectedDescriptor) ||
+        !areDeviceAccessMaterialsEqual(
+          saved.deviceAccessMaterial,
+          params.expectedDeviceAccessMaterial,
+        ) ||
+        !areDeviceAccessRecoveryBackupsEqual(
+          saved.deviceAccessRecoveryBackup,
+          params.expectedDeviceAccessRecoveryBackup,
+        ) ||
+        saved.vaultSnapshotDigest !== params.expectedSnapshotDigest ||
+        saved.localVaultTrustCheckpoint === undefined ||
+        !areJsonEqual(
+          saved.localVaultTrustCheckpoint,
+          params.expectedCheckpoint,
+        ) ||
+        !areEncryptedSyncCredentialStatesEqual(
+          saved.deviceSyncCredentialState,
+          params.expectedSyncCredentialState,
+        )
+      ) {
+        return false;
+      }
 
-        saved.localVaultDescriptor = undefined;
-        saved.deviceAccessMaterial = undefined;
-        saved.deviceAccessRecoveryBackup = undefined;
-        saved.vaultSnapshot = undefined;
-        saved.vaultSnapshotDigest = undefined;
-        saved.localVaultTrustCheckpoint = undefined;
-        saved.deviceSyncCredentialState = undefined;
-        return true;
-      },
-    ),
+      saved.localVaultDescriptor = undefined;
+      saved.deviceAccessMaterial = undefined;
+      saved.deviceAccessRecoveryBackup = undefined;
+      saved.vaultSnapshot = undefined;
+      saved.vaultSnapshotDigest = undefined;
+      saved.localVaultTrustCheckpoint = undefined;
+      saved.deviceSyncCredentialState = undefined;
+      return true;
+    }),
     saveLocalVaultDescriptor: vi.fn(async (descriptor) => {
       saved.localVaultDescriptor = descriptor;
     }),
@@ -670,32 +788,41 @@ export function createCoreTestPorts(
       return vaultSnapshot.metadata.id === vaultId ? vaultSnapshot : null;
     }),
     removeVaultSnapshot: vi.fn(),
-    saveVaultSnapshotWithCheckpoint: vi.fn(
-      async ({
+    saveVaultSnapshotWithCheckpoint: vi.fn(async (params) => {
+      const {
         expectedSnapshotDigest,
+        expectedCheckpoint,
+        expectedSyncCredentialState,
         snapshot,
         checkpoint,
         syncCredentialState,
-      }) => {
-        const currentSnapshot = saved.vaultSnapshot;
+      } = params;
+      const currentSnapshot = saved.vaultSnapshot;
 
-        if (
-          currentSnapshot === undefined ||
-          currentSnapshot.metadata.id !== snapshot.metadata.id ||
-          saved.vaultSnapshotDigest !== expectedSnapshotDigest
-        ) {
-          throw new LocalVaultSnapshotChangedError(snapshot.metadata.id);
-        }
+      if (
+        currentSnapshot === undefined ||
+        currentSnapshot.metadata.id !== snapshot.metadata.id ||
+        saved.vaultSnapshotDigest !== expectedSnapshotDigest ||
+        saved.localVaultTrustCheckpoint === undefined ||
+        !areJsonEqual(saved.localVaultTrustCheckpoint, expectedCheckpoint) ||
+        (syncCredentialState !== undefined &&
+          (!Object.hasOwn(params, "expectedSyncCredentialState") ||
+            !areEncryptedSyncCredentialStatesEqual(
+              saved.deviceSyncCredentialState,
+              expectedSyncCredentialState,
+            )))
+      ) {
+        throw new LocalVaultSnapshotChangedError(snapshot.metadata.id);
+      }
 
-        saved.vaultSnapshot = snapshot;
-        saved.vaultSnapshotDigest = checkpoint.payload.snapshotDigest;
-        saved.localVaultTrustCheckpoint = checkpoint;
+      saved.vaultSnapshot = snapshot;
+      saved.vaultSnapshotDigest = checkpoint.payload.snapshotDigest;
+      saved.localVaultTrustCheckpoint = checkpoint;
 
-        if (syncCredentialState !== undefined) {
-          saved.deviceSyncCredentialState = syncCredentialState ?? undefined;
-        }
-      },
-    ),
+      if (syncCredentialState !== undefined) {
+        saved.deviceSyncCredentialState = syncCredentialState ?? undefined;
+      }
+    }),
     getLocalVaultTrustCheckpoint: vi.fn(async (vaultId) => {
       const checkpoint = saved.localVaultTrustCheckpoint;
 
@@ -816,6 +943,10 @@ export function createCoreTestPorts(
     sessionServices.unlockedVaultSession.commitPersistedSnapshot.bind(
       sessionServices.unlockedVaultSession,
     );
+  const commitPersistedSnapshotIfSessionIsActiveOriginal =
+    sessionServices.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive.bind(
+      sessionServices.unlockedVaultSession,
+    );
   const removeSessionOriginal =
     sessionServices.unlockedVaultSession.remove.bind(
       sessionServices.unlockedVaultSession,
@@ -899,6 +1030,34 @@ export function createCoreTestPorts(
       };
     },
   );
+  vi.spyOn(
+    sessionServices.unlockedVaultSession,
+    "commitPersistedSnapshotIfSessionIsActive",
+  ).mockImplementation(
+    async (
+      sessionId,
+      unlockedVault,
+      sourceSnapshotVersionVector,
+      coordinationLease,
+    ) => {
+      const committed = await commitPersistedSnapshotIfSessionIsActiveOriginal(
+        sessionId,
+        unlockedVault,
+        sourceSnapshotVersionVector,
+        coordinationLease,
+      );
+
+      if (committed) {
+        unlockedVaultSessionMirror = {
+          sessionId,
+          unlockedVault,
+          sourceSnapshotVersionVector,
+        };
+      }
+
+      return committed;
+    },
+  );
   vi.spyOn(sessionServices.unlockedVaultSession, "get").mockImplementation(
     async () => {
       const session = await getSessionOriginal();
@@ -951,16 +1110,52 @@ export function createCoreTestPorts(
     cancelTask: vi.fn(async () => undefined),
   };
 
-  const syncProvider: SyncProviderPort = {
+  const uploadVaultSnapshot: TestSyncProviderPort["uploadVaultSnapshot"] =
+    vi.fn<TestSyncProviderPort["uploadVaultSnapshot"]>(async () => ({
+      status: "committed",
+    }));
+  const removeVaultSnapshots: TestSyncProviderPort["removeVaultSnapshots"] =
+    vi.fn<TestSyncProviderPort["removeVaultSnapshots"]>(async () => undefined);
+  const syncProvider: TestSyncProviderPort = {
     setup: vi.fn(async (input) =>
       input === values.replacementSyncConfigInput
         ? values.replacementSyncAccess
         : values.syncAccess,
     ),
     getLatestVaultSnapshotDescriptor: vi.fn(async () => null),
-    downloadVaultSnapshot: vi.fn(),
-    uploadVaultSnapshot: vi.fn(async () => undefined),
-    removeVaultSnapshots: vi.fn(async () => undefined),
+    downloadVaultSnapshot: vi.fn(async () => {
+      if (saved.vaultSnapshot === undefined) {
+        throw new Error("Expected a saved remote snapshot fixture.");
+      }
+
+      return saved.vaultSnapshot;
+    }),
+    prepareVaultSnapshotUpload: vi.fn(
+      async (syncAccess, vaultSnapshot, expectedRemoteSnapshotIdentity) => ({
+        status: "ready" as const,
+        start: () => ({
+          outcome: uploadVaultSnapshot(
+            syncAccess,
+            vaultSnapshot,
+            expectedRemoteSnapshotIdentity,
+          ),
+        }),
+      }),
+    ),
+    prepareVaultSnapshotRemoval: vi.fn(
+      async (syncAccess, vaultId, expectedRemoteSnapshotIdentity) => ({
+        status: "ready" as const,
+        start: () => ({
+          outcome: removeVaultSnapshots(
+            syncAccess,
+            vaultId,
+            expectedRemoteSnapshotIdentity,
+          ),
+        }),
+      }),
+    ),
+    uploadVaultSnapshot,
+    removeVaultSnapshots,
     checkVaultAccess: vi.fn(async () => "authentication_rejected" as const),
   };
 

--- a/packages/core/src/__tests__/fixtures/ports.ts
+++ b/packages/core/src/__tests__/fixtures/ports.ts
@@ -798,6 +798,26 @@ export function createCoreTestPorts(
         syncCredentialState,
       } = params;
       const currentSnapshot = saved.vaultSnapshot;
+      const replacesSyncCredentialState = syncCredentialState !== undefined;
+      const hasSyncCredentialState = Object.hasOwn(
+        params,
+        "syncCredentialState",
+      );
+      const hasExpectedSyncCredentialState = Object.hasOwn(
+        params,
+        "expectedSyncCredentialState",
+      );
+
+      if (
+        hasSyncCredentialState !== replacesSyncCredentialState ||
+        hasExpectedSyncCredentialState !== replacesSyncCredentialState ||
+        (replacesSyncCredentialState &&
+          expectedSyncCredentialState === undefined)
+      ) {
+        throw new Error(
+          "Expected valid sync credential state replacement parameters.",
+        );
+      }
 
       if (
         currentSnapshot === undefined ||
@@ -805,12 +825,11 @@ export function createCoreTestPorts(
         saved.vaultSnapshotDigest !== expectedSnapshotDigest ||
         saved.localVaultTrustCheckpoint === undefined ||
         !areJsonEqual(saved.localVaultTrustCheckpoint, expectedCheckpoint) ||
-        (syncCredentialState !== undefined &&
-          (!Object.hasOwn(params, "expectedSyncCredentialState") ||
-            !areEncryptedSyncCredentialStatesEqual(
-              saved.deviceSyncCredentialState,
-              expectedSyncCredentialState,
-            )))
+        (replacesSyncCredentialState &&
+          !areEncryptedSyncCredentialStatesEqual(
+            saved.deviceSyncCredentialState,
+            expectedSyncCredentialState,
+          ))
       ) {
         throw new LocalVaultSnapshotChangedError(snapshot.metadata.id);
       }

--- a/packages/core/src/__tests__/fixtures/vault-entries.test.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.test.ts
@@ -73,7 +73,10 @@ describe("createVaultSnapshotServiceMock", () => {
     );
     const secondPersist = await service.persistUnlockedVault(
       values.vaultId,
-      unlockedVault,
+      {
+        ...unlockedVault,
+        trustedSnapshotContext: firstPersist.trustedSnapshotContext,
+      },
       firstPersist.snapshotVersionVector,
     );
 
@@ -94,6 +97,7 @@ describe("createVaultSnapshotServiceMock", () => {
     await service.restorePreparedLocalVaultSnapshot(
       firstPreparedRestore,
       secondPersist.trustedSnapshotContext.snapshotDigest,
+      secondPersist.checkpoint,
     );
 
     expect(ports.saved.vaultSnapshot).toBe(firstPersist.snapshot);

--- a/packages/core/src/__tests__/fixtures/vault-entries.test.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.test.ts
@@ -93,6 +93,15 @@ describe("createVaultSnapshotServiceMock", () => {
     expect(ports.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual(
       secondPersist.snapshotVersionVector,
     );
+    await expect(
+      service.verifyCandidateSnapshotTrust(
+        values.vaultId,
+        secondPersist.snapshot,
+        unlockedVault,
+      ),
+    ).resolves.toMatchObject({
+      snapshotDigest: secondPersist.trustedSnapshotContext.snapshotDigest,
+    });
 
     await service.restorePreparedLocalVaultSnapshot(
       firstPreparedRestore,

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -4,6 +4,7 @@ import type { PasswordEntry } from "../../domain/entry/password-entry.type";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
 import type { Tag } from "../../domain/entry/tag.type";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
+import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
 import type { EncryptedDeviceSyncCredentialState } from "../../domain/sync";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import {
@@ -204,7 +205,10 @@ export function createVaultSnapshotServiceMock(
       return {
         snapshot: vaultSnapshot,
         checkpoint,
-        ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+        syncCredentialState:
+          syncCredentialState === undefined
+            ? (ports.saved.deviceSyncCredentialState ?? null)
+            : syncCredentialState,
       };
     },
   );
@@ -213,14 +217,16 @@ export function createVaultSnapshotServiceMock(
     async (
       preparedRestore: PreparedLocalVaultSnapshotRestore,
       expectedSnapshotDigest: string,
+      expectedCheckpoint: LocalVaultTrustCheckpoint,
+      expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null = preparedRestore.syncCredentialState,
     ) => {
       await ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
         expectedSnapshotDigest,
+        expectedCheckpoint,
+        expectedSyncCredentialState,
         snapshot: preparedRestore.snapshot,
         checkpoint: preparedRestore.checkpoint,
-        ...(preparedRestore.syncCredentialState === undefined
-          ? {}
-          : { syncCredentialState: preparedRestore.syncCredentialState }),
+        syncCredentialState: preparedRestore.syncCredentialState,
       });
       snapshotRestoreStates.set(preparedRestore.snapshot, {
         snapshotDigest: preparedRestore.checkpoint.payload.snapshotDigest,
@@ -254,9 +260,13 @@ export function createVaultSnapshotServiceMock(
         {
           snapshot: vaultSnapshot,
           checkpoint: restoreState.checkpoint,
-          ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+          syncCredentialState:
+            syncCredentialState === undefined
+              ? (ports.saved.deviceSyncCredentialState ?? null)
+              : syncCredentialState,
         },
         replacedState.snapshotDigest,
+        replacedState.checkpoint,
       );
     },
   );
@@ -266,6 +276,23 @@ export function createVaultSnapshotServiceMock(
       requireSavedVaultSnapshot(),
     ),
     requireLocalVaultSnapshot: vi.fn(async () => requireSavedVaultSnapshot()),
+    requireCurrentCheckpointForUnlockedVault: vi.fn(async () => {
+      const checkpoint = ports.saved.localVaultTrustCheckpoint;
+
+      if (checkpoint === undefined) {
+        throw new Error("Expected a saved checkpoint fixture.");
+      }
+
+      return checkpoint;
+    }),
+    verifyCandidateSnapshotTrust: vi.fn(async (vaultId, snapshot) => ({
+      chain: snapshot.trustChain,
+      state: values.verifiedVaultTrustState,
+      snapshotDigest:
+        snapshot.metadata.id === vaultId
+          ? values.vaultSnapshotDigest
+          : "different-vault-snapshot-digest",
+    })),
     restoreLocalVaultSnapshot,
     prepareLocalVaultSnapshotRestore,
     restorePreparedLocalVaultSnapshot,
@@ -278,7 +305,17 @@ export function createVaultSnapshotServiceMock(
           readonly baseSnapshotVersionVector?: VersionVector;
           readonly keySlots?: VaultSnapshot["keySlots"];
           readonly vaultKeyGeneration?: number;
-        } = {},
+          readonly uploadExpectedRemoteSnapshotIdentity?: VaultSnapshot["metadata"]["uploadExpectedRemoteSnapshotIdentity"];
+        } & (
+          | {
+              readonly expectedSyncCredentialState?: undefined;
+              readonly syncCredentialState?: undefined;
+            }
+          | {
+              readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null;
+              readonly syncCredentialState: EncryptedDeviceSyncCredentialState | null;
+            }
+        ) = {},
       ) => {
         const currentVaultSnapshot = requireSavedVaultSnapshot();
         const persistedVaultSnapshot = {
@@ -295,6 +332,12 @@ export function createVaultSnapshotServiceMock(
             vaultKeyGeneration:
               options.vaultKeyGeneration ??
               currentVaultSnapshot.metadata.vaultKeyGeneration,
+            ...(options.uploadExpectedRemoteSnapshotIdentity === undefined
+              ? {}
+              : {
+                  uploadExpectedRemoteSnapshotIdentity:
+                    options.uploadExpectedRemoteSnapshotIdentity,
+                }),
           },
           keySlots: options.keySlots ?? currentVaultSnapshot.keySlots,
           content: values.encryptedVault,
@@ -320,9 +363,27 @@ export function createVaultSnapshotServiceMock(
             snapshotDigest: persistedSnapshotDigest,
           },
         };
-        ports.saved.vaultSnapshot = persistedVaultSnapshot;
-        ports.saved.vaultSnapshotDigest = persistedSnapshotDigest;
-        ports.saved.localVaultTrustCheckpoint = persistedCheckpoint;
+        const persistence = {
+          expectedSnapshotDigest:
+            unlockedVault.trustedSnapshotContext.snapshotDigest,
+          expectedCheckpoint:
+            ports.saved.localVaultTrustCheckpoint ??
+            values.localVaultTrustCheckpoint,
+          snapshot: persistedVaultSnapshot,
+          checkpoint: persistedCheckpoint,
+        };
+
+        if (options.syncCredentialState === undefined) {
+          await ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint(
+            persistence,
+          );
+        } else {
+          await ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+            ...persistence,
+            expectedSyncCredentialState: options.expectedSyncCredentialState,
+            syncCredentialState: options.syncCredentialState,
+          });
+        }
         snapshotRestoreStates.set(persistedVaultSnapshot, {
           snapshotDigest: persistedSnapshotDigest,
           checkpoint: persistedCheckpoint,
@@ -336,6 +397,7 @@ export function createVaultSnapshotServiceMock(
             snapshotDigest: persistedSnapshotDigest,
             trust: values.verifiedVaultTrustState,
           },
+          checkpoint: persistedCheckpoint,
           snapshot: persistedVaultSnapshot,
         };
       },

--- a/packages/core/src/__tests__/fixtures/vault-entries.ts
+++ b/packages/core/src/__tests__/fixtures/vault-entries.ts
@@ -290,7 +290,8 @@ export function createVaultSnapshotServiceMock(
       state: values.verifiedVaultTrustState,
       snapshotDigest:
         snapshot.metadata.id === vaultId
-          ? values.vaultSnapshotDigest
+          ? (snapshotRestoreStates.get(snapshot)?.snapshotDigest ??
+            values.vaultSnapshotDigest)
           : "different-vault-snapshot-digest",
     })),
     restoreLocalVaultSnapshot,

--- a/packages/core/src/domain/snapshot/vault-snapshot-descriptor.type.ts
+++ b/packages/core/src/domain/snapshot/vault-snapshot-descriptor.type.ts
@@ -6,7 +6,12 @@ export type VaultSnapshotDescriptor = {
   readonly revisionTimestamp: number;
 };
 
-export type ReviewedVaultSnapshotDescriptors = {
-  readonly local: VaultSnapshotDescriptor;
-  readonly remote: VaultSnapshotDescriptor;
+export type VaultSnapshotIdentity = {
+  readonly descriptor: VaultSnapshotDescriptor;
+  readonly snapshotDigest: string;
+};
+
+export type ReviewedVaultSnapshotIdentities = {
+  readonly local: VaultSnapshotIdentity;
+  readonly remote: VaultSnapshotIdentity;
 };

--- a/packages/core/src/domain/snapshot/vault-snapshot-descriptor.utils.test.ts
+++ b/packages/core/src/domain/snapshot/vault-snapshot-descriptor.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
   compareVaultSnapshotDescriptors,
 } from "./vault-snapshot-descriptor.utils";
@@ -49,6 +50,34 @@ describe("vault snapshot descriptor utils", () => {
       ),
     ).toBe("remote_ahead");
   });
+
+  it.each([
+    [{ A: 1 }, { A: 1 }],
+    [{ A: 2 }, { A: 1 }],
+    [{ A: 1 }, { A: 2 }],
+    [
+      { A: 2, B: 1 },
+      { A: 1, B: 2 },
+    ],
+  ])(
+    "treats different vaults as broken before comparing vectors",
+    (localVector, remoteVector) => {
+      expect(
+        compareVaultSnapshotDescriptors(
+          {
+            vaultId: "local-vault-id",
+            snapshotVersionVector: localVector,
+            revisionTimestamp: 1,
+          },
+          {
+            vaultId: "remote-vault-id",
+            snapshotVersionVector: remoteVector,
+            revisionTimestamp: 2,
+          },
+        ),
+      ).toBe("broken");
+    },
+  );
 
   it("checks descriptor equality by vault id, vector, and timestamp", () => {
     expect(
@@ -105,6 +134,27 @@ describe("vault snapshot descriptor utils", () => {
           snapshotVersionVector: { A: 7 },
           revisionTimestamp: 2,
         },
+      ),
+    ).toBe(false);
+  });
+
+  it("requires the digest as well as the descriptor for snapshot identity equality", () => {
+    const descriptor = {
+      vaultId: "vault-id",
+      snapshotVersionVector: { A: 7 },
+      revisionTimestamp: 1,
+    };
+
+    expect(
+      areVaultSnapshotIdentitiesEqual(
+        { descriptor, snapshotDigest: "digest-a" },
+        { descriptor: { ...descriptor }, snapshotDigest: "digest-a" },
+      ),
+    ).toBe(true);
+    expect(
+      areVaultSnapshotIdentitiesEqual(
+        { descriptor, snapshotDigest: "digest-a" },
+        { descriptor: { ...descriptor }, snapshotDigest: "digest-b" },
       ),
     ).toBe(false);
   });

--- a/packages/core/src/domain/snapshot/vault-snapshot-descriptor.utils.ts
+++ b/packages/core/src/domain/snapshot/vault-snapshot-descriptor.utils.ts
@@ -1,7 +1,8 @@
 import type { VaultSnapshot } from "./vault-snapshot";
 import type {
-  ReviewedVaultSnapshotDescriptors,
+  ReviewedVaultSnapshotIdentities,
   VaultSnapshotDescriptor,
+  VaultSnapshotIdentity,
 } from "./vault-snapshot-descriptor.type";
 import { compareVersionVectors } from "../versioning/version-vector.utils";
 import type { VersionVectorRelation } from "../versioning/version-vector.type";
@@ -16,12 +17,31 @@ export function cloneVaultSnapshotDescriptor(
   };
 }
 
-export function cloneReviewedVaultSnapshotDescriptors(
-  descriptors: ReviewedVaultSnapshotDescriptors,
-): ReviewedVaultSnapshotDescriptors {
+export function cloneVaultSnapshotIdentity(
+  identity: VaultSnapshotIdentity,
+): VaultSnapshotIdentity {
   return {
-    local: cloneVaultSnapshotDescriptor(descriptors.local),
-    remote: cloneVaultSnapshotDescriptor(descriptors.remote),
+    descriptor: cloneVaultSnapshotDescriptor(identity.descriptor),
+    snapshotDigest: identity.snapshotDigest,
+  };
+}
+
+export function areVaultSnapshotIdentitiesEqual(
+  actual: VaultSnapshotIdentity,
+  expected: VaultSnapshotIdentity,
+): boolean {
+  return (
+    actual.snapshotDigest === expected.snapshotDigest &&
+    areVaultSnapshotDescriptorsEqual(actual.descriptor, expected.descriptor)
+  );
+}
+
+export function cloneReviewedVaultSnapshotIdentities(
+  identities: ReviewedVaultSnapshotIdentities,
+): ReviewedVaultSnapshotIdentities {
+  return {
+    local: cloneVaultSnapshotIdentity(identities.local),
+    remote: cloneVaultSnapshotIdentity(identities.remote),
   };
 }
 
@@ -29,6 +49,10 @@ export function compareVaultSnapshotDescriptors(
   local: VaultSnapshotDescriptor,
   remote: VaultSnapshotDescriptor,
 ): Exclude<VersionVectorRelation, "remote_missing"> {
+  if (local.vaultId !== remote.vaultId) {
+    return "broken";
+  }
+
   return compareVersionVectors(
     local.snapshotVersionVector,
     remote.snapshotVersionVector,
@@ -58,4 +82,15 @@ export function toVaultSnapshotDescriptor(
     snapshotVersionVector: vaultSnapshot.metadata.snapshotVersionVector,
     revisionTimestamp: vaultSnapshot.metadata.revisionTimestamp,
   });
+}
+
+export function toVaultSnapshotIdentity(
+  vaultId: string,
+  vaultSnapshot: VaultSnapshot,
+  snapshotDigest: string,
+): VaultSnapshotIdentity {
+  return {
+    descriptor: toVaultSnapshotDescriptor(vaultId, vaultSnapshot),
+    snapshotDigest,
+  };
 }

--- a/packages/core/src/domain/snapshot/vault-snapshot.ts
+++ b/packages/core/src/domain/snapshot/vault-snapshot.ts
@@ -5,6 +5,7 @@ import type {
 import type { Vault } from "../vault/vault";
 import type { VersionVector } from "../versioning/version-vector.type";
 import type { DeviceKeySlot } from "./key-slot";
+import type { VaultSnapshotIdentity } from "./vault-snapshot-descriptor.type";
 import type { VaultTrustChain } from "../device-trust/vault-trust";
 
 export type VaultSnapshotSchemaVersion = 1;
@@ -18,6 +19,7 @@ export type VaultSnapshotMetadata = {
   algorithmSuiteId: string;
   createdByDeviceId: string;
   vaultKeyGeneration: number;
+  uploadExpectedRemoteSnapshotIdentity?: VaultSnapshotIdentity | null;
 };
 
 export type UnsignedVaultSnapshot = {

--- a/packages/core/src/domain/sync/device-sync-credential-state.ts
+++ b/packages/core/src/domain/sync/device-sync-credential-state.ts
@@ -4,9 +4,14 @@ import type {
   SyncProvider,
   SyncTarget,
 } from "./sync-config.type";
+import type { VaultSnapshotIdentity } from "../snapshot/vault-snapshot-descriptor.type";
 
 export type DeviceSyncCredentialState = {
   readonly currentCredentials: SyncCredentials;
+  readonly pendingSnapshotUpload?: {
+    readonly candidateSnapshotIdentity: VaultSnapshotIdentity;
+    readonly expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null;
+  };
   readonly previousCredentials?: {
     readonly credentials: SyncCredentials;
     readonly revokedDeviceIds: readonly string[];

--- a/packages/core/src/domain/sync/index.ts
+++ b/packages/core/src/domain/sync/index.ts
@@ -1,2 +1,3 @@
 export * from "./sync-config.type";
 export * from "./device-sync-credential-state";
+export type { SyncUploadStatus } from "./sync-upload-status.type";

--- a/packages/core/src/domain/sync/sync-upload-status.type.ts
+++ b/packages/core/src/domain/sync/sync-upload-status.type.ts
@@ -1,0 +1,1 @@
+export type SyncUploadStatus = "complete" | "pending";

--- a/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.test.ts
@@ -12,20 +12,23 @@ import {
 describe("vault sync target mutations", () => {
   it("marks remote removal pending", () => {
     const { values, vaultSnapshot } = createUnlockVaultTestContext();
-    const expectedRemoteSnapshotDescriptor = {
-      vaultId: values.vaultId,
-      snapshotVersionVector: { [values.deviceId]: 1 },
-      revisionTimestamp: values.timestamp,
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: {
+        vaultId: values.vaultId,
+        snapshotVersionVector: { [values.deviceId]: 1 },
+        revisionTimestamp: values.timestamp,
+      },
+      snapshotDigest: values.vaultSnapshotDigest,
     };
 
     expect(
       markVaultSyncRemovalPending(
         values.decryptedVault,
-        expectedRemoteSnapshotDescriptor,
+        expectedRemoteSnapshotIdentity,
         vaultSnapshot,
       ).syncRemovalPending,
     ).toEqual({
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
       rollbackSnapshot: vaultSnapshot,
     });
   });
@@ -36,7 +39,7 @@ describe("vault sync target mutations", () => {
       ...values.decryptedVault,
       syncTarget: values.syncTarget,
       syncRemovalPending: {
-        expectedRemoteSnapshotDescriptor: null,
+        expectedRemoteSnapshotIdentity: null,
         rollbackSnapshot: vaultSnapshot,
       },
     });
@@ -69,7 +72,7 @@ describe("vault sync target mutations", () => {
       ...values.decryptedVault,
       syncTarget: values.syncTarget,
       syncRemovalPending: {
-        expectedRemoteSnapshotDescriptor: null,
+        expectedRemoteSnapshotIdentity: null,
         rollbackSnapshot: vaultSnapshot,
       },
       providerCredentialRevocationPending: {

--- a/packages/core/src/domain/vault/vault-sync-config.mutations.ts
+++ b/packages/core/src/domain/vault/vault-sync-config.mutations.ts
@@ -1,16 +1,16 @@
-import type { VaultSnapshotDescriptor } from "../snapshot/vault-snapshot-descriptor.type";
+import type { VaultSnapshotIdentity } from "../snapshot/vault-snapshot-descriptor.type";
 import type { VaultSnapshot } from "../snapshot/vault-snapshot";
 import type { Vault } from "./vault";
 
 export function markVaultSyncRemovalPending(
   vault: Vault,
-  expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
+  expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
   rollbackSnapshot: VaultSnapshot,
 ): Vault {
   return {
     ...vault,
     syncRemovalPending: {
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
       rollbackSnapshot,
     },
   };

--- a/packages/core/src/domain/vault/vault.ts
+++ b/packages/core/src/domain/vault/vault.ts
@@ -7,7 +7,7 @@ import type {
   PasswordEntry,
 } from "../entry/password-entry.type";
 import type { SyncTarget } from "../sync/sync-config.type";
-import type { VaultSnapshotDescriptor } from "../snapshot/vault-snapshot-descriptor.type";
+import type { VaultSnapshotIdentity } from "../snapshot/vault-snapshot-descriptor.type";
 import type { VaultSnapshot } from "../snapshot/vault-snapshot";
 import type { VersionVector } from "../versioning/version-vector.type";
 import type { DeletedTag, Tag } from "../entry/tag.type";
@@ -20,7 +20,7 @@ export interface Vault {
   deletedDeviceProfiles: DeletedDeviceProfile[];
   syncTarget?: SyncTarget;
   syncRemovalPending?: {
-    readonly expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null;
+    readonly expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null;
     readonly rollbackSnapshot: VaultSnapshot;
   };
   providerCredentialRevocationPending?: {

--- a/packages/core/src/errors/sync.errors.ts
+++ b/packages/core/src/errors/sync.errors.ts
@@ -10,8 +10,16 @@ export class InvalidSyncConfigError extends Error {
 export class InvalidSyncProviderOutcomeError extends Error {
   override readonly name = "InvalidSyncProviderOutcomeError";
 
-  constructor() {
-    super("Sync provider access outcome is malformed.");
+  constructor(operation: "access" | "upload") {
+    super(`Sync provider ${operation} outcome is malformed.`);
+  }
+}
+
+export class SyncProviderUploadRejectedError extends Error {
+  override readonly name = "SyncProviderUploadRejectedError";
+
+  constructor(vaultId: string) {
+    super(`Sync provider rejected the upload for vault "${vaultId}".`);
   }
 }
 

--- a/packages/core/src/ports/sync/sync-provider.port.ts
+++ b/packages/core/src/ports/sync/sync-provider.port.ts
@@ -1,9 +1,48 @@
-import type { VaultSnapshotDescriptor } from "../../domain/snapshot/vault-snapshot-descriptor.type";
+import type {
+  VaultSnapshotDescriptor,
+  VaultSnapshotIdentity,
+} from "../../domain/snapshot/vault-snapshot-descriptor.type";
 import type {
   SyncAccess,
   SyncSetupInput,
 } from "../../domain/sync/sync-config.type";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
+
+export type SyncUploadOutcome =
+  | { readonly status: "committed" }
+  | {
+      readonly status: "definitely_not_committed";
+      readonly reason: "remote_snapshot_changed" | "provider_rejected";
+    }
+  | { readonly status: "outcome_unknown" };
+
+export type DefiniteSyncUploadNonCommit = Extract<
+  SyncUploadOutcome,
+  { readonly status: "definitely_not_committed" }
+>;
+
+export type PreparedSyncUpload =
+  | {
+      readonly status: "ready";
+      /**
+       * Initiates the remote write synchronously and returns its eventual
+       * outcome. Implementations must not perform asynchronous preparation
+       * before initiating the write from this callback.
+       */
+      readonly start: () => { readonly outcome: Promise<SyncUploadOutcome> };
+    }
+  | {
+      readonly status: "not_started";
+      readonly outcome: DefiniteSyncUploadNonCommit;
+    };
+
+export type PreparedSyncRemoval =
+  | {
+      readonly status: "ready";
+      /** Initiates the remote removal synchronously. */
+      readonly start: () => { readonly outcome: Promise<void> };
+    }
+  | { readonly status: "already_absent" };
 
 export interface SyncProviderPort {
   /**
@@ -21,25 +60,35 @@ export interface SyncProviderPort {
     syncAccess: SyncAccess,
     descriptor: VaultSnapshotDescriptor,
   ) => Promise<VaultSnapshot>;
-  uploadVaultSnapshot: (
+  /**
+   * Performs read-only preparation and returns either a proven non-started
+   * outcome or an operation whose synchronous start callback initiates the
+   * remote write. Preparation may reject because it cannot have committed.
+   * Once start is called, failures must resolve as either a definite non-commit
+   * or an outcome-unknown result; a generic rejection must never imply that the
+   * write did not commit. Definite non-commit reasons distinguish a remote
+   * snapshot change from a proven static provider rejection so callers preserve
+   * the established conflict semantics without hiding configuration failures.
+   */
+  prepareVaultSnapshotUpload: (
     syncAccess: SyncAccess,
     vaultSnapshot: VaultSnapshot,
-    expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
-  ) => Promise<void>;
+    expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
+  ) => Promise<PreparedSyncUpload>;
   /**
-   * Removes all remote state for a vault only when the latest snapshot still
-   * matches the expected descriptor. A null expected descriptor means that no
-   * remote snapshot may exist. A different current descriptor, including a
-   * snapshot appearing when null was expected, must fail with
-   * RemoteVaultSnapshotChangedError without removing remote state. This
-   * operation must be idempotent: attempting to remove an already-absent vault
-   * is successful.
+   * Performs read-only preparation for removing remote vault state only when
+   * the latest snapshot still matches the expected identity. A null expected
+   * identity means that no remote snapshot may exist. A different current
+   * identity, including a snapshot appearing when null was expected, must fail
+   * with RemoteVaultSnapshotChangedError without removing remote state. The
+   * returned start callback initiates removal synchronously. Preparation is
+   * idempotent: an already-absent vault returns already_absent.
    */
-  removeVaultSnapshots: (
+  prepareVaultSnapshotRemoval: (
     syncAccess: SyncAccess,
     vaultId: string,
-    expectedRemoteSnapshotDescriptor: VaultSnapshotDescriptor | null,
-  ) => Promise<void>;
+    expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
+  ) => Promise<PreparedSyncRemoval>;
   /**
    * Returns authentication rejection only when the provider definitively
    * rejects the credential. Network, rate-limit, and indeterminate provider

--- a/packages/core/src/ports/vault/vault-local-repository.port.ts
+++ b/packages/core/src/ports/vault/vault-local-repository.port.ts
@@ -25,14 +25,22 @@ export interface VaultLocalRepositoryPort {
   }) => Promise<void>;
   removePersistedLocalVault: (vaultId: string) => Promise<void>;
   /**
-   * Atomically removes all local records for a vault only when its current
-   * snapshot still matches `expectedSnapshotDigest`. Returns false without
-   * changing any record when the snapshot is absent or has changed.
+   * Atomically removes all initialized local records only when every record
+   * still exactly belongs to the operation requesting rollback. The snapshot
+   * is compared by digest; all other artifacts are compared exactly, and a
+   * `null` sync credential expectation means the record must be absent.
+   * Returns false without changing any record when an expectation changed or
+   * disappeared.
    */
-  removePersistedLocalVaultIfSnapshotMatches: (
-    vaultId: string,
-    expectedSnapshotDigest: string,
-  ) => Promise<boolean>;
+  removePersistedLocalVaultIfArtifactsMatch: (params: {
+    readonly vaultId: string;
+    readonly expectedDescriptor: LocalVaultDescriptor;
+    readonly expectedDeviceAccessMaterial: DeviceAccessMaterial;
+    readonly expectedDeviceAccessRecoveryBackup: DeviceAccessRecoveryBackup;
+    readonly expectedSnapshotDigest: string;
+    readonly expectedCheckpoint: LocalVaultTrustCheckpoint;
+    readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null;
+  }) => Promise<boolean>;
 
   saveLocalVaultDescriptor: (descriptor: LocalVaultDescriptor) => Promise<void>;
   getLocalVaultDescriptor: (
@@ -104,17 +112,31 @@ export interface VaultLocalRepositoryPort {
 
   /**
    * Atomically replaces the snapshot, signed rollback checkpoint, and optional
-   * local sync credential state only when the persisted snapshot still matches
-   * `expectedSnapshotDigest`. An omitted credential state remains unchanged;
-   * `null` removes it. Rejects with `LocalVaultSnapshotChangedError` without
-   * changing any record when the expected snapshot is no longer current.
+   * local sync credential state only when the persisted snapshot and exact
+   * signed checkpoint still match their expectations. When replacing
+   * credentials, callers must also provide the exact expected encrypted
+   * credential state; `null` means absent.
+   * An omitted credential state remains unchanged; `null` removes it. Rejects
+   * with `LocalVaultSnapshotChangedError` without changing any record when
+   * either expected artifact is no longer current.
    */
-  saveVaultSnapshotWithCheckpoint: (params: {
-    readonly expectedSnapshotDigest: string;
-    readonly snapshot: VaultSnapshot;
-    readonly checkpoint: LocalVaultTrustCheckpoint;
-    readonly syncCredentialState?: EncryptedDeviceSyncCredentialState | null;
-  }) => Promise<void>;
+  saveVaultSnapshotWithCheckpoint: (
+    params: {
+      readonly expectedSnapshotDigest: string;
+      readonly expectedCheckpoint: LocalVaultTrustCheckpoint;
+      readonly snapshot: VaultSnapshot;
+      readonly checkpoint: LocalVaultTrustCheckpoint;
+    } & (
+      | {
+          readonly expectedSyncCredentialState?: never;
+          readonly syncCredentialState?: never;
+        }
+      | {
+          readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null;
+          readonly syncCredentialState: EncryptedDeviceSyncCredentialState | null;
+        }
+    ),
+  ) => Promise<void>;
   getLocalVaultTrustCheckpoint: (
     vaultId: string,
   ) => Promise<LocalVaultTrustCheckpoint | null>;

--- a/packages/core/src/services/session/unlocked-vault-session.service.test.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.test.ts
@@ -909,6 +909,35 @@ describe("UnlockedVaultSessionService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("skips a conditional persisted snapshot commit after the session was removed", async () => {
+    const ctx = createContext();
+    ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);
+    ctx.ports.saved.encryptedUnlockedVaultSessionPayload =
+      createEncryptedPayload(ctx);
+    const context = await ctx.service.requireUnlockedVaultContext(
+      ctx.values.vaultId,
+      "test",
+    );
+    await ctx.service.remove();
+
+    await expect(
+      ctx.service.commitPersistedSnapshotIfSessionIsActive(
+        context.sessionId,
+        context.unlockedVault,
+        context.sourceSnapshotVersionVector,
+      ),
+    ).resolves.toBe(false);
+
+    expect(
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository
+        .saveEncryptedUnlockedVaultSessionPayload,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.unlockedVaultSessionMaterialRepository
+        .saveUnlockedVaultSessionMaterial,
+    ).not.toHaveBeenCalled();
+  });
+
   it("does not replace a newer session with a stale persisted snapshot commit", async () => {
     const ctx = createContext();
     ctx.ports.saved.unlockedVaultSessionMaterial = createMaterial(ctx);

--- a/packages/core/src/services/session/unlocked-vault-session.service.ts
+++ b/packages/core/src/services/session/unlocked-vault-session.service.ts
@@ -511,16 +511,38 @@ export class UnlockedVaultSessionService {
     sourceSnapshotVersionVector: VersionVector,
     coordinationLease?: ClipboardOperationLease,
   ): Promise<void> {
-    await this.runCoordinatedSessionMutation(coordinationLease, async () => {
+    const committed = await this.commitPersistedSnapshotIfSessionIsActive(
+      sessionId,
+      unlockedVault,
+      sourceSnapshotVersionVector,
+      coordinationLease,
+    );
+
+    if (!committed) {
+      throw new UnlockedVaultSessionExpiredError(unlockedVault.vaultId);
+    }
+  }
+
+  async commitPersistedSnapshotIfSessionIsActive(
+    sessionId: string,
+    unlockedVault: UnlockedVault,
+    sourceSnapshotVersionVector: VersionVector,
+    coordinationLease?: ClipboardOperationLease,
+  ): Promise<boolean> {
+    return this.runCoordinatedSessionMutation(coordinationLease, async () => {
       const persistedIdentity =
         await this.materialRepository.getPersistedUnlockedVaultSessionIdentity();
       const { material } =
         await this.reconcileActiveMaterial(persistedIdentity);
-      const activeMaterial = this.requireActiveSession(
-        material,
-        sessionId,
-        unlockedVault.vaultId,
-      );
+
+      if (
+        material === null ||
+        !this.isActiveSession(material, sessionId, unlockedVault.vaultId)
+      ) {
+        return false;
+      }
+
+      const activeMaterial = material;
 
       let protectedSession:
         | Awaited<ReturnType<UnlockedVaultSessionService["protect"]>>
@@ -547,6 +569,8 @@ export class UnlockedVaultSessionService {
         );
         throw error;
       }
+
+      return true;
     });
   }
 

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
-import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
+import {
+  LocalVaultTrustCheckpointInvalidError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
 import {
   SnapshotSigningDeviceNotTrustedError,
   VaultSnapshotDigestMismatchError,
 } from "../../errors/vault-snapshot.errors";
 import { VaultSnapshotService } from "./vault-snapshot.service";
+import { VaultTrustService } from "../trust/vault-trust.service";
 
 function createContext() {
   const base = createUnlockVaultTestContext();
@@ -111,16 +115,20 @@ describe("VaultSnapshotService", () => {
     ).mock.calls.length;
     new Uint8Array(ctx.unlockedVault.devicePrivateSignKey).fill(0);
     ctx.ports.saved.vaultSnapshotDigest = "replacement-snapshot-digest";
+    ctx.ports.saved.deviceSyncCredentialState = undefined;
 
     await ctx.service.restorePreparedLocalVaultSnapshot(
       preparedRestore,
       "replacement-snapshot-digest",
+      ctx.values.localVaultTrustCheckpoint,
     );
 
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).toHaveBeenLastCalledWith({
       expectedSnapshotDigest: "replacement-snapshot-digest",
+      expectedCheckpoint: ctx.values.localVaultTrustCheckpoint,
+      expectedSyncCredentialState: null,
       snapshot: ctx.vaultSnapshot,
       checkpoint: preparedRestore.checkpoint,
       syncCredentialState: null,
@@ -149,6 +157,44 @@ describe("VaultSnapshotService", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("rejects an unauthenticated current checkpoint before persistence", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.crypto.verifyLocalVaultTrustCheckpointSignature,
+    ).mockResolvedValueOnce(false);
+
+    await expect(
+      ctx.service.persistUnlockedVault(
+        ctx.values.vaultId,
+        ctx.unlockedVault,
+        ctx.vaultSnapshot.metadata.snapshotVersionVector,
+      ),
+    ).rejects.toBeInstanceOf(LocalVaultTrustCheckpointInvalidError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated current checkpoint before restoration", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.crypto.verifyLocalVaultTrustCheckpointSignature,
+    ).mockResolvedValueOnce(false);
+
+    await expect(
+      ctx.service.restoreLocalVaultSnapshot(
+        ctx.vaultSnapshot,
+        ctx.vaultSnapshot,
+        ctx.unlockedVault,
+      ),
+    ).rejects.toBeInstanceOf(LocalVaultTrustCheckpointInvalidError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
   it("verifies candidate trust before returning it", async () => {
     const ctx = createContext();
 
@@ -161,6 +207,63 @@ describe("VaultSnapshotService", () => {
     ).resolves.toEqual({
       chain: ctx.values.vaultTrustChain,
       state: ctx.values.verifiedVaultTrustState,
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
     });
+  });
+
+  it("verifies a historical remote as an ancestor of the current candidate trust", async () => {
+    const ctx = createContext();
+    const historicalTrust = {
+      ...ctx.values.verifiedVaultTrustState,
+      generation: 0,
+    };
+    const currentTrust = {
+      ...ctx.values.verifiedVaultTrustState,
+      generation: 1,
+      certificateDigest: "current-certificate-digest",
+    };
+    const currentSnapshot = {
+      ...ctx.vaultSnapshot,
+      trustChain: {
+        certificates: [...ctx.vaultSnapshot.trustChain.certificates],
+      },
+    };
+    const verifyTrustChain = vi
+      .spyOn(VaultTrustService.prototype, "verifyTrustChain")
+      .mockResolvedValue(historicalTrust);
+    const verifySnapshot = vi
+      .spyOn(VaultTrustService.prototype, "verifySnapshot")
+      .mockResolvedValue(undefined);
+    const requireTrustDescendsFrom = vi
+      .spyOn(VaultTrustService.prototype, "requireTrustDescendsFrom")
+      .mockResolvedValue(undefined);
+
+    try {
+      await expect(
+        ctx.service.verifyHistoricalSnapshotTrust(
+          ctx.values.vaultId,
+          ctx.vaultSnapshot,
+          currentSnapshot,
+          {
+            ...ctx.unlockedVault,
+            trustedSnapshotContext: {
+              ...ctx.unlockedVault.trustedSnapshotContext,
+              trust: currentTrust,
+            },
+          },
+        ),
+      ).resolves.toMatchObject({ state: historicalTrust });
+
+      expect(requireTrustDescendsFrom).toHaveBeenCalledWith(
+        ctx.values.vaultId,
+        currentSnapshot.trustChain,
+        currentTrust,
+        historicalTrust,
+      );
+    } finally {
+      verifyTrustChain.mockRestore();
+      verifySnapshot.mockRestore();
+      requireTrustDescendsFrom.mockRestore();
+    }
   });
 });

--- a/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.test.ts
@@ -260,6 +260,14 @@ describe("VaultSnapshotService", () => {
         currentTrust,
         historicalTrust,
       );
+      expect(verifyTrustChain.mock.calls[0]?.[2]).toBe(
+        ctx.vaultSnapshot.trustChain,
+      );
+      expect(verifySnapshot).toHaveBeenCalledWith(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+        historicalTrust,
+      );
     } finally {
       verifyTrustChain.mockRestore();
       verifySnapshot.mockRestore();

--- a/packages/core/src/services/snapshot/vault-snapshot.service.ts
+++ b/packages/core/src/services/snapshot/vault-snapshot.service.ts
@@ -9,6 +9,8 @@ import type {
   UnsignedVaultSnapshot,
   VaultSnapshot,
 } from "../../domain/snapshot/vault-snapshot";
+import type { VaultSnapshotIdentity } from "../../domain/snapshot/vault-snapshot-descriptor.type";
+import { cloneVaultSnapshotIdentity } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 import type { Vault } from "../../domain/vault/vault";
 import type { EncryptedDeviceSyncCredentialState } from "../../domain/sync";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
@@ -24,7 +26,10 @@ import {
   VaultSnapshotDigestMismatchError,
   VaultSnapshotVersionMismatchError,
 } from "../../errors/vault-snapshot.errors";
-import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
+import {
+  LocalVaultTrustCheckpointNotFoundError,
+  VaultTrustStateInvalidError,
+} from "../../errors/vault-trust.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
@@ -33,8 +38,29 @@ import { VaultTrustService } from "../trust/vault-trust.service";
 export type PreparedLocalVaultSnapshotRestore = {
   readonly snapshot: VaultSnapshot;
   readonly checkpoint: LocalVaultTrustCheckpoint;
-  readonly syncCredentialState?: EncryptedDeviceSyncCredentialState | null;
+  readonly syncCredentialState: EncryptedDeviceSyncCredentialState | null;
 };
+
+type SyncCredentialStatePersistence =
+  | {
+      readonly syncCredentialState?: undefined;
+      readonly expectedSyncCredentialState?: undefined;
+    }
+  | {
+      readonly syncCredentialState: EncryptedDeviceSyncCredentialState | null;
+      readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null;
+    };
+
+type PersistUnlockedVaultOptions = {
+  readonly baseSnapshotVersionVector?: VersionVector;
+  readonly keySlots?: UnsignedVaultSnapshot["keySlots"];
+  readonly vaultKeyGeneration?: number;
+  readonly uploadExpectedRemoteSnapshotIdentity?: VaultSnapshotIdentity | null;
+  readonly nextTrust?: {
+    readonly chain: VaultTrustChain;
+    readonly state: VerifiedVaultTrustState;
+  };
+} & SyncCredentialStatePersistence;
 
 export class VaultSnapshotService {
   private readonly crypto: CryptoPort;
@@ -57,22 +83,19 @@ export class VaultSnapshotService {
     vaultId: string,
     unlockedVault: UnlockedVault,
     sourceSnapshotVersionVector: VersionVector,
-    options: {
-      readonly baseSnapshotVersionVector?: VersionVector;
-      readonly keySlots?: UnsignedVaultSnapshot["keySlots"];
-      readonly vaultKeyGeneration?: number;
-      readonly syncCredentialState?: EncryptedDeviceSyncCredentialState | null;
-      readonly nextTrust?: {
-        readonly chain: VaultTrustChain;
-        readonly state: VerifiedVaultTrustState;
-      };
-    } = {},
+    options: PersistUnlockedVaultOptions = {},
   ) {
     const currentSnapshot = await this.requireCurrentSnapshotForUnlockedVault(
       vaultId,
       unlockedVault,
       sourceSnapshotVersionVector,
     );
+    const expectedCheckpoint =
+      await this.requireCurrentCheckpointForUnlockedVault(
+        vaultId,
+        currentSnapshot,
+        unlockedVault,
+      );
     const trustChain = options.nextTrust?.chain ?? currentSnapshot.trustChain;
     const trustState =
       options.nextTrust?.state ?? unlockedVault.trustedSnapshotContext.trust;
@@ -111,6 +134,16 @@ export class VaultSnapshotService {
         vaultKeyGeneration:
           options.vaultKeyGeneration ??
           currentSnapshot.metadata.vaultKeyGeneration,
+        ...(options.uploadExpectedRemoteSnapshotIdentity === undefined
+          ? {}
+          : {
+              uploadExpectedRemoteSnapshotIdentity:
+                options.uploadExpectedRemoteSnapshotIdentity === null
+                  ? null
+                  : cloneVaultSnapshotIdentity(
+                      options.uploadExpectedRemoteSnapshotIdentity,
+                    ),
+            }),
       },
       trustChain,
       keySlots: options.keySlots ?? currentSnapshot.keySlots,
@@ -136,16 +169,25 @@ export class VaultSnapshotService {
       unlockedVault.deviceId,
       unlockedVault.devicePrivateSignKey,
     );
-
-    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+    const persistence = {
       expectedSnapshotDigest:
         unlockedVault.trustedSnapshotContext.snapshotDigest,
+      expectedCheckpoint,
       snapshot,
       checkpoint,
-      ...(options.syncCredentialState === undefined
-        ? {}
-        : { syncCredentialState: options.syncCredentialState }),
-    });
+    };
+
+    if (options.syncCredentialState === undefined) {
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint(
+        persistence,
+      );
+    } else {
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        ...persistence,
+        expectedSyncCredentialState: options.expectedSyncCredentialState,
+        syncCredentialState: options.syncCredentialState,
+      });
+    }
 
     return {
       snapshotVersionVector: snapshot.metadata.snapshotVersionVector,
@@ -154,6 +196,7 @@ export class VaultSnapshotService {
         snapshotDigest,
         trust: trustState,
       },
+      checkpoint,
       snapshot,
     };
   }
@@ -175,6 +218,7 @@ export class VaultSnapshotService {
   ): Promise<{
     readonly chain: VaultTrustChain;
     readonly state: VerifiedVaultTrustState;
+    readonly snapshotDigest: string;
   }> {
     this.requireSupportedSnapshotAlgorithm(vaultId, snapshot);
 
@@ -194,8 +238,48 @@ export class VaultSnapshotService {
       unlockedVault.trustedSnapshotContext.trust,
     );
     await this.vaultTrust.verifySnapshot(vaultId, snapshot, state);
+    const snapshotDigest = await this.crypto.digestVaultSnapshot(snapshot);
 
-    return { chain: snapshot.trustChain, state };
+    return { chain: snapshot.trustChain, state, snapshotDigest };
+  }
+
+  async verifyHistoricalSnapshotTrust(
+    vaultId: string,
+    historicalSnapshot: VaultSnapshot,
+    currentSnapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
+  ): Promise<{
+    readonly chain: VaultTrustChain;
+    readonly state: VerifiedVaultTrustState;
+    readonly snapshotDigest: string;
+  }> {
+    this.requireSupportedSnapshotAlgorithm(vaultId, historicalSnapshot);
+
+    if (historicalSnapshot.metadata.id !== vaultId) {
+      throw new PersistedVaultMismatchError(
+        vaultId,
+        historicalSnapshot.metadata.id,
+      );
+    }
+
+    const state = await this.vaultTrust.verifyTrustChain(
+      vaultId,
+      unlockedVault.vaultTrustAnchor,
+      historicalSnapshot.trustChain,
+    );
+    await this.vaultTrust.verifySnapshot(vaultId, historicalSnapshot, state);
+    await this.vaultTrust.requireTrustDescendsFrom(
+      vaultId,
+      currentSnapshot.trustChain,
+      unlockedVault.trustedSnapshotContext.trust,
+      state,
+    );
+
+    return {
+      chain: historicalSnapshot.trustChain,
+      state,
+      snapshotDigest: await this.crypto.digestVaultSnapshot(historicalSnapshot),
+    };
   }
 
   async restoreLocalVaultSnapshot(
@@ -204,14 +288,31 @@ export class VaultSnapshotService {
     unlockedVault: UnlockedVault,
     syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
   ): Promise<void> {
-    const preparedRestore = await this.prepareLocalVaultSnapshotRestore(
+    const preparedRestore = {
       snapshot,
-      unlockedVault,
-      syncCredentialState,
-    );
+      checkpoint: await this.vaultTrust.createCheckpoint(
+        snapshot,
+        unlockedVault.trustedSnapshotContext.trust,
+        unlockedVault.deviceId,
+        unlockedVault.devicePrivateSignKey,
+      ),
+      syncCredentialState:
+        syncCredentialState === undefined
+          ? await this.vaultLocalRepository.getDeviceSyncCredentialState(
+              snapshot.metadata.id,
+            )
+          : syncCredentialState,
+    } satisfies PreparedLocalVaultSnapshotRestore;
+    const expectedCheckpoint =
+      await this.requireCurrentCheckpointForUnlockedVault(
+        replacedSnapshot.metadata.id,
+        replacedSnapshot,
+        unlockedVault,
+      );
     await this.restorePreparedLocalVaultSnapshot(
       preparedRestore,
       await this.crypto.digestVaultSnapshot(replacedSnapshot),
+      expectedCheckpoint,
     );
   }
 
@@ -220,31 +321,67 @@ export class VaultSnapshotService {
     unlockedVault: UnlockedVault,
     syncCredentialState?: EncryptedDeviceSyncCredentialState | null,
   ): Promise<PreparedLocalVaultSnapshotRestore> {
-    const checkpoint = await this.vaultTrust.createCheckpoint(
+    const checkpoint = await this.requireCurrentCheckpointForUnlockedVault(
+      snapshot.metadata.id,
       snapshot,
-      unlockedVault.trustedSnapshotContext.trust,
-      unlockedVault.deviceId,
-      unlockedVault.devicePrivateSignKey,
+      unlockedVault,
     );
+
+    const restoredSyncCredentialState =
+      syncCredentialState === undefined
+        ? await this.vaultLocalRepository.getDeviceSyncCredentialState(
+            snapshot.metadata.id,
+          )
+        : syncCredentialState;
 
     return {
       snapshot,
       checkpoint,
-      ...(syncCredentialState === undefined ? {} : { syncCredentialState }),
+      syncCredentialState: restoredSyncCredentialState,
     };
+  }
+
+  async requireCurrentCheckpointForUnlockedVault(
+    vaultId: string,
+    snapshot: VaultSnapshot,
+    unlockedVault: UnlockedVault,
+  ): Promise<LocalVaultTrustCheckpoint> {
+    const checkpoint = await this.requireLocalVaultTrustCheckpoint(vaultId);
+    const trustedDevice =
+      unlockedVault.trustedSnapshotContext.trust.trustedDevices.find(
+        (device) => device.deviceId === unlockedVault.deviceId,
+      );
+
+    if (trustedDevice === undefined) {
+      throw new SnapshotSigningDeviceNotTrustedError(
+        vaultId,
+        unlockedVault.deviceId,
+      );
+    }
+
+    await this.vaultTrust.verifyCheckpoint(vaultId, checkpoint, trustedDevice);
+    await this.vaultTrust.requireSnapshotNotRolledBack(
+      vaultId,
+      snapshot,
+      unlockedVault.trustedSnapshotContext.trust,
+      checkpoint,
+    );
+    return checkpoint;
   }
 
   async restorePreparedLocalVaultSnapshot(
     preparedRestore: PreparedLocalVaultSnapshotRestore,
     expectedSnapshotDigest: string,
+    expectedCheckpoint: LocalVaultTrustCheckpoint,
+    expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null = preparedRestore.syncCredentialState,
   ): Promise<void> {
     await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
       expectedSnapshotDigest,
+      expectedCheckpoint,
+      expectedSyncCredentialState,
       snapshot: preparedRestore.snapshot,
       checkpoint: preparedRestore.checkpoint,
-      ...(preparedRestore.syncCredentialState === undefined
-        ? {}
-        : { syncCredentialState: preparedRestore.syncCredentialState }),
+      syncCredentialState: preparedRestore.syncCredentialState,
     });
   }
 
@@ -253,8 +390,19 @@ export class VaultSnapshotService {
     snapshot: VaultSnapshot,
     trustState: VerifiedVaultTrustState,
     unlockedVault: UnlockedVault,
+    syncCredentialStatePersistence?: {
+      readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState | null;
+      readonly syncCredentialState: EncryptedDeviceSyncCredentialState | null;
+    },
   ) {
     await this.vaultTrust.verifySnapshot(vaultId, snapshot, trustState);
+    const currentSnapshot = await this.requireLocalVaultSnapshot(vaultId);
+    const expectedCheckpoint =
+      await this.requireCurrentCheckpointForUnlockedVault(
+        vaultId,
+        currentSnapshot,
+        unlockedVault,
+      );
 
     const snapshotDigest = await this.crypto.digestVaultSnapshot(snapshot);
     const checkpoint = await this.vaultTrust.createCheckpoint(
@@ -263,13 +411,26 @@ export class VaultSnapshotService {
       unlockedVault.deviceId,
       unlockedVault.devicePrivateSignKey,
     );
-
-    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+    const persistence = {
       expectedSnapshotDigest:
         unlockedVault.trustedSnapshotContext.snapshotDigest,
+      expectedCheckpoint,
       snapshot,
       checkpoint,
-    });
+    };
+
+    if (syncCredentialStatePersistence === undefined) {
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint(
+        persistence,
+      );
+    } else {
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        ...persistence,
+        expectedSyncCredentialState:
+          syncCredentialStatePersistence.expectedSyncCredentialState,
+        syncCredentialState: syncCredentialStatePersistence.syncCredentialState,
+      });
+    }
 
     return {
       snapshotVersionVector: snapshot.metadata.snapshotVersionVector,
@@ -370,5 +531,18 @@ export class VaultSnapshotService {
         actualAlgorithmSuiteId: snapshot.metadata.algorithmSuiteId,
       });
     }
+  }
+
+  private async requireLocalVaultTrustCheckpoint(
+    vaultId: string,
+  ): Promise<LocalVaultTrustCheckpoint> {
+    const checkpoint =
+      await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(vaultId);
+
+    if (checkpoint === null) {
+      throw new LocalVaultTrustCheckpointNotFoundError(vaultId);
+    }
+
+    return checkpoint;
   }
 }

--- a/packages/core/src/services/sync/sync-provider-outcome.policy.test.ts
+++ b/packages/core/src/services/sync/sync-provider-outcome.policy.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  InvalidSyncProviderOutcomeError,
+  RemoteVaultSnapshotChangedError,
+  SyncProviderUploadRejectedError,
+} from "../../errors/sync.errors";
+import {
+  requireSyncProviderUploadOutcome,
+  resolveNonStartedSyncProviderUploadOutcome,
+  resolveSyncProviderUploadOutcome,
+  resolveSyncProviderUploadStatus,
+} from "./sync-provider-outcome.policy";
+
+describe("sync provider upload outcome policy", () => {
+  it.each([
+    { status: "committed" },
+    {
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    },
+    {
+      status: "definitely_not_committed",
+      reason: "provider_rejected",
+    },
+    { status: "outcome_unknown" },
+  ] as const)("accepts the exact $status result", (outcome) => {
+    expect(requireSyncProviderUploadOutcome(outcome)).toEqual(outcome);
+  });
+
+  it.each([
+    undefined,
+    null,
+    "committed",
+    [],
+    new Date(),
+    {},
+    { status: "committed", reason: "remote_snapshot_changed" },
+    { status: "definitely_not_committed" },
+    { status: "definitely_not_committed", reason: "network_error" },
+    { status: "outcome_unknown", extra: true },
+  ])("rejects malformed or non-exact result %#", (outcome) => {
+    expect(() => requireSyncProviderUploadOutcome(outcome)).toThrow(
+      InvalidSyncProviderOutcomeError,
+    );
+  });
+
+  it("rejects accessor and symbol properties", () => {
+    const accessorOutcome = Object.defineProperty({}, "status", {
+      enumerable: true,
+      get: () => "committed",
+    });
+    const symbolOutcome = {
+      status: "committed",
+      [Symbol("extra")]: true,
+    };
+
+    expect(() => requireSyncProviderUploadOutcome(accessorOutcome)).toThrow(
+      InvalidSyncProviderOutcomeError,
+    );
+    expect(() => requireSyncProviderUploadOutcome(symbolOutcome)).toThrow(
+      InvalidSyncProviderOutcomeError,
+    );
+  });
+
+  it("treats a malformed post-write result as outcome unknown", () => {
+    expect(resolveSyncProviderUploadOutcome(undefined)).toEqual({
+      status: "outcome_unknown",
+    });
+  });
+
+  it("treats a hostile record that throws during inspection as outcome unknown", () => {
+    const hostileOutcome = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw new Error("inspection failed");
+        },
+      },
+    );
+
+    expect(resolveSyncProviderUploadOutcome(hostileOutcome)).toEqual({
+      status: "outcome_unknown",
+    });
+  });
+
+  it.each([{ status: "committed" }, { status: "outcome_unknown" }, undefined])(
+    "does not accept %# as a proven non-started outcome",
+    (outcome) => {
+      expect(resolveNonStartedSyncProviderUploadOutcome(outcome)).toEqual({
+        status: "outcome_unknown",
+      });
+    },
+  );
+
+  it("preserves a definite non-commit before start", () => {
+    const outcome = {
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    } as const;
+
+    expect(resolveNonStartedSyncProviderUploadOutcome(outcome)).toEqual(
+      outcome,
+    );
+  });
+
+  it.each([
+    [{ status: "committed" }, "complete"],
+    [{ status: "outcome_unknown" }, "pending"],
+    [undefined, "pending"],
+  ] as const)("maps upload outcome %# to status %s", (outcome, status) => {
+    expect(resolveSyncProviderUploadStatus("vault-id", outcome)).toBe(status);
+  });
+
+  it("preserves distinct definite non-commit errors", () => {
+    expect(() =>
+      resolveSyncProviderUploadStatus("vault-id", {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      }),
+    ).toThrow(RemoteVaultSnapshotChangedError);
+    expect(() =>
+      resolveSyncProviderUploadStatus("vault-id", {
+        status: "definitely_not_committed",
+        reason: "provider_rejected",
+      }),
+    ).toThrow(SyncProviderUploadRejectedError);
+  });
+});

--- a/packages/core/src/services/sync/sync-provider-outcome.policy.ts
+++ b/packages/core/src/services/sync/sync-provider-outcome.policy.ts
@@ -1,11 +1,144 @@
-import { InvalidSyncProviderOutcomeError } from "../../errors/sync.errors";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
+import type { SyncUploadOutcome } from "../../ports/sync/sync-provider.port";
+import {
+  InvalidSyncProviderOutcomeError,
+  RemoteVaultSnapshotChangedError,
+  SyncProviderUploadRejectedError,
+} from "../../errors/sync.errors";
 
 export function requireSyncProviderAccessOutcome(
   value: unknown,
 ): "accessible" | "authentication_rejected" {
   if (value !== "accessible" && value !== "authentication_rejected") {
-    throw new InvalidSyncProviderOutcomeError();
+    throw new InvalidSyncProviderOutcomeError("access");
   }
 
   return value;
+}
+
+export function requireSyncProviderUploadOutcome(
+  value: unknown,
+): SyncUploadOutcome {
+  try {
+    return decodeSyncProviderUploadOutcome(value);
+  } catch (error) {
+    if (error instanceof InvalidSyncProviderOutcomeError) {
+      throw error;
+    }
+
+    throw new InvalidSyncProviderOutcomeError("upload");
+  }
+}
+
+function decodeSyncProviderUploadOutcome(value: unknown): SyncUploadOutcome {
+  const record = requirePlainRecord(value);
+  const status = requireDataProperty(record, "status");
+
+  if (status === "committed" || status === "outcome_unknown") {
+    requireExactKeys(record, ["status"]);
+    return { status };
+  }
+
+  if (status === "definitely_not_committed") {
+    requireExactKeys(record, ["status", "reason"]);
+
+    const reason = requireDataProperty(record, "reason");
+
+    if (
+      reason !== "remote_snapshot_changed" &&
+      reason !== "provider_rejected"
+    ) {
+      throw new InvalidSyncProviderOutcomeError("upload");
+    }
+
+    return { status, reason };
+  }
+
+  throw new InvalidSyncProviderOutcomeError("upload");
+}
+
+export function resolveSyncProviderUploadOutcome(
+  value: unknown,
+): SyncUploadOutcome {
+  try {
+    return requireSyncProviderUploadOutcome(value);
+  } catch (error) {
+    if (error instanceof InvalidSyncProviderOutcomeError) {
+      return { status: "outcome_unknown" };
+    }
+
+    throw error;
+  }
+}
+
+export function resolveNonStartedSyncProviderUploadOutcome(
+  value: unknown,
+): SyncUploadOutcome {
+  const outcome = resolveSyncProviderUploadOutcome(value);
+
+  return outcome.status === "definitely_not_committed"
+    ? outcome
+    : { status: "outcome_unknown" };
+}
+
+export function resolveSyncProviderUploadStatus(
+  vaultId: string,
+  value: unknown,
+): SyncUploadStatus {
+  const outcome = resolveSyncProviderUploadOutcome(value);
+
+  if (outcome.status === "committed") {
+    return "complete";
+  }
+
+  if (outcome.status === "outcome_unknown") {
+    return "pending";
+  }
+
+  if (outcome.reason === "remote_snapshot_changed") {
+    throw new RemoteVaultSnapshotChangedError(vaultId);
+  }
+
+  throw new SyncProviderUploadRejectedError(vaultId);
+}
+
+function requirePlainRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new InvalidSyncProviderOutcomeError("upload");
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown;
+
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new InvalidSyncProviderOutcomeError("upload");
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireExactKeys(
+  record: Record<string, unknown>,
+  expectedKeys: readonly string[],
+): void {
+  const keys = Reflect.ownKeys(record);
+
+  if (
+    keys.length !== expectedKeys.length ||
+    keys.some((key) => typeof key !== "string" || !expectedKeys.includes(key))
+  ) {
+    throw new InvalidSyncProviderOutcomeError("upload");
+  }
+}
+
+function requireDataProperty(
+  record: Record<string, unknown>,
+  key: string,
+): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+
+  if (descriptor === undefined || !("value" in descriptor)) {
+    throw new InvalidSyncProviderOutcomeError("upload");
+  }
+
+  return descriptor.value;
 }

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -546,7 +546,11 @@ export class VaultSyncGuardService {
     vaultId: string,
     unlockedVault: UnlockedVault,
     options: {
-      readonly allowPendingSnapshotUpload: boolean;
+      /**
+       * Accepts and removes an existing pending upload marker from `nextState`.
+       * Use only when the caller atomically replaces the marked local snapshot.
+       */
+      readonly discardPendingSnapshotUpload: boolean;
       readonly requireProviderCredentialRevocationCompleteFor?: string;
     },
   ): Promise<{
@@ -582,7 +586,7 @@ export class VaultSyncGuardService {
 
     if (
       state.pendingSnapshotUpload !== undefined &&
-      !options.allowPendingSnapshotUpload
+      !options.discardPendingSnapshotUpload
     ) {
       throw new LocalVaultSnapshotAheadError(vaultId);
     }

--- a/packages/core/src/services/sync/vault-sync-guard.service.ts
+++ b/packages/core/src/services/sync/vault-sync-guard.service.ts
@@ -1,12 +1,20 @@
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
+  cloneVaultSnapshotIdentity,
   compareVaultSnapshotDescriptors,
   toVaultSnapshotDescriptor,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
+import type { LocalVaultTrustCheckpoint } from "../../domain/device-trust";
 import type { VaultSnapshot } from "../../domain/snapshot/vault-snapshot";
-import type { VaultSnapshotDescriptor } from "../../domain/snapshot/vault-snapshot-descriptor.type";
+import type { VaultSnapshotIdentity } from "../../domain/snapshot/vault-snapshot-descriptor.type";
 import type { UnlockedVault } from "../../domain/session/unlocked-vault";
 import type { SyncAccess } from "../../domain/sync/sync-config.type";
+import type {
+  DeviceSyncCredentialState,
+  EncryptedDeviceSyncCredentialState,
+} from "../../domain/sync/device-sync-credential-state";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import {
   RemoteVaultSnapshotAheadError,
@@ -20,26 +28,45 @@ import {
   SyncRemovalPendingError,
 } from "../../errors/sync.errors";
 import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
+import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
-import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
+import type {
+  PreparedSyncUpload,
+  SyncProviderPort,
+  SyncUploadOutcome,
+} from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../session/unlocked-vault-session.service";
 import type {
   PreparedLocalVaultSnapshotRestore,
   VaultSnapshotService,
 } from "../snapshot/vault-snapshot.service";
+import {
+  resolveNonStartedSyncProviderUploadOutcome,
+  resolveSyncProviderUploadStatus,
+} from "./sync-provider-outcome.policy";
 
 type LocalMutationSyncState =
   | {
       readonly localSnapshot: VaultSnapshot;
       readonly syncAccess?: undefined;
-      readonly remoteSnapshotDescriptor?: undefined;
+      readonly remoteSnapshotIdentity?: undefined;
     }
   | {
       readonly localSnapshot: VaultSnapshot;
       readonly syncAccess: SyncAccess;
-      readonly remoteSnapshotDescriptor: VaultSnapshotDescriptor;
+      readonly syncCredentialState: EncryptedDeviceSyncCredentialState;
+      readonly remoteSnapshotIdentity: VaultSnapshotIdentity;
     };
+
+type PendingSnapshotUpload = NonNullable<
+  DeviceSyncCredentialState["pendingSnapshotUpload"]
+>;
+
+type StagedSnapshotUploadIntent = {
+  readonly clear: EncryptedDeviceSyncCredentialState;
+  readonly pending: EncryptedDeviceSyncCredentialState;
+};
 
 export class VaultSyncGuardService {
   private readonly syncProvider: SyncProviderPort;
@@ -99,7 +126,15 @@ export class VaultSyncGuardService {
       throw new SyncRemovalPendingError(vaultId, "modify vault data");
     }
 
-    const syncAccess = await this.requireSyncAccess(vaultId, unlockedVault);
+    const {
+      encryptedState: syncCredentialState,
+      state: decryptedSyncCredentialState,
+      syncAccess,
+    } = await this.requireSyncCredentialState(vaultId, unlockedVault);
+
+    if (decryptedSyncCredentialState.pendingSnapshotUpload !== undefined) {
+      throw new LocalVaultSnapshotAheadError(vaultId);
+    }
     const remoteSnapshotDescriptor =
       await this.syncProvider.getLatestVaultSnapshotDescriptor(
         syncAccess,
@@ -141,10 +176,39 @@ export class VaultSyncGuardService {
       throw new RemoteVaultSnapshotIntegrityError(vaultId);
     }
 
+    let remoteSnapshot: VaultSnapshot;
+
+    try {
+      remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+        syncAccess,
+        remoteSnapshotDescriptor,
+      );
+    } catch (error) {
+      if (error instanceof RemoteVaultSnapshotChangedError) {
+        throw new SyncConflictDetectedError(vaultId);
+      }
+
+      throw error;
+    }
+
+    const remoteSnapshotDigest =
+      await this.crypto.digestVaultSnapshot(remoteSnapshot);
+
+    if (
+      remoteSnapshotDigest !==
+      unlockedVault.trustedSnapshotContext.snapshotDigest
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(vaultId);
+    }
+
     return {
       localSnapshot,
       syncAccess,
-      remoteSnapshotDescriptor,
+      syncCredentialState,
+      remoteSnapshotIdentity: {
+        descriptor: remoteSnapshotDescriptor,
+        snapshotDigest: remoteSnapshotDigest,
+      },
     };
   }
 
@@ -152,6 +216,581 @@ export class VaultSyncGuardService {
     vaultId: string,
     unlockedVault: UnlockedVault,
   ): Promise<SyncAccess> {
+    return (await this.requireSyncCredentialState(vaultId, unlockedVault))
+      .syncAccess;
+  }
+
+  async requireSnapshotUploadReconciled(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+  ): Promise<void> {
+    const { state } = await this.requireSyncCredentialState(
+      vaultId,
+      unlockedVault,
+    );
+
+    if (state.pendingSnapshotUpload !== undefined) {
+      throw new LocalVaultSnapshotAheadError(vaultId);
+    }
+  }
+
+  async getPendingSnapshotUpload(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+  ): Promise<PendingSnapshotUpload | undefined> {
+    const { state } = await this.requireSyncCredentialState(
+      vaultId,
+      unlockedVault,
+    );
+    const pending = state.pendingSnapshotUpload;
+
+    if (pending === undefined) {
+      return undefined;
+    }
+
+    if (
+      pending.candidateSnapshotIdentity.descriptor.vaultId !== vaultId ||
+      (pending.expectedRemoteSnapshotIdentity !== null &&
+        pending.expectedRemoteSnapshotIdentity.descriptor.vaultId !== vaultId)
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(vaultId);
+    }
+
+    return {
+      candidateSnapshotIdentity: cloneVaultSnapshotIdentity(
+        pending.candidateSnapshotIdentity,
+      ),
+      expectedRemoteSnapshotIdentity:
+        pending.expectedRemoteSnapshotIdentity === null
+          ? null
+          : cloneVaultSnapshotIdentity(pending.expectedRemoteSnapshotIdentity),
+    };
+  }
+
+  async uploadTrackedSnapshot(params: {
+    readonly sessionId: string;
+    readonly vaultId: string;
+    readonly unlockedVault: UnlockedVault;
+    readonly syncAccess: SyncAccess;
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null;
+    readonly onIntentStaged: (intent: StagedSnapshotUploadIntent) => void;
+  }): Promise<SyncUploadStatus> {
+    const pending = {
+      candidateSnapshotIdentity: {
+        descriptor: toVaultSnapshotDescriptor(params.vaultId, params.snapshot),
+        snapshotDigest: params.snapshotDigest,
+      },
+      expectedRemoteSnapshotIdentity:
+        params.expectedRemoteSnapshotIdentity === null
+          ? null
+          : cloneVaultSnapshotIdentity(params.expectedRemoteSnapshotIdentity),
+    } satisfies PendingSnapshotUpload;
+    const stagedCredentialStates = await this.runForActiveSession(
+      params.sessionId,
+      params.vaultId,
+      "stage a snapshot upload",
+      async (activeUnlockedVault) =>
+        this.stagePendingSnapshotUpload(
+          {
+            ...params,
+            unlockedVault: {
+              ...params.unlockedVault,
+              deviceLocalProtectionKey:
+                activeUnlockedVault.deviceLocalProtectionKey,
+            },
+          },
+          pending,
+        ),
+    );
+
+    if (stagedCredentialStates.kind === "already_pending") {
+      return "pending";
+    }
+
+    params.onIntentStaged(stagedCredentialStates);
+    const preparedUpload = await this.syncProvider.prepareVaultSnapshotUpload(
+      params.syncAccess,
+      params.snapshot,
+      params.expectedRemoteSnapshotIdentity,
+    );
+    const uploadOutcome =
+      preparedUpload.status === "not_started"
+        ? resolveNonStartedSyncProviderUploadOutcome(preparedUpload.outcome)
+        : await this.startPreparedUpload(
+            params.sessionId,
+            params.vaultId,
+            "start a snapshot upload",
+            preparedUpload,
+          );
+    const syncUpload = resolveSyncProviderUploadStatus(
+      params.vaultId,
+      uploadOutcome,
+    );
+
+    if (syncUpload === "pending") {
+      return "pending";
+    }
+
+    try {
+      return (await this.runForActiveSession(
+        params.sessionId,
+        params.vaultId,
+        "clear a completed snapshot upload",
+        async () =>
+          this.tryClearPendingSnapshotUpload({
+            ...params,
+            clearCredentialState: stagedCredentialStates.clear,
+            expectedSyncCredentialState: stagedCredentialStates.pending,
+          }),
+      ))
+        ? "complete"
+        : "pending";
+    } catch {
+      return "pending";
+    }
+  }
+
+  async retryPendingSnapshotUpload(params: {
+    readonly sessionId: string;
+    readonly vaultId: string;
+    readonly unlockedVault: UnlockedVault;
+    readonly syncAccess: SyncAccess;
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly pending: PendingSnapshotUpload;
+  }): Promise<SyncUploadStatus> {
+    const restaged = await this.runForActiveSession(
+      params.sessionId,
+      params.vaultId,
+      "restage a pending snapshot upload",
+      async (activeUnlockedVault) =>
+        this.restagePendingSnapshotUpload({
+          ...params,
+          unlockedVault: {
+            ...params.unlockedVault,
+            deviceLocalProtectionKey:
+              activeUnlockedVault.deviceLocalProtectionKey,
+          },
+        }),
+    );
+
+    let syncUpload: SyncUploadStatus;
+    try {
+      const preparedUpload = await this.syncProvider.prepareVaultSnapshotUpload(
+        params.syncAccess,
+        params.snapshot,
+        params.pending.expectedRemoteSnapshotIdentity,
+      );
+      const uploadOutcome =
+        preparedUpload.status === "not_started"
+          ? resolveNonStartedSyncProviderUploadOutcome(preparedUpload.outcome)
+          : await this.startPreparedUpload(
+              params.sessionId,
+              params.vaultId,
+              "retry a pending snapshot upload",
+              preparedUpload,
+            );
+      syncUpload = resolveSyncProviderUploadStatus(
+        params.vaultId,
+        uploadOutcome,
+      );
+    } catch (error) {
+      try {
+        await this.runForActiveSession(
+          params.sessionId,
+          params.vaultId,
+          "restore a failed pending snapshot upload",
+          async () =>
+            this.tryReplaceSyncCredentialState({
+              ...params,
+              expectedSyncCredentialState: restaged.pending,
+              syncCredentialState: restaged.previous,
+            }),
+        );
+      } catch {
+        // The exact restaged intent remains recoverable after session loss.
+      }
+      throw error;
+    }
+
+    if (syncUpload === "pending") {
+      return "pending";
+    }
+
+    try {
+      return (await this.runForActiveSession(
+        params.sessionId,
+        params.vaultId,
+        "clear a retried snapshot upload",
+        async () =>
+          this.tryClearPendingSnapshotUpload({
+            ...params,
+            clearCredentialState: restaged.clear,
+            expectedSyncCredentialState: restaged.pending,
+          }),
+      ))
+        ? "complete"
+        : "pending";
+    } catch {
+      return "pending";
+    }
+  }
+
+  async clearStagedSnapshotUploadIntent(params: {
+    readonly sessionId: string;
+    readonly vaultId: string;
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly intent: StagedSnapshotUploadIntent;
+  }): Promise<boolean> {
+    try {
+      return await this.runForActiveSession(
+        params.sessionId,
+        params.vaultId,
+        "clear a failed snapshot upload",
+        async () =>
+          this.tryClearPendingSnapshotUpload({
+            snapshot: params.snapshot,
+            snapshotDigest: params.snapshotDigest,
+            checkpoint: params.checkpoint,
+            clearCredentialState: params.intent.clear,
+            expectedSyncCredentialState: params.intent.pending,
+          }),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async removeTrackedRemoteSnapshot(params: {
+    readonly sessionId: string;
+    readonly vaultId: string;
+    readonly syncAccess: SyncAccess;
+    readonly expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null;
+  }): Promise<void> {
+    const preparedRemoval = await this.syncProvider.prepareVaultSnapshotRemoval(
+      params.syncAccess,
+      params.vaultId,
+      params.expectedRemoteSnapshotIdentity,
+    );
+
+    if (preparedRemoval.status === "already_absent") {
+      return;
+    }
+
+    const startedRemoval = await this.runForActiveSession(
+      params.sessionId,
+      params.vaultId,
+      "remove the remote vault snapshot",
+      async () => preparedRemoval.start(),
+    );
+    await startedRemoval.outcome;
+  }
+
+  async clearPendingSnapshotUpload(params: {
+    readonly sessionId: string;
+    readonly vaultId: string;
+    readonly unlockedVault: UnlockedVault;
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly pending: PendingSnapshotUpload;
+  }): Promise<boolean> {
+    return this.runForActiveSession(
+      params.sessionId,
+      params.vaultId,
+      "clear a pending snapshot upload",
+      async (activeUnlockedVault) => {
+        const authorizedUnlockedVault = {
+          ...params.unlockedVault,
+          deviceLocalProtectionKey:
+            activeUnlockedVault.deviceLocalProtectionKey,
+        };
+        const { encryptedState, state } = await this.requireSyncCredentialState(
+          params.vaultId,
+          authorizedUnlockedVault,
+        );
+
+        if (
+          state.pendingSnapshotUpload === undefined ||
+          !arePendingSnapshotUploadsEqual(
+            state.pendingSnapshotUpload,
+            params.pending,
+          )
+        ) {
+          return false;
+        }
+
+        const clearCredentialState =
+          await this.encryptDeviceSyncCredentialStateWithoutPending(
+            params.vaultId,
+            authorizedUnlockedVault,
+            state,
+          );
+
+        return this.tryClearPendingSnapshotUpload({
+          ...params,
+          clearCredentialState,
+          expectedSyncCredentialState: encryptedState,
+        });
+      },
+    );
+  }
+
+  async prepareSyncCredentialStateWithoutPending(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+    options: {
+      readonly allowPendingSnapshotUpload: boolean;
+      readonly requireProviderCredentialRevocationCompleteFor?: string;
+    },
+  ): Promise<{
+    readonly expectedState: EncryptedDeviceSyncCredentialState;
+    readonly nextState: EncryptedDeviceSyncCredentialState;
+    readonly syncAccess: SyncAccess;
+  }> {
+    const providerCredentialRevocationOperation =
+      options.requireProviderCredentialRevocationCompleteFor;
+
+    if (
+      providerCredentialRevocationOperation !== undefined &&
+      unlockedVault.vault.providerCredentialRevocationPending !== undefined
+    ) {
+      throw new ProviderCredentialRevocationPendingError(
+        vaultId,
+        providerCredentialRevocationOperation,
+      );
+    }
+
+    const { encryptedState, state, syncAccess } =
+      await this.requireSyncCredentialState(vaultId, unlockedVault);
+
+    if (
+      providerCredentialRevocationOperation !== undefined &&
+      state.previousCredentials !== undefined
+    ) {
+      throw new ProviderCredentialRevocationPendingError(
+        vaultId,
+        providerCredentialRevocationOperation,
+      );
+    }
+
+    if (
+      state.pendingSnapshotUpload !== undefined &&
+      !options.allowPendingSnapshotUpload
+    ) {
+      throw new LocalVaultSnapshotAheadError(vaultId);
+    }
+
+    return {
+      expectedState: encryptedState,
+      nextState: await this.encryptDeviceSyncCredentialStateWithoutPending(
+        vaultId,
+        unlockedVault,
+        state,
+      ),
+      syncAccess,
+    };
+  }
+
+  private async stagePendingSnapshotUpload(
+    params: {
+      readonly vaultId: string;
+      readonly unlockedVault: UnlockedVault;
+      readonly snapshot: VaultSnapshot;
+      readonly snapshotDigest: string;
+      readonly checkpoint: LocalVaultTrustCheckpoint;
+    },
+    pending: PendingSnapshotUpload,
+  ): Promise<
+    | {
+        readonly kind: "already_pending";
+      }
+    | {
+        readonly kind: "staged";
+        readonly clear: EncryptedDeviceSyncCredentialState;
+        readonly pending: EncryptedDeviceSyncCredentialState;
+      }
+  > {
+    if (
+      pending.candidateSnapshotIdentity.descriptor.vaultId !== params.vaultId ||
+      (pending.expectedRemoteSnapshotIdentity !== null &&
+        pending.expectedRemoteSnapshotIdentity.descriptor.vaultId !==
+          params.vaultId)
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+
+    const { encryptedState, state } = await this.requireSyncCredentialState(
+      params.vaultId,
+      params.unlockedVault,
+    );
+
+    if (state.pendingSnapshotUpload !== undefined) {
+      if (
+        arePendingSnapshotUploadsEqual(state.pendingSnapshotUpload, pending)
+      ) {
+        return { kind: "already_pending" };
+      }
+
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+
+    const clearCredentialState =
+      await this.encryptDeviceSyncCredentialStateWithoutPending(
+        params.vaultId,
+        params.unlockedVault,
+        state,
+      );
+    const markerFreeState = toSyncCredentialStateWithoutPending(state);
+    const pendingCredentialState =
+      await this.crypto.encryptDeviceSyncCredentialState(
+        {
+          ...markerFreeState,
+          pendingSnapshotUpload: pending,
+        },
+        params.unlockedVault.deviceLocalProtectionKey,
+        requireSyncCredentialEncryptionContext(
+          params.vaultId,
+          params.unlockedVault,
+        ),
+      );
+
+    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: params.snapshotDigest,
+      expectedCheckpoint: params.checkpoint,
+      expectedSyncCredentialState: encryptedState,
+      snapshot: params.snapshot,
+      checkpoint: params.checkpoint,
+      syncCredentialState: pendingCredentialState,
+    });
+
+    return {
+      kind: "staged",
+      clear: clearCredentialState,
+      pending: pendingCredentialState,
+    };
+  }
+
+  private async encryptDeviceSyncCredentialStateWithoutPending(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+    state: DeviceSyncCredentialState,
+  ): Promise<EncryptedDeviceSyncCredentialState> {
+    return this.crypto.encryptDeviceSyncCredentialState(
+      toSyncCredentialStateWithoutPending(state),
+      unlockedVault.deviceLocalProtectionKey,
+      requireSyncCredentialEncryptionContext(vaultId, unlockedVault),
+    );
+  }
+
+  private async restagePendingSnapshotUpload(params: {
+    readonly vaultId: string;
+    readonly unlockedVault: UnlockedVault;
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly pending: PendingSnapshotUpload;
+  }): Promise<{
+    readonly previous: EncryptedDeviceSyncCredentialState;
+    readonly clear: EncryptedDeviceSyncCredentialState;
+    readonly pending: EncryptedDeviceSyncCredentialState;
+  }> {
+    const { encryptedState, state } = await this.requireSyncCredentialState(
+      params.vaultId,
+      params.unlockedVault,
+    );
+
+    if (
+      state.pendingSnapshotUpload === undefined ||
+      !arePendingSnapshotUploadsEqual(
+        state.pendingSnapshotUpload,
+        params.pending,
+      )
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+
+    const [clearCredentialState, pendingCredentialState] = await Promise.all([
+      this.encryptDeviceSyncCredentialStateWithoutPending(
+        params.vaultId,
+        params.unlockedVault,
+        state,
+      ),
+      this.crypto.encryptDeviceSyncCredentialState(
+        state,
+        params.unlockedVault.deviceLocalProtectionKey,
+        requireSyncCredentialEncryptionContext(
+          params.vaultId,
+          params.unlockedVault,
+        ),
+      ),
+    ]);
+
+    await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      expectedSnapshotDigest: params.snapshotDigest,
+      expectedCheckpoint: params.checkpoint,
+      expectedSyncCredentialState: encryptedState,
+      snapshot: params.snapshot,
+      checkpoint: params.checkpoint,
+      syncCredentialState: pendingCredentialState,
+    });
+
+    return {
+      previous: encryptedState,
+      clear: clearCredentialState,
+      pending: pendingCredentialState,
+    };
+  }
+
+  private async tryClearPendingSnapshotUpload(params: {
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly clearCredentialState: EncryptedDeviceSyncCredentialState;
+    readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState;
+  }): Promise<boolean> {
+    return this.tryReplaceSyncCredentialState({
+      ...params,
+      syncCredentialState: params.clearCredentialState,
+    });
+  }
+
+  private async tryReplaceSyncCredentialState(params: {
+    readonly snapshot: VaultSnapshot;
+    readonly snapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly expectedSyncCredentialState: EncryptedDeviceSyncCredentialState;
+    readonly syncCredentialState: EncryptedDeviceSyncCredentialState;
+  }): Promise<boolean> {
+    try {
+      await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: params.snapshotDigest,
+        expectedCheckpoint: params.checkpoint,
+        expectedSyncCredentialState: params.expectedSyncCredentialState,
+        snapshot: params.snapshot,
+        checkpoint: params.checkpoint,
+        syncCredentialState: params.syncCredentialState,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async requireSyncCredentialState(
+    vaultId: string,
+    unlockedVault: UnlockedVault,
+  ): Promise<{
+    readonly encryptedState: EncryptedDeviceSyncCredentialState;
+    readonly state: DeviceSyncCredentialState;
+    readonly syncAccess: SyncAccess;
+  }> {
     const syncTarget = unlockedVault.vault.syncTarget;
 
     if (syncTarget === undefined) {
@@ -181,8 +820,12 @@ export class VaultSyncGuardService {
     }
 
     return {
-      target: syncTarget,
-      credentials: state.currentCredentials,
+      encryptedState,
+      state,
+      syncAccess: {
+        target: syncTarget,
+        credentials: state.currentCredentials,
+      },
     };
   }
 
@@ -224,54 +867,90 @@ export class VaultSyncGuardService {
     }
   }
 
-  async uploadPersistedLocalMutation(
-    vaultId: string,
-    syncState: {
-      readonly localSnapshot: VaultSnapshot;
-      readonly syncAccess?: SyncAccess;
-      readonly remoteSnapshotDescriptor?: VaultSnapshotDescriptor;
-    },
-    persistedSnapshot: VaultSnapshot,
-    persistedSnapshotDigest: string,
-    preparedRestore: PreparedLocalVaultSnapshotRestore,
+  private async runForActiveSession<T>(
     sessionId: string,
-  ): Promise<void> {
-    if (
-      syncState.syncAccess === undefined ||
-      syncState.remoteSnapshotDescriptor === undefined
-    ) {
-      return;
+    vaultId: string,
+    operation: string,
+    run: (unlockedVault: UnlockedVault) => Promise<T>,
+  ): Promise<T> {
+    return this.unlockedVaultSession.runWithUnlockedVaultContext(
+      vaultId,
+      operation,
+      async (session) => {
+        if (session.sessionId !== sessionId) {
+          throw new UnlockedVaultSessionExpiredError(vaultId);
+        }
+
+        return run(session.unlockedVault);
+      },
+    );
+  }
+
+  private async startPreparedUpload(
+    sessionId: string,
+    vaultId: string,
+    operation: string,
+    preparedUpload: Extract<PreparedSyncUpload, { readonly status: "ready" }>,
+  ): Promise<SyncUploadOutcome> {
+    let startInvoked = false;
+    let startedUpload: { readonly outcome: Promise<SyncUploadOutcome> };
+
+    try {
+      startedUpload = await this.runForActiveSession(
+        sessionId,
+        vaultId,
+        operation,
+        async () => {
+          startInvoked = true;
+          return preparedUpload.start();
+        },
+      );
+    } catch (error) {
+      if (!startInvoked) {
+        throw error;
+      }
+
+      return { status: "outcome_unknown" };
     }
 
     try {
-      await this.syncProvider.uploadVaultSnapshot(
-        syncState.syncAccess,
-        persistedSnapshot,
-        syncState.remoteSnapshotDescriptor,
-      );
-    } catch (error) {
-      const rollbackResult =
-        await this.unlockedVaultSession.restorePersistedState(
-          sessionId,
-          vaultId,
-          syncState.localSnapshot.metadata.snapshotVersionVector,
-          async () =>
-            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-              preparedRestore,
-              persistedSnapshotDigest,
-            ),
-        );
-
-      if (rollbackResult === "rollback_failed") {
-        throw new PersistedVaultRollbackIncompleteError(vaultId, error);
-      }
-
-      if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(vaultId);
-      }
-
-      throw error;
+      return await startedUpload.outcome;
+    } catch {
+      return { status: "outcome_unknown" };
     }
+  }
+
+  async uploadPersistedLocalMutation(
+    vaultId: string,
+    syncState: LocalMutationSyncState,
+    persistedSnapshot: VaultSnapshot,
+    persistedSnapshotDigest: string,
+    checkpoint: LocalVaultTrustCheckpoint,
+    unlockedVault: UnlockedVault,
+    preparedRestore: PreparedLocalVaultSnapshotRestore,
+    sessionId: string,
+  ): Promise<SyncUploadStatus> {
+    if (
+      syncState.syncAccess === undefined ||
+      syncState.remoteSnapshotIdentity === undefined
+    ) {
+      return "complete";
+    }
+
+    return this.uploadPersistedSnapshot({
+      vaultId,
+      syncAccess: syncState.syncAccess,
+      persistedSnapshot,
+      expectedRemoteSnapshotIdentity: syncState.remoteSnapshotIdentity,
+      previousSnapshotVersionVector:
+        syncState.localSnapshot.metadata.snapshotVersionVector,
+      persistedSnapshotDigest,
+      checkpoint,
+      persistedSyncCredentialState: syncState.syncCredentialState,
+      unlockedVault,
+      preparedRestore,
+      sessionId,
+    });
   }
 
   async uploadPersistedInitialSyncSnapshot(
@@ -280,37 +959,139 @@ export class VaultSyncGuardService {
     localSnapshot: VaultSnapshot,
     persistedSnapshot: VaultSnapshot,
     persistedSnapshotDigest: string,
+    checkpoint: LocalVaultTrustCheckpoint,
+    persistedSyncCredentialState: EncryptedDeviceSyncCredentialState,
+    unlockedVault: UnlockedVault,
     preparedRestore: PreparedLocalVaultSnapshotRestore,
     sessionId: string,
-  ): Promise<void> {
+  ): Promise<SyncUploadStatus> {
+    return this.uploadPersistedSnapshot({
+      vaultId,
+      syncAccess,
+      persistedSnapshot,
+      expectedRemoteSnapshotIdentity: null,
+      previousSnapshotVersionVector:
+        localSnapshot.metadata.snapshotVersionVector,
+      persistedSnapshotDigest,
+      checkpoint,
+      persistedSyncCredentialState,
+      unlockedVault,
+      preparedRestore,
+      sessionId,
+    });
+  }
+
+  async uploadPersistedSnapshot(params: {
+    readonly vaultId: string;
+    readonly syncAccess: SyncAccess;
+    readonly persistedSnapshot: VaultSnapshot;
+    readonly expectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null;
+    readonly previousSnapshotVersionVector: VersionVector;
+    readonly persistedSnapshotDigest: string;
+    readonly checkpoint: LocalVaultTrustCheckpoint;
+    readonly persistedSyncCredentialState: EncryptedDeviceSyncCredentialState;
+    readonly unlockedVault: UnlockedVault;
+    readonly preparedRestore: PreparedLocalVaultSnapshotRestore;
+    readonly sessionId: string;
+  }): Promise<SyncUploadStatus> {
+    let expectedSyncCredentialState = params.persistedSyncCredentialState;
+
     try {
-      await this.syncProvider.uploadVaultSnapshot(
-        syncAccess,
-        persistedSnapshot,
-        null,
-      );
+      return await this.uploadTrackedSnapshot({
+        sessionId: params.sessionId,
+        vaultId: params.vaultId,
+        unlockedVault: params.unlockedVault,
+        syncAccess: params.syncAccess,
+        snapshot: params.persistedSnapshot,
+        snapshotDigest: params.persistedSnapshotDigest,
+        checkpoint: params.checkpoint,
+        expectedRemoteSnapshotIdentity: params.expectedRemoteSnapshotIdentity,
+        onIntentStaged: ({ pending }) => {
+          expectedSyncCredentialState = pending;
+        },
+      });
     } catch (error) {
       const rollbackResult =
         await this.unlockedVaultSession.restorePersistedState(
-          sessionId,
-          vaultId,
-          localSnapshot.metadata.snapshotVersionVector,
+          params.sessionId,
+          params.vaultId,
+          params.previousSnapshotVersionVector,
           async () =>
             this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-              preparedRestore,
-              persistedSnapshotDigest,
+              params.preparedRestore,
+              params.persistedSnapshotDigest,
+              params.checkpoint,
+              expectedSyncCredentialState,
             ),
         );
 
       if (rollbackResult === "rollback_failed") {
-        throw new PersistedVaultRollbackIncompleteError(vaultId, error);
+        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
       }
 
       if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(vaultId);
+        throw new SyncConflictDetectedError(params.vaultId);
       }
 
       throw error;
     }
   }
+}
+
+function toSyncCredentialStateWithoutPending(
+  state: DeviceSyncCredentialState,
+): DeviceSyncCredentialState {
+  return {
+    currentCredentials: state.currentCredentials,
+    ...(state.previousCredentials === undefined
+      ? {}
+      : { previousCredentials: state.previousCredentials }),
+  };
+}
+
+function requireSyncCredentialEncryptionContext(
+  vaultId: string,
+  unlockedVault: UnlockedVault,
+) {
+  const syncTarget = unlockedVault.vault.syncTarget;
+
+  if (syncTarget === undefined) {
+    throw new LocalSyncCredentialsMissingError(vaultId);
+  }
+
+  return {
+    vaultId,
+    deviceId: unlockedVault.deviceId,
+    provider: syncTarget.provider,
+    target: syncTarget,
+  };
+}
+
+function arePendingSnapshotUploadsEqual(
+  left: PendingSnapshotUpload,
+  right: PendingSnapshotUpload,
+): boolean {
+  if (
+    !areVaultSnapshotIdentitiesEqual(
+      left.candidateSnapshotIdentity,
+      right.candidateSnapshotIdentity,
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    left.expectedRemoteSnapshotIdentity === null ||
+    right.expectedRemoteSnapshotIdentity === null
+  ) {
+    return (
+      left.expectedRemoteSnapshotIdentity === null &&
+      right.expectedRemoteSnapshotIdentity === null
+    );
+  }
+
+  return areVaultSnapshotIdentitiesEqual(
+    left.expectedRemoteSnapshotIdentity,
+    right.expectedRemoteSnapshotIdentity,
+  );
 }

--- a/packages/core/src/services/trust/device-enrollment-consumption.service.ts
+++ b/packages/core/src/services/trust/device-enrollment-consumption.service.ts
@@ -4,11 +4,13 @@ import type { UnlockedVault } from "../../domain/session";
 import { requireDeviceProfilesMatchTrust } from "../../domain/sync/device-profile-review.utils";
 import { findChangesInKeySlots } from "../../domain/sync/key-slot-review.utils";
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
   cloneVaultSnapshotDescriptor,
   toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot";
-import type { ReviewedVaultSnapshotDescriptors } from "../../domain/snapshot";
+import type { ReviewedVaultSnapshotIdentities } from "../../domain/snapshot";
 import type { Vault } from "../../domain/vault";
 import { clearVaultProviderCredentialRevocationPending } from "../../domain/vault/vault-sync-config.mutations";
 import { compareVersionVectors } from "../../domain/versioning";
@@ -50,7 +52,7 @@ export class DeviceEnrollmentConsumptionService {
     readonly operation: string;
     readonly unlockedVault: UnlockedVault;
     readonly sourceSnapshotVersionVector: VersionVector;
-    readonly reviewedSnapshotDescriptors?: ReviewedVaultSnapshotDescriptors;
+    readonly reviewedSnapshotIdentities?: ReviewedVaultSnapshotIdentities;
   }) {
     if (params.unlockedVault.vault.syncTarget === undefined) {
       throw new SyncNotConfiguredError(params.vaultId, params.operation);
@@ -68,10 +70,14 @@ export class DeviceEnrollmentConsumptionService {
       );
 
     if (
-      params.reviewedSnapshotDescriptors !== undefined &&
-      !areVaultSnapshotDescriptorsEqual(
-        toVaultSnapshotDescriptor(params.vaultId, localSnapshot),
-        params.reviewedSnapshotDescriptors.local,
+      params.reviewedSnapshotIdentities !== undefined &&
+      !areVaultSnapshotIdentitiesEqual(
+        toVaultSnapshotIdentity(
+          params.vaultId,
+          localSnapshot,
+          params.unlockedVault.trustedSnapshotContext.snapshotDigest,
+        ),
+        params.reviewedSnapshotIdentities.local,
       )
     ) {
       throw new LocalVaultSnapshotChangedError(params.vaultId);
@@ -94,10 +100,10 @@ export class DeviceEnrollmentConsumptionService {
     );
 
     if (
-      params.reviewedSnapshotDescriptors !== undefined &&
+      params.reviewedSnapshotIdentities !== undefined &&
       !areVaultSnapshotDescriptorsEqual(
         remoteSnapshotDescriptor,
-        params.reviewedSnapshotDescriptors.remote,
+        params.reviewedSnapshotIdentities.remote.descriptor,
       )
     ) {
       throw new RemoteVaultSnapshotChangedError(params.vaultId);
@@ -122,6 +128,20 @@ export class DeviceEnrollmentConsumptionService {
       remoteSnapshot,
       params.unlockedVault,
     );
+
+    if (
+      params.reviewedSnapshotIdentities !== undefined &&
+      !areVaultSnapshotIdentitiesEqual(
+        toVaultSnapshotIdentity(
+          params.vaultId,
+          remoteSnapshot,
+          remoteTrust.snapshotDigest,
+        ),
+        params.reviewedSnapshotIdentities.remote,
+      )
+    ) {
+      throw new RemoteVaultSnapshotChangedError(params.vaultId);
+    }
 
     if (
       remoteSnapshot.metadata.vaultCreationTimestamp !==

--- a/packages/core/src/services/trust/device-revocation-consumption.service.ts
+++ b/packages/core/src/services/trust/device-revocation-consumption.service.ts
@@ -4,11 +4,13 @@ import type { UnlockedVault } from "../../domain/session";
 import type { SyncAccess, SyncSetupInput } from "../../domain/sync";
 import { requireDeviceProfilesMatchTrust } from "../../domain/sync/device-profile-review.utils";
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
   cloneVaultSnapshotDescriptor,
   toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot";
-import type { ReviewedVaultSnapshotDescriptors } from "../../domain/snapshot";
+import type { ReviewedVaultSnapshotIdentities } from "../../domain/snapshot";
 import type { Vault } from "../../domain/vault";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device.mutations";
 import {
@@ -65,7 +67,7 @@ export class DeviceRevocationConsumptionService {
     readonly replacementSyncConfig: SyncSetupInput;
     readonly unlockedVault: UnlockedVault;
     readonly sourceSnapshotVersionVector: VersionVector;
-    readonly reviewedSnapshotDescriptors?: ReviewedVaultSnapshotDescriptors;
+    readonly reviewedSnapshotIdentities?: ReviewedVaultSnapshotIdentities;
   }) {
     const syncTarget = params.unlockedVault.vault.syncTarget;
 
@@ -81,10 +83,14 @@ export class DeviceRevocationConsumptionService {
       );
 
     if (
-      params.reviewedSnapshotDescriptors !== undefined &&
-      !areVaultSnapshotDescriptorsEqual(
-        toVaultSnapshotDescriptor(params.vaultId, localSnapshot),
-        params.reviewedSnapshotDescriptors.local,
+      params.reviewedSnapshotIdentities !== undefined &&
+      !areVaultSnapshotIdentitiesEqual(
+        toVaultSnapshotIdentity(
+          params.vaultId,
+          localSnapshot,
+          params.unlockedVault.trustedSnapshotContext.snapshotDigest,
+        ),
+        params.reviewedSnapshotIdentities.local,
       )
     ) {
       throw new LocalVaultSnapshotChangedError(params.vaultId);
@@ -169,10 +175,10 @@ export class DeviceRevocationConsumptionService {
     );
 
     if (
-      params.reviewedSnapshotDescriptors !== undefined &&
+      params.reviewedSnapshotIdentities !== undefined &&
       !areVaultSnapshotDescriptorsEqual(
         remoteSnapshotDescriptor,
-        params.reviewedSnapshotDescriptors.remote,
+        params.reviewedSnapshotIdentities.remote.descriptor,
       )
     ) {
       throw new RemoteVaultSnapshotChangedError(params.vaultId);
@@ -197,6 +203,20 @@ export class DeviceRevocationConsumptionService {
       remoteSnapshot,
       params.unlockedVault,
     );
+
+    if (
+      params.reviewedSnapshotIdentities !== undefined &&
+      !areVaultSnapshotIdentitiesEqual(
+        toVaultSnapshotIdentity(
+          params.vaultId,
+          remoteSnapshot,
+          remoteTrust.snapshotDigest,
+        ),
+        params.reviewedSnapshotIdentities.remote,
+      )
+    ) {
+      throw new RemoteVaultSnapshotChangedError(params.vaultId);
+    }
 
     if (
       remoteSnapshot.metadata.vaultCreationTimestamp !==

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  createDivergedTrustBaselineFixture,
-} from "../../__tests__/fixtures/device-trust";
+import { createDivergedTrustBaselineFixture } from "../../__tests__/fixtures/device-trust";
 import { createCoreTestPorts } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import type {
@@ -12,7 +10,10 @@ import type {
 } from "../../domain/device-trust";
 import type { UnlockedVault } from "../../domain/session";
 import type { VaultSnapshot } from "../../domain/snapshot";
-import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
+import {
+  toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
+} from "../../domain/snapshot";
 import { InvalidDeviceEnrollmentTransitionError } from "../../errors/device-enrollment.errors";
 import {
   RemoteVaultSnapshotChangedError,
@@ -204,6 +205,15 @@ function createContext() {
   };
   ports.saved.vaultSnapshot = localSnapshot;
   ports.saved.vaultSnapshotDigest = values.vaultSnapshotDigest;
+  ports.saved.localVaultTrustCheckpoint = {
+    ...values.localVaultTrustCheckpoint,
+    payload: {
+      ...values.localVaultTrustCheckpoint.payload,
+      trustGeneration: localTrust.generation,
+      snapshotVersionVector: localSnapshot.metadata.snapshotVersionVector,
+      snapshotDigest: values.vaultSnapshotDigest,
+    },
+  };
   ports.saved.deviceSyncCredentialState =
     values.encryptedDeviceSyncCredentialState;
   ports.saved.unlockedVaultSession = {
@@ -266,9 +276,17 @@ function createContext() {
 function createCommand(ctx: ReturnType<typeof createContext>) {
   return {
     vaultId: ctx.values.vaultId,
-    reviewedSnapshotDescriptors: {
-      local: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.localSnapshot),
-      remote: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.remoteSnapshot),
+    reviewedSnapshotIdentities: {
+      local: toVaultSnapshotIdentity(
+        ctx.values.vaultId,
+        ctx.localSnapshot,
+        ctx.values.vaultSnapshotDigest,
+      ),
+      remote: toVaultSnapshotIdentity(
+        ctx.values.vaultId,
+        ctx.remoteSnapshot,
+        ctx.values.vaultSnapshotDigest,
+      ),
     },
     resolution: {
       entryResolutions: [],
@@ -307,8 +325,12 @@ describe("device enrollment consumption", () => {
 
     expect(result.enrolledDeviceIds).toEqual([ctx.enrolledDevice.deviceId]);
     expect(result.vaultKeyGeneration).toBe(1);
-    expect(result.reviewedSnapshotDescriptors.local).toEqual(
-      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.localSnapshot),
+    expect(result.reviewedSnapshotIdentities.local).toEqual(
+      toVaultSnapshotIdentity(
+        ctx.values.vaultId,
+        ctx.localSnapshot,
+        ctx.values.vaultSnapshotDigest,
+      ),
     );
     expect(result.review.deviceProfileReviews).toEqual([]);
     expect(
@@ -326,23 +348,19 @@ describe("device enrollment consumption", () => {
       throw new Error("Expected local and remote trust transitions.");
     }
 
-    const {
-      divergedBaseline,
-      divergedBaselineDigest,
-      forgedRemoteSnapshot,
-    } = createDivergedTrustBaselineFixture({
-      remoteSnapshot: ctx.remoteSnapshot,
-      remotePrefix: ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
-      localBaseline,
-      remoteTransition,
-      replacementSignature: ctx.values.enrollmentRequestSignature,
-    });
-    vi.mocked(
-      ctx.ports.crypto.digestVaultTrustCertificate,
-    ).mockImplementation(async (certificate) =>
-      certificate === divergedBaseline
-        ? divergedBaselineDigest
-        : ctx.values.vaultTrustCertificateDigest,
+    const { divergedBaseline, divergedBaselineDigest, forgedRemoteSnapshot } =
+      createDivergedTrustBaselineFixture({
+        remoteSnapshot: ctx.remoteSnapshot,
+        remotePrefix: ctx.remoteSnapshot.trustChain.certificates.slice(0, 1),
+        localBaseline,
+        remoteTransition,
+        replacementSignature: ctx.values.enrollmentRequestSignature,
+      });
+    vi.mocked(ctx.ports.crypto.digestVaultTrustCertificate).mockImplementation(
+      async (certificate) =>
+        certificate === divergedBaseline
+          ? divergedBaselineDigest
+          : ctx.values.vaultTrustCertificateDigest,
     );
     vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
       forgedRemoteSnapshot,
@@ -507,6 +525,7 @@ describe("device enrollment consumption", () => {
     expect(result).toEqual({
       enrolledDeviceIds: [ctx.enrolledDevice.deviceId],
       vaultKeyGeneration: 1,
+      syncUpload: "complete",
     });
     expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.remoteSnapshot);
     expect(
@@ -584,7 +603,13 @@ describe("device enrollment consumption", () => {
         trustChain: ctx.remoteSnapshot.trustChain,
         keySlots: ctx.remoteSnapshot.keySlots,
       }),
-      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.remoteSnapshot),
+      {
+        descriptor: toVaultSnapshotDescriptor(
+          ctx.values.vaultId,
+          ctx.remoteSnapshot,
+        ),
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
     expect(
       ctx.ports.saved.unlockedVaultSession?.unlockedVault.vault.tags,
@@ -746,6 +771,29 @@ describe("device enrollment consumption", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("rejects same-descriptor enrollment bytes that differ from the reviewed identity", async () => {
+    const ctx = createContext();
+    const verification = vi
+      .spyOn(VaultSnapshotService.prototype, "verifyCandidateSnapshotTrust")
+      .mockResolvedValue({
+        chain: ctx.remoteSnapshot.trustChain,
+        state: ctx.values.verifiedVaultTrustState,
+        snapshotDigest: "substituted-remote-snapshot-digest",
+      });
+
+    try {
+      await expect(
+        ctx.consumeUseCase.execute(createCommand(ctx)),
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    } finally {
+      verification.mockRestore();
+    }
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
   it("rejects when the reviewed local snapshot changes before apply", async () => {
     const ctx = createContext();
     const command = createCommand(ctx);
@@ -753,12 +801,16 @@ describe("device enrollment consumption", () => {
     await expect(
       ctx.consumeUseCase.execute({
         ...command,
-        reviewedSnapshotDescriptors: {
-          ...command.reviewedSnapshotDescriptors,
+        reviewedSnapshotIdentities: {
+          ...command.reviewedSnapshotIdentities,
           local: {
-            ...command.reviewedSnapshotDescriptors.local,
-            revisionTimestamp:
-              command.reviewedSnapshotDescriptors.local.revisionTimestamp - 1,
+            ...command.reviewedSnapshotIdentities.local,
+            descriptor: {
+              ...command.reviewedSnapshotIdentities.local.descriptor,
+              revisionTimestamp:
+                command.reviewedSnapshotIdentities.local.descriptor
+                  .revisionTimestamp - 1,
+            },
           },
         },
       }),
@@ -788,8 +840,11 @@ describe("device enrollment consumption", () => {
     vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue(
       remoteVault,
     );
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
     );
 
     await expect(
@@ -807,5 +862,47 @@ describe("device enrollment consumption", () => {
     expect(ctx.ports.saved.unlockedVaultSession?.unlockedVault.vault).toBe(
       ctx.localVault,
     );
+  });
+
+  it("keeps resolved enrollment content and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    const remoteVault = {
+      ...ctx.localVault,
+      versionVector: { [ctx.values.deviceId]: 3 },
+      tags: [
+        {
+          id: 1,
+          name: "Remote tag",
+          versionVector: { [ctx.values.deviceId]: 3 },
+        },
+      ],
+    };
+    vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue(
+      remoteVault,
+    );
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.consumeUseCase.execute({
+      ...createCommand(ctx),
+      resolution: {
+        entryResolutions: [],
+        tagResolutions: [{ tagId: 1, action: "use_remote" }],
+        deviceProfileResolutions: [],
+      },
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(ctx.ports.saved.vaultSnapshot).not.toBe(ctx.localSnapshot);
+    expect(
+      ctx.ports.saved.unlockedVaultSession?.unlockedVault.vault.tags,
+    ).toEqual([expect.objectContaining({ id: 1, name: "Remote tag" })]);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
@@ -180,7 +180,7 @@ export class ConsumeDeviceEnrollmentUseCase {
             await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
               params.vaultId,
               unlockedVault,
-              { allowPendingSnapshotUpload: true },
+              { discardPendingSnapshotUpload: true },
             );
           const persistedSnapshot =
             await this.vaultSnapshot.persistUnlockedVault(
@@ -288,7 +288,7 @@ export class ConsumeDeviceEnrollmentUseCase {
           await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
             unlockedVault.vaultId,
             unlockedVault,
-            { allowPendingSnapshotUpload: true },
+            { discardPendingSnapshotUpload: true },
           );
 
         await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({

--- a/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-enrollment.ts
@@ -9,11 +9,11 @@ import {
 } from "../../domain/sync/sync-resolution.utils";
 import { findChangedTags } from "../../domain/sync/tag-review.utils";
 import type {
-  ReviewedVaultSnapshotDescriptors,
+  ReviewedVaultSnapshotIdentities,
   VaultSnapshot,
 } from "../../domain/snapshot";
 import {
-  cloneReviewedVaultSnapshotDescriptors,
+  cloneReviewedVaultSnapshotIdentities,
   cloneVaultSnapshotDescriptor,
 } from "../../domain/snapshot";
 import type { Vault } from "../../domain/vault";
@@ -31,16 +31,18 @@ import type { VaultSnapshotService } from "../../services/snapshot/vault-snapsho
 import type { VaultSyncGuardService } from "../../services/sync";
 import { DeviceEnrollmentConsumptionService } from "../../services/trust/device-enrollment-consumption.service";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type ConsumeDeviceEnrollmentCommandParams = {
   readonly vaultId: string;
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly resolution: VaultSyncResolution;
 };
 
 export type ConsumeDeviceEnrollmentResult = {
   readonly enrolledDeviceIds: readonly string[];
   readonly vaultKeyGeneration: number;
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class ConsumeDeviceEnrollmentUseCase {
@@ -77,13 +79,13 @@ export class ConsumeDeviceEnrollmentUseCase {
   async execute(
     params: ConsumeDeviceEnrollmentCommandParams,
   ): Promise<ConsumeDeviceEnrollmentResult> {
-    const reviewedSnapshotDescriptors = cloneReviewedVaultSnapshotDescriptors(
-      params.reviewedSnapshotDescriptors,
+    const reviewedSnapshotIdentities = cloneReviewedVaultSnapshotIdentities(
+      params.reviewedSnapshotIdentities,
     );
     const resolution = cloneVaultSyncResolution(params.resolution);
     if (
-      reviewedSnapshotDescriptors.local.vaultId !== params.vaultId ||
-      reviewedSnapshotDescriptors.remote.vaultId !== params.vaultId
+      reviewedSnapshotIdentities.local.descriptor.vaultId !== params.vaultId ||
+      reviewedSnapshotIdentities.remote.descriptor.vaultId !== params.vaultId
     ) {
       throw new InvalidSyncResolutionError(
         params.vaultId,
@@ -101,7 +103,7 @@ export class ConsumeDeviceEnrollmentUseCase {
       operation: "consume device enrollment",
       unlockedVault,
       sourceSnapshotVersionVector,
-      reviewedSnapshotDescriptors,
+      reviewedSnapshotIdentities,
     });
     const entryReviews = findChangedEntries(
       candidate.enrollmentBaseline,
@@ -128,6 +130,7 @@ export class ConsumeDeviceEnrollmentUseCase {
       entryReviews.length > 0 ||
       tagReviews.length > 0 ||
       deviceProfileReviews.length > 0;
+    let syncUpload: SyncUploadStatus = "complete";
 
     if (!hasContentChanges) {
       await this.persistRemoteSnapshot(
@@ -160,53 +163,80 @@ export class ConsumeDeviceEnrollmentUseCase {
         ...unlockedVault,
         vault: resolvedVault,
       };
-      const { persistedSnapshot, preparedRestore } =
-        await this.unlockedVaultSession.persistForActiveSession(
-          sessionId,
-          params.vaultId,
-          async () => {
-            const preparedRestore =
-              await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
-                candidate.localSnapshot,
-                unlockedVault,
-              );
-            const persistedSnapshot =
-              await this.vaultSnapshot.persistUnlockedVault(
-                params.vaultId,
-                updatedUnlockedVault,
-                sourceSnapshotVersionVector,
-                {
-                  baseSnapshotVersionVector: mergeVersionVectors(
-                    candidate.localSnapshot.metadata.snapshotVersionVector,
-                    candidate.remoteSnapshot.metadata.snapshotVersionVector,
-                  ),
-                  keySlots: candidate.remoteSnapshot.keySlots,
-                  vaultKeyGeneration:
-                    candidate.remoteSnapshot.metadata.vaultKeyGeneration,
-                  nextTrust: candidate.remoteTrust,
+      const {
+        persistedSnapshot,
+        preparedRestore,
+        persistedSyncCredentialState,
+      } = await this.unlockedVaultSession.persistForActiveSession(
+        sessionId,
+        params.vaultId,
+        async () => {
+          const preparedRestore =
+            await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
+              candidate.localSnapshot,
+              unlockedVault,
+            );
+          const syncCredentialStateTransition =
+            await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
+              params.vaultId,
+              unlockedVault,
+              { allowPendingSnapshotUpload: true },
+            );
+          const persistedSnapshot =
+            await this.vaultSnapshot.persistUnlockedVault(
+              params.vaultId,
+              updatedUnlockedVault,
+              sourceSnapshotVersionVector,
+              {
+                baseSnapshotVersionVector: mergeVersionVectors(
+                  candidate.localSnapshot.metadata.snapshotVersionVector,
+                  candidate.remoteSnapshot.metadata.snapshotVersionVector,
+                ),
+                keySlots: candidate.remoteSnapshot.keySlots,
+                vaultKeyGeneration:
+                  candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+                nextTrust: candidate.remoteTrust,
+                uploadExpectedRemoteSnapshotIdentity: {
+                  descriptor: candidate.remoteSnapshotDescriptor,
+                  snapshotDigest: candidate.remoteTrust.snapshotDigest,
                 },
-              );
+                expectedSyncCredentialState:
+                  syncCredentialStateTransition.expectedState,
+                syncCredentialState: syncCredentialStateTransition.nextState,
+              },
+            );
 
-            return { persistedSnapshot, preparedRestore };
-          },
-        );
+          return {
+            persistedSnapshot,
+            preparedRestore,
+            persistedSyncCredentialState:
+              syncCredentialStateTransition.nextState,
+          };
+        },
+      );
 
-      await this.vaultSyncGuard.uploadPersistedLocalMutation(
+      syncUpload = await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         {
           localSnapshot: candidate.localSnapshot,
           syncAccess: candidate.syncAccess,
-          remoteSnapshotDescriptor: cloneVaultSnapshotDescriptor(
-            candidate.remoteSnapshotDescriptor,
-          ),
+          syncCredentialState: persistedSyncCredentialState,
+          remoteSnapshotIdentity: {
+            descriptor: cloneVaultSnapshotDescriptor(
+              candidate.remoteSnapshotDescriptor,
+            ),
+            snapshotDigest: candidate.remoteTrust.snapshotDigest,
+          },
         },
         persistedSnapshot.snapshot,
         persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        persistedSnapshot.checkpoint,
+        updatedUnlockedVault,
         preparedRestore,
         sessionId,
       );
 
-      await this.unlockedVaultSession.commitPersistedSnapshot(
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
         sessionId,
         {
           ...updatedUnlockedVault,
@@ -221,6 +251,7 @@ export class ConsumeDeviceEnrollmentUseCase {
         (transition) => transition.enrolledDeviceId,
       ),
       vaultKeyGeneration: candidate.remoteSnapshot.metadata.vaultKeyGeneration,
+      syncUpload,
     };
   }
 
@@ -239,17 +270,38 @@ export class ConsumeDeviceEnrollmentUseCase {
       unlockedVault.deviceId,
       unlockedVault.devicePrivateSignKey,
     );
+    const currentSnapshot = await this.vaultSnapshot.requireLocalVaultSnapshot(
+      unlockedVault.vaultId,
+    );
+    const expectedCheckpoint =
+      await this.vaultSnapshot.requireCurrentCheckpointForUnlockedVault(
+        unlockedVault.vaultId,
+        currentSnapshot,
+        unlockedVault,
+      );
 
     await this.unlockedVaultSession.persistForActiveSession(
       sessionId,
       unlockedVault.vaultId,
-      async () =>
-        this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+      async () => {
+        const syncCredentialStateTransition =
+          await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
+            unlockedVault.vaultId,
+            unlockedVault,
+            { allowPendingSnapshotUpload: true },
+          );
+
+        await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
           expectedSnapshotDigest:
             unlockedVault.trustedSnapshotContext.snapshotDigest,
+          expectedCheckpoint,
+          expectedSyncCredentialState:
+            syncCredentialStateTransition.expectedState,
           snapshot: remoteSnapshot,
           checkpoint,
-        }),
+          syncCredentialState: syncCredentialStateTransition.nextState,
+        });
+      },
     );
 
     await this.unlockedVaultSession.commitPersistedSnapshot(

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createDivergedTrustBaselineFixture } from "../../__tests__/fixtures/device-trust";
 import {
   createCoreTestPorts,
-  replaceVaultSnapshotAfterNextSave,
+  captureVaultSnapshotFromNextSave,
 } from "../../__tests__/fixtures/ports";
 import {
   createCoreTestValues,
@@ -16,7 +16,10 @@ import type {
 } from "../../domain/device-trust";
 import type { UnlockedVault } from "../../domain/session";
 import type { VaultSnapshot } from "../../domain/snapshot";
-import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
+import {
+  toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
+} from "../../domain/snapshot";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device.mutations";
 import {
   CurrentDeviceRevokedError,
@@ -34,6 +37,7 @@ import {
 import { UnlockedVaultSessionExpiredError } from "../../errors/vault-session.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import { VaultSnapshotRollbackDetectedError } from "../../errors/vault-trust.errors";
+import type { SyncUploadOutcome } from "../../ports/sync/sync-provider.port";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { ConsumeDeviceRevocationUseCase } from "./consume-device-revocation";
 import { PrepareDeviceRevocationConsumptionUseCase } from "./prepare-device-revocation-consumption";
@@ -190,6 +194,15 @@ function createContext() {
   };
   ports.saved.vaultSnapshot = localSnapshot;
   ports.saved.vaultSnapshotDigest = values.vaultSnapshotDigest;
+  ports.saved.localVaultTrustCheckpoint = {
+    ...values.localVaultTrustCheckpoint,
+    payload: {
+      ...values.localVaultTrustCheckpoint.payload,
+      trustGeneration: localTrust.generation,
+      snapshotVersionVector: localSnapshot.metadata.snapshotVersionVector,
+      snapshotDigest: values.vaultSnapshotDigest,
+    },
+  };
   ports.saved.deviceSyncCredentialState =
     values.encryptedDeviceSyncCredentialState;
   ports.saved.unlockedVaultSession = {
@@ -243,9 +256,17 @@ function createCommand(ctx: {
   return {
     vaultId: ctx.values.vaultId,
     replacementSyncConfig: ctx.values.replacementSyncConfigInput,
-    reviewedSnapshotDescriptors: {
-      local: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.localSnapshot),
-      remote: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.remoteSnapshot),
+    reviewedSnapshotIdentities: {
+      local: toVaultSnapshotIdentity(
+        ctx.values.vaultId,
+        ctx.localSnapshot,
+        ctx.values.vaultSnapshotDigest,
+      ),
+      remote: toVaultSnapshotIdentity(
+        ctx.values.vaultId,
+        ctx.remoteSnapshot,
+        ctx.values.vaultSnapshotDigest,
+      ),
     },
     resolution: {
       entryResolutions: [],
@@ -285,8 +306,12 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
     });
 
     expect(result).toMatchObject({
-      reviewedSnapshotDescriptors: {
-        local: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.localSnapshot),
+      reviewedSnapshotIdentities: {
+        local: toVaultSnapshotIdentity(
+          ctx.values.vaultId,
+          ctx.localSnapshot,
+          ctx.values.vaultSnapshotDigest,
+        ),
       },
       revokedDeviceIds: [ctx.values.pendingDeviceId],
       vaultKeyGeneration: 2,
@@ -770,7 +795,7 @@ describe("PrepareDeviceRevocationConsumptionUseCase", () => {
 });
 
 describe("ConsumeDeviceRevocationUseCase", () => {
-  it("uploads the signed consumption even when local storage replaces it after save", async () => {
+  it("uploads the exact signed consumption persisted by the local save", async () => {
     const ctx = createContext();
     const remoteVault = {
       ...ctx.remoteVault,
@@ -785,10 +810,7 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue(
       remoteVault,
     );
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      ctx.localSnapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
     await ctx.useCase.execute({
       ...createCommand(ctx),
@@ -803,8 +825,6 @@ describe("ConsumeDeviceRevocationUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
-    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.localSnapshot);
   });
 
   it("opens the survivor envelope and commits the rotated snapshot", async () => {
@@ -847,6 +867,7 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     expect(result.providerCredentialRevocation).toBe(
       "pending_external_deletion",
     );
+    expect(result.syncUpload).toBe("complete");
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
 
@@ -1044,9 +1065,17 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     await expect(
       ctx.useCase.execute({
         ...createCommand(ctx),
-        reviewedSnapshotDescriptors: {
-          local: toVaultSnapshotDescriptor(ctx.values.vaultId, localSnapshot),
-          remote: toVaultSnapshotDescriptor(ctx.values.vaultId, remoteSnapshot),
+        reviewedSnapshotIdentities: {
+          local: toVaultSnapshotIdentity(
+            ctx.values.vaultId,
+            localSnapshot,
+            ctx.values.vaultSnapshotDigest,
+          ),
+          remote: toVaultSnapshotIdentity(
+            ctx.values.vaultId,
+            remoteSnapshot,
+            ctx.values.vaultSnapshotDigest,
+          ),
         },
       }),
     ).resolves.toMatchObject({
@@ -1232,9 +1261,13 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     await expect(
       ctx.useCase.execute({
         ...createCommand(ctx),
-        reviewedSnapshotDescriptors: {
-          ...createCommand(ctx).reviewedSnapshotDescriptors,
-          remote: toVaultSnapshotDescriptor(ctx.values.vaultId, remoteSnapshot),
+        reviewedSnapshotIdentities: {
+          ...createCommand(ctx).reviewedSnapshotIdentities,
+          remote: toVaultSnapshotIdentity(
+            ctx.values.vaultId,
+            remoteSnapshot,
+            ctx.values.vaultSnapshotDigest,
+          ),
         },
       }),
     ).resolves.toMatchObject({
@@ -1278,12 +1311,19 @@ describe("ConsumeDeviceRevocationUseCase", () => {
 
     await expect(ctx.useCase.execute(command)).resolves.toMatchObject({
       revokedDeviceIds: [ctx.values.pendingDeviceId],
+      syncUpload: "complete",
     });
 
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.replacementSyncAccess,
       expect.anything(),
-      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.remoteSnapshot),
+      {
+        descriptor: toVaultSnapshotDescriptor(
+          ctx.values.vaultId,
+          ctx.remoteSnapshot,
+        ),
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
   });
 
@@ -1326,6 +1366,29 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
   });
 
+  it("rejects same-descriptor revocation bytes that differ from the reviewed identity", async () => {
+    const ctx = createContext();
+    const verification = vi
+      .spyOn(VaultSnapshotService.prototype, "verifyCandidateSnapshotTrust")
+      .mockResolvedValue({
+        chain: ctx.remoteSnapshot.trustChain,
+        state: ctx.values.verifiedVaultTrustState,
+        snapshotDigest: "substituted-remote-snapshot-digest",
+      });
+
+    try {
+      await expect(
+        ctx.useCase.execute(createCommand(ctx)),
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    } finally {
+      verification.mockRestore();
+    }
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
   it("rejects when the local descriptor changed after review", async () => {
     const ctx = createContext();
     const command = createCommand(ctx);
@@ -1333,12 +1396,16 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     await expect(
       ctx.useCase.execute({
         ...command,
-        reviewedSnapshotDescriptors: {
-          ...command.reviewedSnapshotDescriptors,
+        reviewedSnapshotIdentities: {
+          ...command.reviewedSnapshotIdentities,
           local: {
-            ...command.reviewedSnapshotDescriptors.local,
-            revisionTimestamp:
-              command.reviewedSnapshotDescriptors.local.revisionTimestamp - 1,
+            ...command.reviewedSnapshotIdentities.local,
+            descriptor: {
+              ...command.reviewedSnapshotIdentities.local.descriptor,
+              revisionTimestamp:
+                command.reviewedSnapshotIdentities.local.descriptor
+                  .revisionTimestamp - 1,
+            },
           },
         },
       }),
@@ -1365,8 +1432,11 @@ describe("ConsumeDeviceRevocationUseCase", () => {
         },
       ],
     });
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValue(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
     );
 
     await expect(
@@ -1384,6 +1454,126 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
+  });
+
+  it("keeps resolved revocation content and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue({
+      ...ctx.remoteVault,
+      tags: [
+        {
+          id: 1,
+          name: "Later change",
+          versionVector: { [ctx.values.deviceId]: 3 },
+        },
+      ],
+    });
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      ...createCommand(ctx),
+      resolution: {
+        entryResolutions: [],
+        tagResolutions: [{ tagId: 1, action: "use_remote" }],
+        deviceProfileResolutions: [],
+      },
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(ctx.ports.saved.vaultSnapshot).not.toEqual(ctx.localSnapshot);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.replacementSyncCredentials,
+        previousCredentials: expect.any(Object),
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
+    expect(
+      ctx.ports.saved.unlockedVaultSession?.unlockedVault.vault.tags,
+    ).toEqual([expect.objectContaining({ id: 1, name: "Later change" })]);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("keeps resolved revocation content but wipes its key when the session is removed after upload start", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue({
+      ...ctx.remoteVault,
+      tags: [
+        {
+          id: 1,
+          name: "Later change",
+          versionVector: { [ctx.values.deviceId]: 3 },
+        },
+      ],
+    });
+    let signalUploadStarted: () => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
+    const uploadStarted = new Promise<void>((resolve) => {
+      signalUploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
+          signalUploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      ...createCommand(ctx),
+      resolution: {
+        entryResolutions: [],
+        tagResolutions: [{ tagId: 1, action: "use_remote" }],
+        deviceProfileResolutions: [],
+      },
+    });
+    await uploadStarted;
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    resolveUpload({ status: "committed" });
+
+    await expect(execution).resolves.toMatchObject({ syncUpload: "pending" });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.ports.saved.vaultSnapshot).not.toEqual(ctx.localSnapshot);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.replacementSyncCredentials,
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
+    expect(
+      Array.from(new Uint8Array(ctx.values.rotatedVaultMasterKey)),
+    ).toEqual([0]);
   });
 
   it("rejects a changed vault creation timestamp before staging credentials", async () => {
@@ -1534,11 +1724,12 @@ describe("ConsumeDeviceRevocationUseCase", () => {
       await expect(
         ctx.useCase.execute({
           ...createCommand(ctx),
-          reviewedSnapshotDescriptors: {
-            ...createCommand(ctx).reviewedSnapshotDescriptors,
-            remote: toVaultSnapshotDescriptor(
+          reviewedSnapshotIdentities: {
+            ...createCommand(ctx).reviewedSnapshotIdentities,
+            remote: toVaultSnapshotIdentity(
               ctx.values.vaultId,
               remoteSnapshot,
+              ctx.values.vaultSnapshotDigest,
             ),
           },
         }),
@@ -1608,9 +1799,13 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     await expect(
       ctx.useCase.execute({
         ...createCommand(ctx),
-        reviewedSnapshotDescriptors: {
-          ...createCommand(ctx).reviewedSnapshotDescriptors,
-          remote: toVaultSnapshotDescriptor(ctx.values.vaultId, remoteSnapshot),
+        reviewedSnapshotIdentities: {
+          ...createCommand(ctx).reviewedSnapshotIdentities,
+          remote: toVaultSnapshotIdentity(
+            ctx.values.vaultId,
+            remoteSnapshot,
+            ctx.values.vaultSnapshotDigest,
+          ),
         },
       }),
     ).rejects.toBeInstanceOf(Error);
@@ -1718,9 +1913,13 @@ describe("ConsumeDeviceRevocationUseCase", () => {
     await expect(
       ctx.useCase.execute({
         ...createCommand(ctx),
-        reviewedSnapshotDescriptors: {
-          ...createCommand(ctx).reviewedSnapshotDescriptors,
-          remote: toVaultSnapshotDescriptor(ctx.values.vaultId, remoteSnapshot),
+        reviewedSnapshotIdentities: {
+          ...createCommand(ctx).reviewedSnapshotIdentities,
+          remote: toVaultSnapshotIdentity(
+            ctx.values.vaultId,
+            remoteSnapshot,
+            ctx.values.vaultSnapshotDigest,
+          ),
         },
       }),
     ).rejects.toBeInstanceOf(CurrentDeviceRevokedError);

--- a/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
+++ b/packages/core/src/use-cases/device-trust/consume-device-revocation.ts
@@ -17,26 +17,24 @@ import {
 } from "../../domain/sync/sync-resolution.utils";
 import { findChangedTags } from "../../domain/sync/tag-review.utils";
 import type {
-  ReviewedVaultSnapshotDescriptors,
+  ReviewedVaultSnapshotIdentities,
   VaultMasterKey,
   VaultSnapshot,
   VaultSnapshotDescriptor,
 } from "../../domain/snapshot";
 import {
-  cloneReviewedVaultSnapshotDescriptors,
+  cloneReviewedVaultSnapshotIdentities,
   cloneVaultSnapshotDescriptor,
 } from "../../domain/snapshot";
 import type { Vault } from "../../domain/vault";
 import type { VersionVector } from "../../domain/versioning";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import { mergeVersionVectors } from "../../domain/versioning";
 import {
   InvalidSyncResolutionError,
   InvalidVaultSyncResolutionError,
-  RemoteVaultSnapshotChangedError,
-  SyncConflictDetectedError,
   SyncResolutionIncompleteError,
 } from "../../errors/sync.errors";
-import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
@@ -45,11 +43,12 @@ import type { VaultSnapshotService } from "../../services/snapshot/vault-snapsho
 import { DeviceRevocationConsumptionService } from "../../services/trust/device-revocation-consumption.service";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
 import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
+import { VaultSyncGuardService } from "../../services/sync/vault-sync-guard.service";
 
 export type ConsumeDeviceRevocationCommandParams = {
   readonly vaultId: string;
   readonly replacementSyncConfig: SyncSetupInput;
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly resolution: VaultSyncResolution;
 };
 
@@ -58,16 +57,17 @@ export type ConsumeDeviceRevocationResult = {
   readonly enrolledDeviceIds: readonly string[];
   readonly vaultKeyGeneration: number;
   readonly providerCredentialRevocation: "pending_external_deletion";
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class ConsumeDeviceRevocationUseCase {
   private readonly crypto: CryptoPort;
-  private readonly syncProvider: SyncProviderPort;
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultSnapshot: VaultSnapshotService;
   private readonly vaultLocalRepository: VaultLocalRepositoryPort;
   private readonly revocationConsumption: DeviceRevocationConsumptionService;
   private readonly vaultTrust: VaultTrustService;
+  private readonly vaultSyncGuard: VaultSyncGuardService;
 
   constructor(
     crypto: CryptoPort,
@@ -77,7 +77,6 @@ export class ConsumeDeviceRevocationUseCase {
     vaultLocalRepository: VaultLocalRepositoryPort,
   ) {
     this.crypto = crypto;
-    this.syncProvider = syncProvider;
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultSnapshot = vaultSnapshot;
     this.vaultLocalRepository = vaultLocalRepository;
@@ -88,18 +87,25 @@ export class ConsumeDeviceRevocationUseCase {
       vaultLocalRepository,
     );
     this.vaultTrust = new VaultTrustService(crypto);
+    this.vaultSyncGuard = new VaultSyncGuardService(
+      syncProvider,
+      vaultSnapshot,
+      unlockedVaultSession,
+      crypto,
+      vaultLocalRepository,
+    );
   }
 
   async execute(
     params: ConsumeDeviceRevocationCommandParams,
   ): Promise<ConsumeDeviceRevocationResult> {
-    const reviewedSnapshotDescriptors = cloneReviewedVaultSnapshotDescriptors(
-      params.reviewedSnapshotDescriptors,
+    const reviewedSnapshotIdentities = cloneReviewedVaultSnapshotIdentities(
+      params.reviewedSnapshotIdentities,
     );
     const resolution = cloneVaultSyncResolution(params.resolution);
     if (
-      reviewedSnapshotDescriptors.local.vaultId !== params.vaultId ||
-      reviewedSnapshotDescriptors.remote.vaultId !== params.vaultId
+      reviewedSnapshotIdentities.local.descriptor.vaultId !== params.vaultId ||
+      reviewedSnapshotIdentities.remote.descriptor.vaultId !== params.vaultId
     ) {
       throw new InvalidSyncResolutionError(
         params.vaultId,
@@ -117,7 +123,7 @@ export class ConsumeDeviceRevocationUseCase {
       replacementSyncConfig: params.replacementSyncConfig,
       unlockedVault,
       sourceSnapshotVersionVector,
-      reviewedSnapshotDescriptors,
+      reviewedSnapshotIdentities,
     });
     let vaultMasterKeyTransferred = false;
 
@@ -168,6 +174,7 @@ export class ConsumeDeviceRevocationUseCase {
         entryReviews.length > 0 ||
         tagReviews.length > 0 ||
         deviceProfileReviews.length > 0;
+      let syncUpload: SyncUploadStatus = "complete";
 
       if (!hasContentChanges) {
         await this.persistRemoteSnapshot(
@@ -177,8 +184,10 @@ export class ConsumeDeviceRevocationUseCase {
           candidate.remoteTrust.state,
           candidate.remoteVault,
           candidate.vaultMasterKey,
+          candidate.previousEncryptedState,
           encryptedCredentialState,
         );
+        vaultMasterKeyTransferred = true;
       } else {
         let resolvedVault: Vault;
 
@@ -198,7 +207,7 @@ export class ConsumeDeviceRevocationUseCase {
           throw error;
         }
 
-        await this.persistResolvedSnapshot({
+        const resolvedSnapshot = await this.persistResolvedSnapshot({
           vaultId: params.vaultId,
           sessionId,
           sourceSnapshotVersionVector,
@@ -213,8 +222,9 @@ export class ConsumeDeviceRevocationUseCase {
           previousEncryptedState: candidate.previousEncryptedState,
           encryptedCredentialState,
         });
+        syncUpload = resolvedSnapshot.syncUpload;
+        vaultMasterKeyTransferred = resolvedSnapshot.sessionCommitted;
       }
-      vaultMasterKeyTransferred = true;
 
       return {
         revokedDeviceIds,
@@ -222,6 +232,7 @@ export class ConsumeDeviceRevocationUseCase {
         vaultKeyGeneration:
           candidate.remoteSnapshot.metadata.vaultKeyGeneration,
         providerCredentialRevocation: "pending_external_deletion",
+        syncUpload,
       };
     } finally {
       if (!vaultMasterKeyTransferred) {
@@ -237,6 +248,7 @@ export class ConsumeDeviceRevocationUseCase {
     remoteTrust: VerifiedVaultTrustState,
     remoteVault: Vault,
     vaultMasterKey: VaultMasterKey,
+    previousEncryptedState: EncryptedDeviceSyncCredentialState,
     encryptedCredentialState: EncryptedDeviceSyncCredentialState,
   ): Promise<void> {
     const snapshotDigest =
@@ -247,6 +259,15 @@ export class ConsumeDeviceRevocationUseCase {
       unlockedVault.deviceId,
       unlockedVault.devicePrivateSignKey,
     );
+    const currentSnapshot = await this.vaultSnapshot.requireLocalVaultSnapshot(
+      unlockedVault.vaultId,
+    );
+    const expectedCheckpoint =
+      await this.vaultSnapshot.requireCurrentCheckpointForUnlockedVault(
+        unlockedVault.vaultId,
+        currentSnapshot,
+        unlockedVault,
+      );
 
     await this.unlockedVaultSession.persistForActiveSession(
       sessionId,
@@ -255,6 +276,8 @@ export class ConsumeDeviceRevocationUseCase {
         this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
           expectedSnapshotDigest:
             unlockedVault.trustedSnapshotContext.snapshotDigest,
+          expectedCheckpoint,
+          expectedSyncCredentialState: previousEncryptedState,
           snapshot: remoteSnapshot,
           checkpoint,
           syncCredentialState: encryptedCredentialState,
@@ -287,13 +310,17 @@ export class ConsumeDeviceRevocationUseCase {
     readonly remoteTrust: {
       readonly chain: VaultTrustChain;
       readonly state: VerifiedVaultTrustState;
+      readonly snapshotDigest: string;
     };
     readonly replacementAccess: SyncAccess;
     readonly vaultMasterKey: VaultMasterKey;
     readonly resolvedVault: Vault;
     readonly previousEncryptedState: EncryptedDeviceSyncCredentialState;
     readonly encryptedCredentialState: EncryptedDeviceSyncCredentialState;
-  }): Promise<void> {
+  }): Promise<{
+    readonly syncUpload: SyncUploadStatus;
+    readonly sessionCommitted: boolean;
+  }> {
     const rotatedUnlockedVault = {
       ...params.unlockedVault,
       vault: params.resolvedVault,
@@ -324,6 +351,11 @@ export class ConsumeDeviceRevocationUseCase {
                 vaultKeyGeneration:
                   params.remoteSnapshot.metadata.vaultKeyGeneration,
                 nextTrust: params.remoteTrust,
+                uploadExpectedRemoteSnapshotIdentity: {
+                  descriptor: params.remoteSnapshotDescriptor,
+                  snapshotDigest: params.remoteTrust.snapshotDigest,
+                },
+                expectedSyncCredentialState: params.previousEncryptedState,
                 syncCredentialState: params.encryptedCredentialState,
               },
             );
@@ -332,43 +364,36 @@ export class ConsumeDeviceRevocationUseCase {
         },
       );
 
-    try {
-      await this.syncProvider.uploadVaultSnapshot(
-        params.replacementAccess,
-        persistedSnapshot.snapshot,
-        cloneVaultSnapshotDescriptor(params.remoteSnapshotDescriptor),
-      );
-    } catch (error) {
-      const rollbackResult =
-        await this.unlockedVaultSession.restorePersistedState(
-          params.sessionId,
-          params.vaultId,
-          params.sourceSnapshotVersionVector,
-          async () =>
-            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-              preparedRestore,
-              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
-            ),
-        );
-
-      if (rollbackResult === "rollback_failed") {
-        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
-      }
-
-      if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(params.vaultId);
-      }
-
-      throw error;
-    }
-
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      params.sessionId,
-      {
-        ...rotatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    const syncUpload = await this.vaultSyncGuard.uploadPersistedSnapshot({
+      vaultId: params.vaultId,
+      syncAccess: params.replacementAccess,
+      persistedSnapshot: persistedSnapshot.snapshot,
+      expectedRemoteSnapshotIdentity: {
+        descriptor: cloneVaultSnapshotDescriptor(
+          params.remoteSnapshotDescriptor,
+        ),
+        snapshotDigest: params.remoteTrust.snapshotDigest,
       },
-      persistedSnapshot.snapshotVersionVector,
-    );
+      previousSnapshotVersionVector: params.sourceSnapshotVersionVector,
+      persistedSnapshotDigest:
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      checkpoint: persistedSnapshot.checkpoint,
+      persistedSyncCredentialState: params.encryptedCredentialState,
+      unlockedVault: rotatedUnlockedVault,
+      preparedRestore,
+      sessionId: params.sessionId,
+    });
+
+    const sessionCommitted =
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
+        params.sessionId,
+        {
+          ...rotatedUnlockedVault,
+          trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+        },
+        persistedSnapshot.snapshotVersionVector,
+      );
+
+    return { syncUpload, sessionCommitted };
   }
 }

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
-import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
+import { captureVaultSnapshotFromNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import type {
   DevicePublicSignKey,
@@ -48,7 +48,7 @@ function createContext() {
 }
 
 describe("InitializeDeviceEnrollmentUseCase", () => {
-  it("uploads the signed snapshot even when local storage replaces it after save", async () => {
+  it("uploads the exact signed snapshot persisted by the local save", async () => {
     const ctx = createContext();
     const session = ctx.saved.unlockedVaultSession;
 
@@ -73,10 +73,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     ).mockResolvedValue(
       toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
     );
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      ctx.vaultSnapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
@@ -87,17 +84,16 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
-    expect(ctx.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
   });
 
   it("authorizes a signed public request and creates a normal target envelope", async () => {
     const ctx = createContext();
 
-    const response = await ctx.useCase.execute({
+    const result = await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
       request: ctx.values.enrollmentRequest,
     });
+    const response = result.enrollmentResponse;
 
     expect(
       ctx.ports.crypto.verifyDeviceEnrollmentRequestSignature,
@@ -120,6 +116,7 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     expect(response).not.toHaveProperty("devicePrivateSignKey");
     expect(response).not.toHaveProperty("devicePrivateVaultKey");
     expect(response).not.toHaveProperty("credentials");
+    expect(result.syncUpload).toBe("complete");
   });
 
   it("rejects an invalid request self-signature before mutation", async () => {
@@ -266,8 +263,11 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
         request: ctx.values.enrollmentRequest,
       }),
     ).resolves.toMatchObject({
-      requestId: ctx.values.requestId,
-      snapshot: currentSnapshot,
+      enrollmentResponse: {
+        requestId: ctx.values.requestId,
+        snapshot: currentSnapshot,
+      },
+      syncUpload: "complete",
     });
 
     expect(ctx.ports.crypto.signVaultTrustCertificate).not.toHaveBeenCalled();
@@ -398,7 +398,8 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
         request: ctx.values.enrollmentRequest,
       }),
     ).resolves.toMatchObject({
-      snapshot: finalSnapshot,
+      enrollmentResponse: { snapshot: finalSnapshot },
+      syncUpload: "complete",
     });
 
     expect(
@@ -551,7 +552,8 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
         request: ctx.values.enrollmentRequest,
       }),
     ).resolves.toMatchObject({
-      snapshot: currentSnapshot,
+      enrollmentResponse: { snapshot: currentSnapshot },
+      syncUpload: "complete",
     });
 
     expect(
@@ -599,5 +601,67 @@ describe("InitializeDeviceEnrollmentUseCase", () => {
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
+  });
+
+  it("keeps the authorized enrollment and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    ctx.saved.deviceSyncCredentialState =
+      ctx.values.encryptedDeviceSyncCredentialState;
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+    );
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      request: ctx.values.enrollmentRequest,
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(result.enrollmentResponse.snapshot).toBe(ctx.saved.vaultSnapshot);
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 2,
+    });
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenCalledTimes(2);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.syncCredentials,
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
   });
 });

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -210,35 +210,27 @@ export class InitializeDeviceEnrollmentUseCase {
               currentSnapshot,
               unlockedVault,
             );
+          const commonSnapshotOptions = {
+            keySlots: {
+              deviceSlots: [
+                ...currentSnapshot.keySlots.deviceSlots,
+                targetSlot,
+              ],
+            },
+            nextTrust: {
+              chain: nextTrust.chain,
+              state: nextTrust.trust,
+            },
+          };
           const snapshotOptions =
             syncState.remoteSnapshotIdentity === undefined
-              ? {
-                  keySlots: {
-                    deviceSlots: [
-                      ...currentSnapshot.keySlots.deviceSlots,
-                      targetSlot,
-                    ],
-                  },
-                  nextTrust: {
-                    chain: nextTrust.chain,
-                    state: nextTrust.trust,
-                  },
-                }
+              ? commonSnapshotOptions
               : {
+                  ...commonSnapshotOptions,
                   uploadExpectedRemoteSnapshotIdentity:
                     syncState.remoteSnapshotIdentity,
                   expectedSyncCredentialState: syncState.syncCredentialState,
                   syncCredentialState: syncState.syncCredentialState,
-                  keySlots: {
-                    deviceSlots: [
-                      ...currentSnapshot.keySlots.deviceSlots,
-                      targetSlot,
-                    ],
-                  },
-                  nextTrust: {
-                    chain: nextTrust.chain,
-                    state: nextTrust.trust,
-                  },
                 };
           const persistedSnapshot =
             await this.vaultSnapshot.persistUnlockedVault(

--- a/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/initialize-device-enrollment.ts
@@ -9,10 +9,16 @@ import type { UnlockedVaultSessionService } from "../../services/session/unlocke
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import type { VaultSyncGuardService } from "../../services/sync";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type InitializeDeviceEnrollmentCommandParams = {
   readonly vaultId: string;
   readonly request: DeviceEnrollmentRequest;
+};
+
+export type InitializeDeviceEnrollmentResult = {
+  readonly enrollmentResponse: DeviceEnrollmentResponse;
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class InitializeDeviceEnrollmentUseCase {
@@ -37,7 +43,7 @@ export class InitializeDeviceEnrollmentUseCase {
 
   async execute(
     params: InitializeDeviceEnrollmentCommandParams,
-  ): Promise<DeviceEnrollmentResponse> {
+  ): Promise<InitializeDeviceEnrollmentResult> {
     const { request } = params;
 
     if (
@@ -132,11 +138,14 @@ export class InitializeDeviceEnrollmentUseCase {
       }
 
       return {
-        version: 1,
-        requestId: request.payload.requestId,
-        vaultId: params.vaultId,
-        vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
-        snapshot: currentSnapshot,
+        enrollmentResponse: {
+          version: 1,
+          requestId: request.payload.requestId,
+          vaultId: params.vaultId,
+          vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
+          snapshot: currentSnapshot,
+        },
+        syncUpload: "complete",
       };
     }
 
@@ -201,53 +210,87 @@ export class InitializeDeviceEnrollmentUseCase {
               currentSnapshot,
               unlockedVault,
             );
+          const snapshotOptions =
+            syncState.remoteSnapshotIdentity === undefined
+              ? {
+                  keySlots: {
+                    deviceSlots: [
+                      ...currentSnapshot.keySlots.deviceSlots,
+                      targetSlot,
+                    ],
+                  },
+                  nextTrust: {
+                    chain: nextTrust.chain,
+                    state: nextTrust.trust,
+                  },
+                }
+              : {
+                  uploadExpectedRemoteSnapshotIdentity:
+                    syncState.remoteSnapshotIdentity,
+                  expectedSyncCredentialState: syncState.syncCredentialState,
+                  syncCredentialState: syncState.syncCredentialState,
+                  keySlots: {
+                    deviceSlots: [
+                      ...currentSnapshot.keySlots.deviceSlots,
+                      targetSlot,
+                    ],
+                  },
+                  nextTrust: {
+                    chain: nextTrust.chain,
+                    state: nextTrust.trust,
+                  },
+                };
           const persistedSnapshot =
             await this.vaultSnapshot.persistUnlockedVault(
               params.vaultId,
               unlockedVault,
               sourceSnapshotVersionVector,
-              {
-                keySlots: {
-                  deviceSlots: [
-                    ...currentSnapshot.keySlots.deviceSlots,
-                    targetSlot,
-                  ],
-                },
-                nextTrust: {
-                  chain: nextTrust.chain,
-                  state: nextTrust.trust,
-                },
-              },
+              snapshotOptions,
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
-    await this.vaultSyncGuard.uploadPersistedLocalMutation(
+    const syncUpload = await this.vaultSyncGuard.uploadPersistedLocalMutation(
       params.vaultId,
       syncState,
       persistedSnapshot.snapshot,
       persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      persistedSnapshot.checkpoint,
+      unlockedVault,
       preparedRestore,
       sessionId,
     );
 
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...unlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
+    const committedUnlockedVault = {
+      ...unlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    };
+
+    if (syncState.syncAccess === undefined) {
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    } else {
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    }
 
     return {
-      version: 1,
-      requestId: request.payload.requestId,
-      vaultId: params.vaultId,
-      vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
-      snapshot: persistedSnapshot.snapshot,
+      enrollmentResponse: {
+        version: 1,
+        requestId: request.payload.requestId,
+        vaultId: params.vaultId,
+        vaultTrustAnchor: unlockedVault.vaultTrustAnchor,
+        snapshot: persistedSnapshot.snapshot,
+      },
+      syncUpload,
     };
   }
 }

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createCoreTestPorts,
-  replaceVaultSnapshotAfterNextInitializedSave,
+  captureVaultSnapshotFromNextInitializedSave,
 } from "../../__tests__/fixtures/ports";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
@@ -30,8 +30,11 @@ import { LocalVaultAlreadyInitializedError } from "../../errors/vault-lifecycle.
 import { InvalidVaultLockDelayError } from "../../errors/vault-session.errors";
 import type { ClipboardClearTaskRepositoryPort } from "../../ports/clipboard/clipboard-clear-task-repository.port";
 import type { ClipboardPort } from "../../ports/clipboard/clipboard.port";
+import type { SyncUploadOutcome } from "../../ports/sync/sync-provider.port";
 import { ClipboardClearService } from "../../services/clipboard/clipboard-clear.service";
+import { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import { VaultLifecycleCleanupService } from "../../services/session/vault-lifecycle-cleanup.service";
+import { ChangeMasterPasswordUseCase } from "../vault-lifecycle/change-master-password";
 import { LockVaultUseCase } from "../vault-lifecycle/lock-vault";
 import { PerformDeviceEnrollmentUseCase } from "./perform-device-enrollment";
 
@@ -404,11 +407,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("uploads the signed enrollment even when local storage replaces it after save", async () => {
+  it("uploads the exact signed enrollment persisted by the local save", async () => {
     const ctx = createContext(true);
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextInitializedSave(
+    const getPersistedSnapshot = captureVaultSnapshotFromNextInitializedSave(
       ctx.ports,
-      ctx.response.snapshot,
     );
 
     await ctx.useCase.execute({
@@ -423,8 +425,6 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
-    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.response.snapshot);
   });
 
   it("uses retained target keys and removes pending state only after completion", async () => {
@@ -565,9 +565,18 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         target: ctx.values.syncTarget,
       },
     );
-    expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
-      ctx.values.encryptedDeviceSyncCredentialState,
-    );
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.pendingDeviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.pendingDeviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual({ currentCredentials: ctx.values.syncCredentials });
     expect(result).not.toHaveProperty("credentials");
     expect(result).not.toHaveProperty("syncConfig");
     expect(result.vault).not.toHaveProperty("syncTarget");
@@ -581,7 +590,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ...ctx.values.decryptedVault,
       syncTarget: ctx.values.syncTarget,
       syncRemovalPending: {
-        expectedRemoteSnapshotDescriptor: null,
+        expectedRemoteSnapshotIdentity: null,
         rollbackSnapshot,
       },
     });
@@ -673,8 +682,18 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
     expect(ctx.ports.saved.localVaultDescriptor).toBeUndefined();
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
-    ).toHaveBeenCalledWith(ctx.values.vaultId, ctx.values.vaultSnapshotDigest);
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vaultId: ctx.values.vaultId,
+        expectedDescriptor: expect.any(Object),
+        expectedDeviceAccessMaterial: expect.any(Object),
+        expectedDeviceAccessRecoveryBackup: expect.any(Object),
+        expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+        expectedCheckpoint: expect.any(Object),
+        expectedSyncCredentialState: null,
+      }),
+    );
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
     expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
       name: "lockVault",
@@ -698,7 +717,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         .saveUnlockedVaultSessionMaterial,
     ).mockRejectedValueOnce(activationError);
     vi.mocked(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).mockRejectedValueOnce(new Error("local cleanup failed"));
 
     await expect(
@@ -726,7 +745,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("preserves newer local state without reporting a rejected upload as complete", async () => {
     const ctx = createContext(true);
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
     const started = new Promise<void>((resolve) => {
       uploadStarted = resolve;
@@ -735,8 +754,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(
       async () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectUpload = reject;
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
           uploadStarted();
         }),
     );
@@ -761,7 +780,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       activeSession.unlockedVault,
       { [ctx.values.deviceId]: 3 },
     );
-    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
 
     await expect(execution).rejects.toBeInstanceOf(
       DeviceEnrollmentRollbackIncompleteError,
@@ -771,14 +793,14 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       sourceSnapshotVersionVector: { [ctx.values.deviceId]: 3 },
     });
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
   it("preserves advanced session keys when rejected-upload rollback cannot read material", async () => {
     const ctx = createContext(true);
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
     const started = new Promise<void>((resolve) => {
       uploadStarted = resolve;
@@ -787,8 +809,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(
       async () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectUpload = reject;
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
           uploadStarted();
         }),
     );
@@ -817,7 +839,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.unlockedVaultSessionMaterialRepository
         .getUnlockedVaultSessionMaterial,
     ).mockRejectedValueOnce(new Error("material read failed"));
-    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
 
     await expect(execution).rejects.toBeInstanceOf(
       DeviceEnrollmentRollbackIncompleteError,
@@ -837,7 +862,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("preserves shared keys owned by a replacement same-vault session", async () => {
     const ctx = createContext(true);
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
     const started = new Promise<void>((resolve) => {
       uploadStarted = resolve;
@@ -846,8 +871,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(
       async () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectUpload = reject;
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
           uploadStarted();
         }),
     );
@@ -879,7 +904,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       activeSession.unlockedVault,
       activeSession.sourceSnapshotVersionVector,
     );
-    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
 
     await expect(execution).rejects.toBeInstanceOf(
       DeviceEnrollmentRollbackIncompleteError,
@@ -901,7 +929,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("does not report rejected enrollment upload as complete after concurrent lock", async () => {
     const ctx = createContext(true);
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
     const started = new Promise<void>((resolve) => {
       uploadStarted = resolve;
@@ -910,8 +938,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(
       async () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectUpload = reject;
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
           uploadStarted();
         }),
     );
@@ -927,7 +955,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
     await started;
     await lockVault.execute();
-    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
 
     await expect(execution).rejects.toBeInstanceOf(
       DeviceEnrollmentRollbackIncompleteError,
@@ -935,14 +966,14 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
   it("does not remove a locally replaced enrollment snapshot", async () => {
     const ctx = createContext(true);
-    let rejectUpload: (error: Error) => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
     let uploadStarted: () => void = () => undefined;
     const started = new Promise<void>((resolve) => {
       uploadStarted = resolve;
@@ -951,8 +982,8 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(
       async () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectUpload = reject;
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
           uploadStarted();
         }),
     );
@@ -967,7 +998,10 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
     await started;
     ctx.ports.saved.vaultSnapshotDigest = "newer-local-snapshot-digest";
-    rejectUpload(new RemoteVaultSnapshotChangedError(ctx.values.vaultId));
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
 
     await expect(execution).rejects.toBeInstanceOf(
       DeviceEnrollmentRollbackIncompleteError,
@@ -978,15 +1012,142 @@ describe("PerformDeviceEnrollmentUseCase", () => {
     );
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).toHaveBeenCalledOnce();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
   });
 
-  it("returns recoverable local enrollment after an indeterminate upload failure", async () => {
+  it("preserves access records changed while a rejected enrollment upload is pending", async () => {
     const ctx = createContext(true);
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new Error("upload failed"),
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
+    let uploadStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      uploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
+          uploadStarted();
+        }),
+    );
+    const otherContextSession = new UnlockedVaultSessionService(
+      ctx.ports.unlockedVaultSessionMaterialRepository,
+      ctx.ports.encryptedUnlockedVaultSessionPayloadRepository,
+      ctx.ports.crypto,
+      ctx.ports.ids,
+      ctx.ports.clipboardOperations,
+    );
+    const changeMasterPassword = new ChangeMasterPasswordUseCase(
+      ctx.ports.crypto,
+      ctx.ports.vaultLocalRepository,
+      otherContextSession,
+      ctx.ports.ids,
+    );
+
+    const execution = ctx.useCase.execute({
+      enrollmentResponse: ctx.response,
+      masterPassword: ctx.values.masterPassword,
+      deviceName: "New laptop",
+      lockAfterMs: 60_000,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    await started;
+    await changeMasterPassword.execute({
+      vaultId: ctx.values.vaultId,
+      currentMasterPassword: ctx.values.masterPassword,
+      newMasterPassword: ctx.values.newMasterPassword,
+    });
+    const changedMaterial = ctx.ports.saved.deviceAccessMaterial;
+    const changedBackup = ctx.ports.saved.deviceAccessRecoveryBackup;
+    expect(changedMaterial?.revision).toBe(2);
+    expect(changedBackup?.revision).toBe(2);
+
+    resolveUpload({
+      status: "definitely_not_committed",
+      reason: "remote_snapshot_changed",
+    });
+
+    await expect(execution).rejects.toBeInstanceOf(
+      DeviceEnrollmentRollbackIncompleteError,
+    );
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.deviceAccessMaterial).toBe(changedMaterial);
+    expect(ctx.ports.saved.deviceAccessRecoveryBackup).toBe(changedBackup);
+    expect(ctx.ports.saved.vaultSnapshot).toBeDefined();
+    expect(ctx.ports.saved.localVaultTrustCheckpoint).toBeDefined();
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
+    ).toHaveBeenCalledOnce();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+  });
+
+  it("does not remove enrollment state after another reconciler replaces the staged upload intent", async () => {
+    const ctx = createContext(true);
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(async () => {
+      const snapshot = ctx.ports.saved.vaultSnapshot;
+      const snapshotDigest = ctx.ports.saved.vaultSnapshotDigest;
+      const checkpoint = ctx.ports.saved.localVaultTrustCheckpoint;
+      const stagedCredentialState = ctx.ports.saved.deviceSyncCredentialState;
+
+      if (
+        snapshot === undefined ||
+        snapshotDigest === undefined ||
+        checkpoint === undefined ||
+        stagedCredentialState === undefined
+      ) {
+        throw new Error("Expected a staged enrollment upload intent.");
+      }
+
+      await ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: snapshotDigest,
+        expectedCheckpoint: checkpoint,
+        expectedSyncCredentialState: stagedCredentialState,
+        snapshot,
+        checkpoint,
+        syncCredentialState: ctx.values.encryptedDeviceSyncCredentialState,
+      });
+
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        enrollmentResponse: ctx.response,
+        masterPassword: ctx.values.masterPassword,
+        deviceName: "New laptop",
+        lockAfterMs: 60_000,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).rejects.toBeInstanceOf(DeviceEnrollmentRollbackIncompleteError);
+
+    expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
+    expect(ctx.ports.saved.vaultSnapshot).toBeDefined();
+    expect(ctx.ports.saved.deviceSyncCredentialState).toEqual(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
+    ).toHaveBeenCalledOnce();
+    expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
+  });
+
+  it("returns recoverable local enrollment after an outcome-unknown upload", async () => {
+    const ctx = createContext(true);
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
     );
 
     const result = await ctx.useCase.execute({
@@ -1009,8 +1170,11 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("keeps local state when session invalidation fails after a rejected upload", async () => {
     const ctx = createContext(true);
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
     );
     vi.mocked(
       ctx.ports.unlockedVaultSessionMaterialRepository
@@ -1036,11 +1200,13 @@ describe("PerformDeviceEnrollmentUseCase", () => {
 
   it("reports incomplete rollback when rejected-upload local cleanup fails", async () => {
     const ctx = createContext(true);
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
     vi.mocked(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).mockRejectedValueOnce(new Error("local cleanup failed"));
 
     const execution = ctx.useCase.execute({
@@ -1065,13 +1231,16 @@ describe("PerformDeviceEnrollmentUseCase", () => {
   it("preserves the active session and local enrollment when rollback coordination is unavailable", async () => {
     const ctx = createContext(true);
     const coordinationError = new Error("clipboard coordination unavailable");
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValueOnce(
       new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
     );
     const runExclusive = ctx.clipboardOperations.runExclusive.bind(
       ctx.clipboardOperations,
     );
     vi.spyOn(ctx.clipboardOperations, "runExclusive")
+      .mockImplementationOnce(runExclusive)
       .mockImplementationOnce(runExclusive)
       .mockImplementationOnce(runExclusive)
       .mockRejectedValueOnce(coordinationError);
@@ -1106,7 +1275,7 @@ describe("PerformDeviceEnrollmentUseCase", () => {
         .removeEncryptedUnlockedVaultSessionPayload,
     ).not.toHaveBeenCalled();
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.saved.localVaultDescriptor).toBeDefined();
     expect(ctx.ports.saved.pendingDeviceEnrollment).toBeDefined();
@@ -1124,8 +1293,11 @@ describe("PerformDeviceEnrollmentUseCase", () => {
       copiedValueHash: `hash:${singlePasswordEntry.password}`,
       expiresAt: ctx.values.timestamp + 60_000,
     });
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
     );
 
     await expect(

--- a/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
+++ b/packages/core/src/use-cases/device-trust/perform-device-enrollment.ts
@@ -10,7 +10,11 @@ import { isValidLocalAccessGenerationId } from "../../domain/device-trust/device
 import type { RawMasterPassword } from "../../domain/master-password";
 import { assertNewMasterPasswordMeetsPolicy } from "../../domain/master-password/master-password.utils";
 import type { RecoveryKeyMnemonic } from "../../domain/recovery";
-import type { SyncAccess, SyncSetupInput } from "../../domain/sync";
+import type {
+  SyncAccess,
+  SyncSetupInput,
+  SyncUploadStatus,
+} from "../../domain/sync";
 import type {
   UnsignedVaultSnapshot,
   VaultSnapshot,
@@ -60,6 +64,8 @@ import type { ClipboardOperationCoordinatorPort } from "../../ports/clipboard/cl
 import { VaultSessionActivationService } from "../../services/session/vault-session-activation.service";
 import { bestEffortWipeArrayBuffers } from "../../lib/secure-wipe.utils";
 import { VaultTrustService } from "../../services/trust/vault-trust.service";
+import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
+import { VaultSyncGuardService } from "../../services/sync/vault-sync-guard.service";
 
 export type PerformDeviceEnrollmentCommandParams = {
   readonly enrollmentResponse: DeviceEnrollmentResponse;
@@ -75,7 +81,7 @@ export type PerformDeviceEnrollmentResult = {
   readonly recoveryMnemonicKey: RecoveryKeyMnemonic;
   readonly snapshotVersionVector: VersionVector;
   readonly revisionTimestamp: number;
-  readonly syncUpload: "complete" | "pending";
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class PerformDeviceEnrollmentUseCase {
@@ -90,6 +96,7 @@ export class PerformDeviceEnrollmentUseCase {
   private readonly vaultTrust: VaultTrustService;
   private readonly sessionActivation: VaultSessionActivationService;
   private readonly lifecycleCleanup: VaultLifecycleCleanupService;
+  private readonly vaultSyncGuard: VaultSyncGuardService;
 
   constructor(
     clock: ClockPort,
@@ -123,6 +130,13 @@ export class PerformDeviceEnrollmentUseCase {
       clipboardOperations,
     );
     this.lifecycleCleanup = lifecycleCleanup;
+    this.vaultSyncGuard = new VaultSyncGuardService(
+      syncProvider,
+      new VaultSnapshotService(crypto, clock, vaultLocalRepository),
+      unlockedVaultSession,
+      crypto,
+      vaultLocalRepository,
+    );
   }
 
   async execute(
@@ -308,6 +322,8 @@ export class PerformDeviceEnrollmentUseCase {
         params.syncConfig,
         authorizedSnapshot,
       );
+      const authorizedSnapshotDigest =
+        await this.crypto.digestVaultSnapshot(authorizedSnapshot);
       const unsignedSnapshot: UnsignedVaultSnapshot = {
         metadata: {
           ...authorizedSnapshot.metadata,
@@ -317,6 +333,17 @@ export class PerformDeviceEnrollmentUseCase {
             request.payload.deviceId,
           ),
           createdByDeviceId: request.payload.deviceId,
+          ...(syncAccess === undefined
+            ? {}
+            : {
+                uploadExpectedRemoteSnapshotIdentity: {
+                  descriptor: toVaultSnapshotDescriptor(
+                    response.vaultId,
+                    authorizedSnapshot,
+                  ),
+                  snapshotDigest: authorizedSnapshotDigest,
+                },
+              }),
         },
         trustChain: authorizedSnapshot.trustChain,
         keySlots: authorizedSnapshot.keySlots,
@@ -429,6 +456,8 @@ export class PerformDeviceEnrollmentUseCase {
                 target: syncAccess.target,
               },
             );
+      let expectedRollbackSyncCredentialState =
+        encryptedSyncCredentialState ?? null;
       const unlockedVault: UnlockedVault = {
         vaultId: response.vaultId,
         deviceId: request.payload.deviceId,
@@ -461,64 +490,93 @@ export class PerformDeviceEnrollmentUseCase {
               : { syncCredentialState: encryptedSyncCredentialState }),
           }),
         rollbackPreparedActivation: async () => {
-          await this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
-            response.vaultId,
-            snapshotDigest,
+          await this.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch(
+            {
+              vaultId: response.vaultId,
+              expectedDescriptor: descriptor,
+              expectedDeviceAccessMaterial: deviceAccessMaterial,
+              expectedDeviceAccessRecoveryBackup: deviceAccessRecoveryBackup,
+              expectedSnapshotDigest: snapshotDigest,
+              expectedCheckpoint: checkpoint,
+              expectedSyncCredentialState: expectedRollbackSyncCredentialState,
+            },
           );
         },
       });
       const { sessionId, generation: sessionGeneration } = activatedSession;
       sessionActivated = true;
 
-      let syncUpload: "complete" | "pending" = "complete";
+      let syncUpload: SyncUploadStatus = "complete";
 
       if (syncAccess !== undefined) {
         try {
-          await this.syncProvider.uploadVaultSnapshot(
+          syncUpload = await this.vaultSyncGuard.uploadTrackedSnapshot({
+            sessionId,
+            vaultId: response.vaultId,
+            unlockedVault,
             syncAccess,
             snapshot,
-            toVaultSnapshotDescriptor(response.vaultId, authorizedSnapshot),
-          );
-        } catch (error) {
-          if (!(error instanceof RemoteVaultSnapshotChangedError)) {
-            syncUpload = "pending";
-          } else {
-            const remoteSnapshotChanged =
-              new DeviceEnrollmentRemoteSnapshotChangedError(response.vaultId, {
-                cause: error,
-              });
-            const rollbackResult =
-              await this.lifecycleCleanup.discardIfSessionIsActive(
-                {
-                  sessionId,
-                  vaultId: response.vaultId,
-                  generation: sessionGeneration,
-                  sourceSnapshotVersionVector:
-                    snapshot.metadata.snapshotVersionVector,
-                },
-                async () =>
-                  this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
-                    response.vaultId,
-                    snapshotDigest,
-                  ),
-              );
-
-            if (
-              rollbackResult !== "session_advanced" &&
-              rollbackResult !== "session_replaced"
-            ) {
-              sessionActivated = false;
-            }
-
-            if (rollbackResult !== "discarded") {
-              throw new DeviceEnrollmentRollbackIncompleteError(
+            snapshotDigest,
+            checkpoint,
+            expectedRemoteSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
                 response.vaultId,
-                remoteSnapshotChanged,
-              );
-            }
+                authorizedSnapshot,
+              ),
+              snapshotDigest: authorizedSnapshotDigest,
+            },
+            onIntentStaged: ({ pending }) => {
+              expectedRollbackSyncCredentialState = pending;
+            },
+          });
+        } catch (error) {
+          const uploadError =
+            error instanceof RemoteVaultSnapshotChangedError
+              ? new DeviceEnrollmentRemoteSnapshotChangedError(
+                  response.vaultId,
+                  { cause: error },
+                )
+              : error;
+          const rollbackResult =
+            await this.lifecycleCleanup.discardIfSessionIsActive(
+              {
+                sessionId,
+                vaultId: response.vaultId,
+                generation: sessionGeneration,
+                sourceSnapshotVersionVector:
+                  snapshot.metadata.snapshotVersionVector,
+              },
+              async () =>
+                this.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch(
+                  {
+                    vaultId: response.vaultId,
+                    expectedDescriptor: descriptor,
+                    expectedDeviceAccessMaterial: deviceAccessMaterial,
+                    expectedDeviceAccessRecoveryBackup:
+                      deviceAccessRecoveryBackup,
+                    expectedSnapshotDigest: snapshotDigest,
+                    expectedCheckpoint: checkpoint,
+                    expectedSyncCredentialState:
+                      expectedRollbackSyncCredentialState,
+                  },
+                ),
+            );
 
-            throw remoteSnapshotChanged;
+          if (
+            rollbackResult !== "session_advanced" &&
+            rollbackResult !== "session_replaced"
+          ) {
+            sessionActivated = false;
           }
+
+          if (rollbackResult !== "discarded") {
+            throw new DeviceEnrollmentRollbackIncompleteError(
+              response.vaultId,
+              uploadError,
+            );
+          }
+
+          throw uploadError;
         }
       }
 

--- a/packages/core/src/use-cases/device-trust/prepare-device-enrollment-consumption.ts
+++ b/packages/core/src/use-cases/device-trust/prepare-device-enrollment-consumption.ts
@@ -6,9 +6,8 @@ import { findChangedEntries } from "../../domain/sync/entry-review.utils";
 import type { TagReviewItem } from "../../domain/sync/tag-review.type";
 import { findChangedTags } from "../../domain/sync/tag-review.utils";
 import {
-  cloneVaultSnapshotDescriptor,
-  toVaultSnapshotDescriptor,
-  type ReviewedVaultSnapshotDescriptors,
+  toVaultSnapshotIdentity,
+  type ReviewedVaultSnapshotIdentities,
 } from "../../domain/snapshot";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
@@ -22,7 +21,7 @@ export type PrepareDeviceEnrollmentConsumptionCommandParams = {
 };
 
 export type PrepareDeviceEnrollmentConsumptionResult = {
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly enrolledDeviceIds: readonly string[];
   readonly vaultKeyGeneration: number;
   readonly review: {
@@ -68,13 +67,16 @@ export class PrepareDeviceEnrollmentConsumptionUseCase {
     });
 
     return {
-      reviewedSnapshotDescriptors: {
-        local: toVaultSnapshotDescriptor(
+      reviewedSnapshotIdentities: {
+        local: toVaultSnapshotIdentity(
           params.vaultId,
           candidate.localSnapshot,
+          unlockedVault.trustedSnapshotContext.snapshotDigest,
         ),
-        remote: cloneVaultSnapshotDescriptor(
-          candidate.remoteSnapshotDescriptor,
+        remote: toVaultSnapshotIdentity(
+          params.vaultId,
+          candidate.remoteSnapshot,
+          candidate.remoteTrust.snapshotDigest,
         ),
       },
       enrolledDeviceIds: candidate.transitions.map(

--- a/packages/core/src/use-cases/device-trust/prepare-device-revocation-consumption.ts
+++ b/packages/core/src/use-cases/device-trust/prepare-device-revocation-consumption.ts
@@ -7,9 +7,8 @@ import type { SyncSetupInput } from "../../domain/sync";
 import type { TagReviewItem } from "../../domain/sync/tag-review.type";
 import { findChangedTags } from "../../domain/sync/tag-review.utils";
 import {
-  cloneVaultSnapshotDescriptor,
-  toVaultSnapshotDescriptor,
-  type ReviewedVaultSnapshotDescriptors,
+  toVaultSnapshotIdentity,
+  type ReviewedVaultSnapshotIdentities,
 } from "../../domain/snapshot";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
@@ -25,7 +24,7 @@ export type PrepareDeviceRevocationConsumptionCommandParams = {
 };
 
 export type PrepareDeviceRevocationConsumptionResult = {
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly revokedDeviceIds: readonly string[];
   readonly enrolledDeviceIds: readonly string[];
   readonly vaultKeyGeneration: number;
@@ -73,13 +72,16 @@ export class PrepareDeviceRevocationConsumptionUseCase {
 
     try {
       return {
-        reviewedSnapshotDescriptors: {
-          local: toVaultSnapshotDescriptor(
+        reviewedSnapshotIdentities: {
+          local: toVaultSnapshotIdentity(
             params.vaultId,
             candidate.localSnapshot,
+            unlockedVault.trustedSnapshotContext.snapshotDigest,
           ),
-          remote: cloneVaultSnapshotDescriptor(
-            candidate.remoteSnapshotDescriptor,
+          remote: toVaultSnapshotIdentity(
+            params.vaultId,
+            candidate.remoteSnapshot,
+            candidate.remoteTrust.snapshotDigest,
           ),
         },
         revokedDeviceIds: candidate.revocations.map(

--- a/packages/core/src/use-cases/device-trust/recover-device-access.ts
+++ b/packages/core/src/use-cases/device-trust/recover-device-access.ts
@@ -311,6 +311,7 @@ export class RecoverDeviceAccessUseCase {
         await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
           expectedSnapshotDigest:
             await this.crypto.digestVaultSnapshot(vaultSnapshot),
+          expectedCheckpoint: checkpoint,
           snapshot: vaultSnapshot,
           checkpoint: await this.vaultTrust.createCheckpoint(
             vaultSnapshot,

--- a/packages/core/src/use-cases/device-trust/revoke-device.test.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createCoreTestPorts,
-  replaceVaultSnapshotAfterNextSave,
+  captureVaultSnapshotFromNextSave,
 } from "../../__tests__/fixtures/ports";
 import { createCoreTestValues } from "../../__tests__/fixtures/values";
 import { singlePasswordEntry } from "../../__tests__/fixtures/vault-entries";
@@ -18,7 +18,9 @@ import {
   ProviderCredentialRevocationPendingError,
   ReplacementSyncCredentialsRequiredError,
   ReplacementSyncCredentialsUnchangedError,
+  SyncConflictDetectedError,
 } from "../../errors/sync.errors";
+import type { SyncUploadOutcome } from "../../ports/sync/sync-provider.port";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { RevokeDeviceUseCase } from "./revoke-device";
@@ -125,6 +127,15 @@ function createContext() {
   };
   ports.saved.vaultSnapshot = snapshot;
   ports.saved.vaultSnapshotDigest = values.vaultSnapshotDigest;
+  ports.saved.localVaultTrustCheckpoint = {
+    ...values.localVaultTrustCheckpoint,
+    payload: {
+      ...values.localVaultTrustCheckpoint.payload,
+      trustGeneration: trust.generation,
+      snapshotVersionVector: snapshot.metadata.snapshotVersionVector,
+      snapshotDigest: values.vaultSnapshotDigest,
+    },
+  };
   ports.saved.deviceSyncCredentialState =
     values.encryptedDeviceSyncCredentialState;
   ports.saved.unlockedVaultSession = {
@@ -157,7 +168,6 @@ function createContext() {
     ports.sessionServices.unlockedVaultSession,
     syncGuard,
     snapshotService,
-    ports.vaultLocalRepository,
   );
 
   return { values, ports, snapshot, useCase };
@@ -174,12 +184,9 @@ async function expectGeneratedVaultMasterKeyWiped(
 }
 
 describe("RevokeDeviceUseCase", () => {
-  it("uploads the signed revocation even when local storage replaces it after save", async () => {
+  it("uploads the exact signed revocation persisted by the local save", async () => {
     const ctx = createContext();
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      ctx.snapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
@@ -191,8 +198,6 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
-    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.snapshot);
   });
 
   it("rotates the vault key and creates envelopes only for survivors", async () => {
@@ -219,7 +224,10 @@ describe("RevokeDeviceUseCase", () => {
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.replacementSyncAccess,
       expect.anything(),
-      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.snapshot),
+      {
+        descriptor: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.snapshot),
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
     expect(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
@@ -232,6 +240,7 @@ describe("RevokeDeviceUseCase", () => {
     expect(result.providerCredentialRevocation).toBe(
       "pending_external_deletion",
     );
+    expect(result.syncUpload).toBe("complete");
     expect(result.vault.entries[0]).toEqual({
       id: singlePasswordEntry.id,
       login: singlePasswordEntry.login,
@@ -337,9 +346,9 @@ describe("RevokeDeviceUseCase", () => {
 
   it("restores the old snapshot and credentials when upload fails", async () => {
     const ctx = createContext();
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValue(
-      new Error("upload failed"),
-    );
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValue(new Error("upload failed"));
 
     await expect(
       ctx.useCase.execute({
@@ -359,6 +368,121 @@ describe("RevokeDeviceUseCase", () => {
     await expectGeneratedVaultMasterKeyWiped(ctx);
   });
 
+  it("keeps the rotated revocation and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      deviceId: ctx.values.pendingDeviceId,
+      replacementSyncConfig: ctx.values.replacementSyncConfigInput,
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(ctx.ports.saved.vaultSnapshot?.metadata.vaultKeyGeneration).toBe(2);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.replacementSyncCredentials,
+        previousCredentials: expect.any(Object),
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
+    expect(
+      ctx.ports.saved.unlockedVaultSession?.unlockedVault.vaultMasterKey,
+    ).toBe(ctx.values.rotatedVaultMasterKey);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the durable revocation but wipes its key when the session is removed after upload start", async () => {
+    const ctx = createContext();
+    let signalUploadStarted: () => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
+    const uploadStarted = new Promise<void>((resolve) => {
+      signalUploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
+          signalUploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      deviceId: ctx.values.pendingDeviceId,
+      replacementSyncConfig: ctx.values.replacementSyncConfigInput,
+    });
+    await uploadStarted;
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    resolveUpload({ status: "committed" });
+
+    await expect(execution).resolves.toMatchObject({ syncUpload: "pending" });
+    expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.ports.saved.vaultSnapshot?.metadata.vaultKeyGeneration).toBe(2);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.replacementSyncCredentials,
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
+    await expectGeneratedVaultMasterKeyWiped(ctx);
+  });
+
+  it("restores revocation state when upload is definitely not committed", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        deviceId: ctx.values.pendingDeviceId,
+        replacementSyncConfig: ctx.values.replacementSyncConfigInput,
+      }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(ctx.ports.saved.vaultSnapshot?.metadata.vaultKeyGeneration).toBe(1);
+    expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
+      ctx.values.encryptedDeviceSyncCredentialState,
+    );
+  });
+
   it("restores the old state when the session expires during upload", async () => {
     const ctx = createContext();
     vi.mocked(
@@ -373,7 +497,10 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(async () => {
       await ctx.ports.sessionServices.unlockedVaultSession.remove();
-      throw new Error("upload failed");
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
     });
 
     await expect(
@@ -382,7 +509,7 @@ describe("RevokeDeviceUseCase", () => {
         deviceId: ctx.values.pendingDeviceId,
         replacementSyncConfig: ctx.values.replacementSyncConfigInput,
       }),
-    ).rejects.toThrow("upload failed");
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
 
     expect(ctx.ports.saved.vaultSnapshot).toEqual(ctx.snapshot);
     expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
@@ -458,7 +585,10 @@ describe("RevokeDeviceUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mockImplementationOnce(async () => {
       ctx.ports.saved.vaultSnapshotDigest = "concurrent-snapshot-digest";
-      throw new Error("upload failed");
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
     });
 
     await expect(
@@ -489,9 +619,25 @@ describe("RevokeDeviceUseCase", () => {
     ).rejects.toThrow("session commit failed");
 
     expect(ctx.ports.saved.vaultSnapshot?.metadata.vaultKeyGeneration).toBe(2);
-    expect(ctx.ports.saved.deviceSyncCredentialState).toBe(
-      ctx.values.replacementEncryptedDeviceSyncCredentialState,
-    );
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.ports.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual({
+      currentCredentials: ctx.values.replacementSyncCredentials,
+      previousCredentials: {
+        credentials: ctx.values.syncCredentials,
+        revokedDeviceIds: [ctx.values.pendingDeviceId],
+        vaultKeyGeneration: 2,
+      },
+    });
     expect(ctx.ports.saved.unlockedVaultSession).toBeUndefined();
     await expectGeneratedVaultMasterKeyWiped(ctx);
   });

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -11,20 +11,17 @@ import { toVisibleVaultFields } from "../../domain/vault/visible-vault.mapper";
 import { revokeDeviceProfileFromVault } from "../../domain/vault/vault-device.mutations";
 import { markVaultProviderCredentialRevocationPending } from "../../domain/vault/vault-sync-config.mutations";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import {
   InvalidSyncConfigError,
   LocalSyncCredentialsMissingError,
-  RemoteVaultSnapshotChangedError,
   ReplacementSyncCredentialsRequiredError,
   ReplacementSyncCredentialsUnchangedError,
   ReplacementSyncTargetMismatchError,
-  SyncConflictDetectedError,
 } from "../../errors/sync.errors";
-import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { ClockPort } from "../../ports/system/clock.port";
-import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import type { VaultSyncGuardService } from "../../services/sync";
@@ -49,6 +46,7 @@ export type RevokeDeviceResult = {
   readonly providerCredentialRevocation:
     | "not_configured"
     | "pending_external_deletion";
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class RevokeDeviceUseCase {
@@ -58,7 +56,6 @@ export class RevokeDeviceUseCase {
   private readonly unlockedVaultSession: UnlockedVaultSessionService;
   private readonly vaultSyncGuard: VaultSyncGuardService;
   private readonly vaultSnapshot: VaultSnapshotService;
-  private readonly vaultLocalRepository: VaultLocalRepositoryPort;
   private readonly vaultTrust: VaultTrustService;
 
   constructor(
@@ -68,7 +65,6 @@ export class RevokeDeviceUseCase {
     unlockedVaultSession: UnlockedVaultSessionService,
     vaultSyncGuard: VaultSyncGuardService,
     vaultSnapshot: VaultSnapshotService,
-    vaultLocalRepository: VaultLocalRepositoryPort,
   ) {
     this.clock = clock;
     this.crypto = crypto;
@@ -76,7 +72,6 @@ export class RevokeDeviceUseCase {
     this.unlockedVaultSession = unlockedVaultSession;
     this.vaultSyncGuard = vaultSyncGuard;
     this.vaultSnapshot = vaultSnapshot;
-    this.vaultLocalRepository = vaultLocalRepository;
     this.vaultTrust = new VaultTrustService(crypto);
   }
 
@@ -158,14 +153,10 @@ export class RevokeDeviceUseCase {
         throw new ReplacementSyncCredentialsRequiredError(params.vaultId);
       }
 
-      previousEncryptedCredentials =
-        await this.vaultLocalRepository.getDeviceSyncCredentialState(
-          params.vaultId,
-        );
-
-      if (previousEncryptedCredentials === null) {
+      if (syncState.syncAccess === undefined) {
         throw new LocalSyncCredentialsMissingError(params.vaultId);
       }
+      previousEncryptedCredentials = syncState.syncCredentialState;
 
       const previousState = await this.crypto.decryptDeviceSyncCredentialState(
         previousEncryptedCredentials,
@@ -216,10 +207,10 @@ export class RevokeDeviceUseCase {
 
       if (
         replacementRemoteDescriptor === null ||
-        syncState.remoteSnapshotDescriptor === undefined ||
+        syncState.remoteSnapshotIdentity === undefined ||
         !areVaultSnapshotDescriptorsEqual(
           replacementRemoteDescriptor,
-          syncState.remoteSnapshotDescriptor,
+          syncState.remoteSnapshotIdentity.descriptor,
         )
       ) {
         throw new ReplacementSyncTargetMismatchError(params.vaultId);
@@ -318,75 +309,101 @@ export class RevokeDeviceUseCase {
                 unlockedVault,
                 previousEncryptedCredentials,
               );
+            const snapshotOptions =
+              encryptedCredentialState === undefined
+                ? {
+                    vaultKeyGeneration,
+                    keySlots: { deviceSlots },
+                    nextTrust: {
+                      chain: nextTrust.chain,
+                      state: nextTrust.trust,
+                    },
+                    ...(syncState.remoteSnapshotIdentity === undefined
+                      ? {}
+                      : {
+                          uploadExpectedRemoteSnapshotIdentity:
+                            syncState.remoteSnapshotIdentity,
+                        }),
+                  }
+                : {
+                    vaultKeyGeneration,
+                    keySlots: { deviceSlots },
+                    nextTrust: {
+                      chain: nextTrust.chain,
+                      state: nextTrust.trust,
+                    },
+                    ...(syncState.remoteSnapshotIdentity === undefined
+                      ? {}
+                      : {
+                          uploadExpectedRemoteSnapshotIdentity:
+                            syncState.remoteSnapshotIdentity,
+                        }),
+                    expectedSyncCredentialState:
+                      previousEncryptedCredentials ?? null,
+                    syncCredentialState: encryptedCredentialState,
+                  };
             const persistedSnapshot =
               await this.vaultSnapshot.persistUnlockedVault(
                 params.vaultId,
                 rotatedUnlockedVault,
                 sourceSnapshotVersionVector,
-                {
-                  vaultKeyGeneration,
-                  keySlots: { deviceSlots },
-                  nextTrust: {
-                    chain: nextTrust.chain,
-                    state: nextTrust.trust,
-                  },
-                  ...(encryptedCredentialState === undefined
-                    ? {}
-                    : { syncCredentialState: encryptedCredentialState }),
-                },
+                snapshotOptions,
               );
 
             return { persistedSnapshot, preparedRestore };
           },
         );
 
-      try {
-        if (
-          replacementAccess !== undefined &&
-          syncState.remoteSnapshotDescriptor !== undefined
-        ) {
-          await this.syncProvider.uploadVaultSnapshot(
-            replacementAccess,
-            persistedSnapshot.snapshot,
-            syncState.remoteSnapshotDescriptor,
+      let syncUpload: SyncUploadStatus = "complete";
+      let sessionCommitted: boolean;
+
+      if (
+        replacementAccess !== undefined &&
+        syncState.remoteSnapshotIdentity !== undefined
+      ) {
+        if (encryptedCredentialState === undefined) {
+          throw new InvalidDeviceRevocationTransitionError(
+            params.vaultId,
+            "replacement credential state was not prepared",
           );
         }
-      } catch (error) {
-        const rollbackResult =
-          await this.unlockedVaultSession.restorePersistedState(
+
+        syncUpload = await this.vaultSyncGuard.uploadPersistedSnapshot({
+          vaultId: params.vaultId,
+          syncAccess: replacementAccess,
+          persistedSnapshot: persistedSnapshot.snapshot,
+          expectedRemoteSnapshotIdentity: syncState.remoteSnapshotIdentity,
+          previousSnapshotVersionVector: sourceSnapshotVersionVector,
+          persistedSnapshotDigest:
+            persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+          checkpoint: persistedSnapshot.checkpoint,
+          persistedSyncCredentialState: encryptedCredentialState,
+          unlockedVault: rotatedUnlockedVault,
+          preparedRestore,
+          sessionId,
+        });
+
+        sessionCommitted =
+          await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
             sessionId,
-            params.vaultId,
-            sourceSnapshotVersionVector,
-            async () =>
-              this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-                preparedRestore,
-                persistedSnapshot.trustedSnapshotContext.snapshotDigest,
-              ),
+            {
+              ...rotatedUnlockedVault,
+              trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+            },
+            persistedSnapshot.snapshotVersionVector,
           );
-
-        if (rollbackResult === "rollback_failed") {
-          throw new PersistedVaultRollbackIncompleteError(
-            params.vaultId,
-            error,
-          );
-        }
-
-        if (error instanceof RemoteVaultSnapshotChangedError) {
-          throw new SyncConflictDetectedError(params.vaultId);
-        }
-
-        throw error;
+      } else {
+        await this.unlockedVaultSession.commitPersistedSnapshot(
+          sessionId,
+          {
+            ...rotatedUnlockedVault,
+            trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+          },
+          persistedSnapshot.snapshotVersionVector,
+        );
+        sessionCommitted = true;
       }
-
-      await this.unlockedVaultSession.commitPersistedSnapshot(
-        sessionId,
-        {
-          ...rotatedUnlockedVault,
-          trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-        },
-        persistedSnapshot.snapshotVersionVector,
-      );
-      vaultMasterKeyTransferred = true;
+      vaultMasterKeyTransferred = sessionCommitted;
 
       return {
         vault: toVisibleVaultFields(revokedVault),
@@ -398,6 +415,7 @@ export class RevokeDeviceUseCase {
           replacementAccess === undefined
             ? "not_configured"
             : "pending_external_deletion",
+        syncUpload,
       };
     } finally {
       if (!vaultMasterKeyTransferred) {

--- a/packages/core/src/use-cases/device-trust/revoke-device.ts
+++ b/packages/core/src/use-cases/device-trust/revoke-device.ts
@@ -309,35 +309,25 @@ export class RevokeDeviceUseCase {
                 unlockedVault,
                 previousEncryptedCredentials,
               );
+            const commonSnapshotOptions = {
+              vaultKeyGeneration,
+              keySlots: { deviceSlots },
+              nextTrust: {
+                chain: nextTrust.chain,
+                state: nextTrust.trust,
+              },
+              ...(syncState.remoteSnapshotIdentity === undefined
+                ? {}
+                : {
+                    uploadExpectedRemoteSnapshotIdentity:
+                      syncState.remoteSnapshotIdentity,
+                  }),
+            };
             const snapshotOptions =
               encryptedCredentialState === undefined
-                ? {
-                    vaultKeyGeneration,
-                    keySlots: { deviceSlots },
-                    nextTrust: {
-                      chain: nextTrust.chain,
-                      state: nextTrust.trust,
-                    },
-                    ...(syncState.remoteSnapshotIdentity === undefined
-                      ? {}
-                      : {
-                          uploadExpectedRemoteSnapshotIdentity:
-                            syncState.remoteSnapshotIdentity,
-                        }),
-                  }
+                ? commonSnapshotOptions
                 : {
-                    vaultKeyGeneration,
-                    keySlots: { deviceSlots },
-                    nextTrust: {
-                      chain: nextTrust.chain,
-                      state: nextTrust.trust,
-                    },
-                    ...(syncState.remoteSnapshotIdentity === undefined
-                      ? {}
-                      : {
-                          uploadExpectedRemoteSnapshotIdentity:
-                            syncState.remoteSnapshotIdentity,
-                        }),
+                    ...commonSnapshotOptions,
                     expectedSyncCredentialState:
                       previousEncryptedCredentials ?? null,
                     syncCredentialState: encryptedCredentialState,

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -16,6 +16,7 @@ import {
   InvalidVaultSyncReviewError,
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
+  SyncAlreadyResolvedError,
   SyncConflictDetectedError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
@@ -356,8 +357,9 @@ describe("ApplySyncResolutionUseCase", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("authenticates an equal-descriptor remote before reporting it resolved", async () => {
+  it("rejects equal descriptors with different snapshot digests", async () => {
     const ctx = createContext();
+    const remoteSnapshotDigest = "equal-descriptor-remote-snapshot-digest";
     const equalDescriptorSnapshot = {
       ...ctx.remoteSnapshot,
       metadata: {
@@ -377,7 +379,7 @@ describe("ApplySyncResolutionUseCase", () => {
       .mockResolvedValue({
         chain: ctx.values.vaultTrustChain,
         state: ctx.values.verifiedVaultTrustState,
-        snapshotDigest: "substituted-equal-remote-digest",
+        snapshotDigest: remoteSnapshotDigest,
       });
 
     try {
@@ -388,7 +390,7 @@ describe("ApplySyncResolutionUseCase", () => {
             local: ctx.localIdentity,
             remote: {
               descriptor: ctx.localDescriptor,
-              snapshotDigest: ctx.values.vaultSnapshotDigest,
+              snapshotDigest: remoteSnapshotDigest,
             },
           },
           resolution: {
@@ -397,10 +399,51 @@ describe("ApplySyncResolutionUseCase", () => {
             deviceProfileResolutions: [],
           },
         }),
-      ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
     } finally {
       verification.mockRestore();
     }
+
+    expect(ctx.ports.syncProvider.downloadVaultSnapshot).toHaveBeenCalledOnce();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("reports fully equal snapshot identities as already resolved", async () => {
+    const ctx = createContext();
+    const equalDescriptorSnapshot = {
+      ...ctx.remoteSnapshot,
+      metadata: {
+        ...ctx.remoteSnapshot.metadata,
+        revisionTimestamp: ctx.localDescriptor.revisionTimestamp,
+        snapshotVersionVector: ctx.localDescriptor.snapshotVersionVector,
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(ctx.localDescriptor);
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      equalDescriptorSnapshot,
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: {
+            descriptor: ctx.localDescriptor,
+            snapshotDigest: ctx.values.vaultSnapshotDigest,
+          },
+        },
+        resolution: {
+          entryResolutions: [],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncAlreadyResolvedError);
 
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).toHaveBeenCalledOnce();
     expect(

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
-import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
+import { captureVaultSnapshotFromNextSave } from "../../__tests__/fixtures/ports";
 import {
   createUnlockedVaultWithEntries,
   singlePasswordEntry,
 } from "../../__tests__/fixtures/vault-entries";
 import {
-  cloneVaultSnapshotDescriptor,
+  cloneVaultSnapshotIdentity,
   toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot";
 import type { EntryReviewResolution } from "../../domain/sync/entry-resolution.type";
 import {
+  InvalidSyncResolutionError,
   InvalidVaultSyncReviewError,
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
+  SyncConflictDetectedError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
@@ -55,6 +58,16 @@ function createContext() {
     ctx.values.vaultId,
     ctx.vaultSnapshot,
   );
+  const localIdentity = toVaultSnapshotIdentity(
+    ctx.values.vaultId,
+    ctx.vaultSnapshot,
+    ctx.values.vaultSnapshotDigest,
+  );
+  const remoteIdentity = toVaultSnapshotIdentity(
+    ctx.values.vaultId,
+    remoteSnapshot,
+    ctx.values.vaultSnapshotDigest,
+  );
   vi.mocked(
     ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
   ).mockResolvedValue(remoteDescriptor);
@@ -89,25 +102,24 @@ function createContext() {
   return {
     ...ctx,
     localDescriptor,
+    localIdentity,
     remoteSnapshot,
     remoteDescriptor,
+    remoteIdentity,
     useCase,
   };
 }
 
 describe("ApplySyncResolutionUseCase", () => {
-  it("uploads the signed resolution even when local storage replaces it after save", async () => {
+  it("uploads the exact signed resolution persisted by the local save", async () => {
     const ctx = createContext();
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      ctx.vaultSnapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
-      reviewedSnapshotDescriptors: {
-        local: ctx.localDescriptor,
-        remote: ctx.remoteDescriptor,
+      reviewedSnapshotIdentities: {
+        local: ctx.localIdentity,
+        remote: ctx.remoteIdentity,
       },
       resolution: {
         entryResolutions: [
@@ -122,8 +134,6 @@ describe("ApplySyncResolutionUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.ports.saved.vaultSnapshot);
-    expect(ctx.ports.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
   });
 
   it("applies ordinary content resolution with local credentials", async () => {
@@ -131,9 +141,9 @@ describe("ApplySyncResolutionUseCase", () => {
 
     const result = await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
-      reviewedSnapshotDescriptors: {
-        local: ctx.localDescriptor,
-        remote: ctx.remoteDescriptor,
+      reviewedSnapshotIdentities: {
+        local: ctx.localIdentity,
+        remote: ctx.remoteIdentity,
       },
       resolution: {
         entryResolutions: [
@@ -165,8 +175,12 @@ describe("ApplySyncResolutionUseCase", () => {
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       uploadedSnapshot,
-      ctx.remoteDescriptor,
+      {
+        descriptor: ctx.remoteDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
+    expect(result.syncUpload).toBe("complete");
     const expectedSnapshotVersionVector = {
       ...result.snapshotVersionVector,
     };
@@ -204,9 +218,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -232,8 +246,7 @@ describe("ApplySyncResolutionUseCase", () => {
               vaultId: ctx.values.vaultId,
               generation: 1,
               vaultKeyGeneration: 1,
-              previousCertificateDigest:
-                ctx.values.vaultTrustCertificateDigest,
+              previousCertificateDigest: ctx.values.vaultTrustCertificateDigest,
               authorizedByDeviceId: ctx.values.deviceId,
               trustedDevices: [
                 ...ctx.values.verifiedVaultTrustState.trustedDevices,
@@ -263,9 +276,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -292,9 +305,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -307,6 +320,127 @@ describe("ApplySyncResolutionUseCase", () => {
     ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
   });
 
+  it("rejects same-descriptor remote bytes that differ from the reviewed identity", async () => {
+    const ctx = createContext();
+    const verification = vi
+      .spyOn(VaultSnapshotService.prototype, "verifyCandidateSnapshotTrust")
+      .mockResolvedValue({
+        chain: ctx.values.vaultTrustChain,
+        state: ctx.values.verifiedVaultTrustState,
+        snapshotDigest: "substituted-remote-snapshot-digest",
+      });
+
+    try {
+      await expect(
+        ctx.useCase.execute({
+          vaultId: ctx.values.vaultId,
+          reviewedSnapshotIdentities: {
+            local: ctx.localIdentity,
+            remote: ctx.remoteIdentity,
+          },
+          resolution: {
+            entryResolutions: [
+              { entryId: singlePasswordEntry.id, action: "use_remote" },
+            ],
+            tagResolutions: [],
+            deviceProfileResolutions: [],
+          },
+        }),
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    } finally {
+      verification.mockRestore();
+    }
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("authenticates an equal-descriptor remote before reporting it resolved", async () => {
+    const ctx = createContext();
+    const equalDescriptorSnapshot = {
+      ...ctx.remoteSnapshot,
+      metadata: {
+        ...ctx.remoteSnapshot.metadata,
+        revisionTimestamp: ctx.localDescriptor.revisionTimestamp,
+        snapshotVersionVector: ctx.localDescriptor.snapshotVersionVector,
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(ctx.localDescriptor);
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      equalDescriptorSnapshot,
+    );
+    const verification = vi
+      .spyOn(VaultSnapshotService.prototype, "verifyCandidateSnapshotTrust")
+      .mockResolvedValue({
+        chain: ctx.values.vaultTrustChain,
+        state: ctx.values.verifiedVaultTrustState,
+        snapshotDigest: "substituted-equal-remote-digest",
+      });
+
+    try {
+      await expect(
+        ctx.useCase.execute({
+          vaultId: ctx.values.vaultId,
+          reviewedSnapshotIdentities: {
+            local: ctx.localIdentity,
+            remote: {
+              descriptor: ctx.localDescriptor,
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+          },
+          resolution: {
+            entryResolutions: [],
+            tagResolutions: [],
+            deviceProfileResolutions: [],
+          },
+        }),
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotChangedError);
+    } finally {
+      verification.mockRestore();
+    }
+
+    expect(ctx.ports.syncProvider.downloadVaultSnapshot).toHaveBeenCalledOnce();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a reviewed descriptor from another vault before provider access", async () => {
+    const ctx = createContext();
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: {
+            ...ctx.remoteIdentity,
+            descriptor: {
+              ...ctx.remoteIdentity.descriptor,
+              vaultId: "other-vault-id",
+            },
+          },
+        },
+        resolution: {
+          entryResolutions: [
+            { entryId: singlePasswordEntry.id, action: "use_remote" },
+          ],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      }),
+    ).rejects.toBeInstanceOf(InvalidSyncResolutionError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
   it("captures reviewed inputs before asynchronous work", async () => {
     const ctx = createContext();
     const entryResolution: EntryReviewResolution = {
@@ -315,9 +449,9 @@ describe("ApplySyncResolutionUseCase", () => {
     };
     const command = {
       vaultId: ctx.values.vaultId,
-      reviewedSnapshotDescriptors: {
-        local: cloneVaultSnapshotDescriptor(ctx.localDescriptor),
-        remote: cloneVaultSnapshotDescriptor(ctx.remoteDescriptor),
+      reviewedSnapshotIdentities: {
+        local: cloneVaultSnapshotIdentity(ctx.localIdentity),
+        remote: cloneVaultSnapshotIdentity(ctx.remoteIdentity),
       },
       resolution: {
         entryResolutions: [entryResolution],
@@ -328,10 +462,10 @@ describe("ApplySyncResolutionUseCase", () => {
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockImplementationOnce(async () => {
-      command.reviewedSnapshotDescriptors.local.snapshotVersionVector[
+      command.reviewedSnapshotIdentities.local.descriptor.snapshotVersionVector[
         ctx.values.deviceId
       ] = 99;
-      command.reviewedSnapshotDescriptors.remote.snapshotVersionVector[
+      command.reviewedSnapshotIdentities.remote.descriptor.snapshotVersionVector[
         ctx.values.deviceId
       ] = 99;
       command.resolution.entryResolutions[0] = {
@@ -372,9 +506,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -397,12 +531,16 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
+        reviewedSnapshotIdentities: {
           local: {
-            ...ctx.localDescriptor,
-            revisionTimestamp: ctx.localDescriptor.revisionTimestamp - 1,
+            ...ctx.localIdentity,
+            descriptor: {
+              ...ctx.localIdentity.descriptor,
+              revisionTimestamp:
+                ctx.localIdentity.descriptor.revisionTimestamp - 1,
+            },
           },
-          remote: ctx.remoteDescriptor,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -443,9 +581,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -491,9 +629,9 @@ describe("ApplySyncResolutionUseCase", () => {
 
     const result = await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
-      reviewedSnapshotDescriptors: {
-        local: ctx.localDescriptor,
-        remote: ctx.remoteDescriptor,
+      reviewedSnapshotIdentities: {
+        local: ctx.localIdentity,
+        remote: ctx.remoteIdentity,
       },
       resolution: {
         entryResolutions: [],
@@ -508,6 +646,7 @@ describe("ApplySyncResolutionUseCase", () => {
     ).toBeUndefined();
     expect(ctx.ports.saved.vaultSnapshot).toEqual(ctx.remoteSnapshot);
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(result.syncUpload).toBe("complete");
     const expectedSnapshotVersionVector = {
       ...result.snapshotVersionVector,
     };
@@ -544,9 +683,9 @@ describe("ApplySyncResolutionUseCase", () => {
 
     await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
-      reviewedSnapshotDescriptors: {
-        local: ctx.localDescriptor,
-        remote: ctx.remoteDescriptor,
+      reviewedSnapshotIdentities: {
+        local: ctx.localIdentity,
+        remote: ctx.remoteIdentity,
       },
       resolution: {
         entryResolutions: [
@@ -570,7 +709,10 @@ describe("ApplySyncResolutionUseCase", () => {
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       expect.anything(),
-      ctx.remoteDescriptor,
+      {
+        descriptor: ctx.remoteDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
   });
 
@@ -599,9 +741,9 @@ describe("ApplySyncResolutionUseCase", () => {
     await expect(
       ctx.useCase.execute({
         vaultId: ctx.values.vaultId,
-        reviewedSnapshotDescriptors: {
-          local: ctx.localDescriptor,
-          remote: ctx.remoteDescriptor,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
         },
         resolution: {
           entryResolutions: [
@@ -617,5 +759,74 @@ describe("ApplySyncResolutionUseCase", () => {
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     ).not.toHaveBeenCalled();
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps the resolved snapshot and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      reviewedSnapshotIdentities: {
+        local: ctx.localIdentity,
+        remote: ctx.remoteIdentity,
+      },
+      resolution: {
+        entryResolutions: [
+          { entryId: singlePasswordEntry.id, action: "use_remote" },
+        ],
+        tagResolutions: [],
+        deviceProfileResolutions: [],
+      },
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(ctx.ports.saved.vaultSnapshot).not.toBe(ctx.vaultSnapshot);
+    expect(
+      ctx.ports.saved.unlockedVaultSession?.unlockedVault.vault.entries,
+    ).toContainEqual({
+      ...singlePasswordEntry,
+      versionVector: { [ctx.values.deviceId]: 2 },
+    });
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("restores the reviewed local snapshot when upload is definitely not committed", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        reviewedSnapshotIdentities: {
+          local: ctx.localIdentity,
+          remote: ctx.remoteIdentity,
+        },
+        resolution: {
+          entryResolutions: [
+            { entryId: singlePasswordEntry.id, action: "use_remote" },
+          ],
+          tagResolutions: [],
+          deviceProfileResolutions: [],
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(ctx.ports.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -1,4 +1,4 @@
-import type { ReviewedVaultSnapshotDescriptors } from "../../domain/snapshot";
+import type { ReviewedVaultSnapshotIdentities } from "../../domain/snapshot";
 import { areJsonEqual } from "../../domain/common";
 import {
   findChangedDeviceProfiles,
@@ -13,14 +13,17 @@ import {
 } from "../../domain/sync/sync-resolution.utils";
 import { findChangedTags } from "../../domain/sync/tag-review.utils";
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
-  cloneReviewedVaultSnapshotDescriptors,
+  cloneReviewedVaultSnapshotIdentities,
   cloneVaultSnapshotDescriptor,
   compareVaultSnapshotDescriptors,
-  toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 import { mergeVersionVectors } from "../../domain/versioning/version-vector.utils";
+import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { Vault } from "../../domain/vault";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import { clearVaultProviderCredentialRevocationPending } from "../../domain/vault/vault-sync-config.mutations";
 import {
   InvalidSyncResolutionError,
@@ -29,16 +32,12 @@ import {
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
   SyncAlreadyResolvedError,
-  SyncConflictDetectedError,
   SyncNotConfiguredError,
   SyncRemovalPendingError,
   SyncResolutionIncompleteError,
   SyncTrustChangeRequiresDeviceTrustFlowError,
 } from "../../errors/sync.errors";
-import {
-  LocalVaultSnapshotChangedError,
-  PersistedVaultRollbackIncompleteError,
-} from "../../errors/vault-snapshot.errors";
+import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { UnlockedVaultSessionService } from "../../services/session/unlocked-vault-session.service";
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
@@ -53,8 +52,14 @@ export type {
 
 export type ApplySyncResolutionCommandParams = {
   readonly vaultId: string;
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly resolution: VaultSyncResolution;
+};
+
+export type ApplySyncResolutionResult = {
+  readonly snapshotVersionVector: VersionVector;
+  readonly revisionTimestamp: number;
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class ApplySyncResolutionUseCase {
@@ -75,9 +80,13 @@ export class ApplySyncResolutionUseCase {
     this.vaultSyncGuard = vaultSyncGuard;
   }
 
-  async execute(params: ApplySyncResolutionCommandParams) {
-    const { local: localSnapshotDescriptor, remote: remoteSnapshotDescriptor } =
-      cloneReviewedVaultSnapshotDescriptors(params.reviewedSnapshotDescriptors);
+  async execute(
+    params: ApplySyncResolutionCommandParams,
+  ): Promise<ApplySyncResolutionResult> {
+    const { local: localSnapshotIdentity, remote: remoteSnapshotIdentity } =
+      cloneReviewedVaultSnapshotIdentities(params.reviewedSnapshotIdentities);
+    const localSnapshotDescriptor = localSnapshotIdentity.descriptor;
+    const remoteSnapshotDescriptor = remoteSnapshotIdentity.descriptor;
     const resolution = cloneVaultSyncResolution(params.resolution);
     const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
@@ -112,15 +121,18 @@ export class ApplySyncResolutionUseCase {
         unlockedVault,
         sourceSnapshotVersionVector,
       );
-    const currentLocalSnapshotDescriptor = toVaultSnapshotDescriptor(
+    const currentLocalSnapshotIdentity = toVaultSnapshotIdentity(
       params.vaultId,
       localSnapshot,
+      unlockedVault.trustedSnapshotContext.snapshotDigest,
     );
+    const currentLocalSnapshotDescriptor =
+      currentLocalSnapshotIdentity.descriptor;
 
     if (
-      !areVaultSnapshotDescriptorsEqual(
-        currentLocalSnapshotDescriptor,
-        localSnapshotDescriptor,
+      !areVaultSnapshotIdentitiesEqual(
+        currentLocalSnapshotIdentity,
+        localSnapshotIdentity,
       )
     ) {
       throw new LocalVaultSnapshotChangedError(params.vaultId);
@@ -156,10 +168,6 @@ export class ApplySyncResolutionUseCase {
 
     if (relation === "local_ahead") {
       throw new LocalVaultSnapshotAheadError(params.vaultId);
-    }
-
-    if (relation === "equal") {
-      throw new SyncAlreadyResolvedError(params.vaultId);
     }
 
     const remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
@@ -229,12 +237,29 @@ export class ApplySyncResolutionUseCase {
     }
 
     if (
-      !areVaultSnapshotDescriptorsEqual(
-        toVaultSnapshotDescriptor(params.vaultId, remoteSnapshot),
-        remoteSnapshotDescriptor,
+      !areVaultSnapshotIdentitiesEqual(
+        toVaultSnapshotIdentity(
+          params.vaultId,
+          remoteSnapshot,
+          remoteTrust.snapshotDigest,
+        ),
+        remoteSnapshotIdentity,
       )
     ) {
       throw new RemoteVaultSnapshotChangedError(params.vaultId);
+    }
+
+    if (relation === "equal") {
+      if (
+        !areVaultSnapshotIdentitiesEqual(
+          currentLocalSnapshotIdentity,
+          remoteSnapshotIdentity,
+        )
+      ) {
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+      }
+
+      throw new SyncAlreadyResolvedError(params.vaultId);
     }
 
     const trustedDeviceIds = new Set(
@@ -295,13 +320,26 @@ export class ApplySyncResolutionUseCase {
         await this.unlockedVaultSession.persistForActiveSession(
           sessionId,
           params.vaultId,
-          async () =>
-            this.vaultSnapshot.persistVerifiedRemoteSnapshot(
+          async () => {
+            const syncCredentialStateTransition =
+              await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
+                params.vaultId,
+                unlockedVault,
+                { allowPendingSnapshotUpload: true },
+              );
+
+            return this.vaultSnapshot.persistVerifiedRemoteSnapshot(
               params.vaultId,
               remoteSnapshot,
               remoteTrust.state,
               unlockedVault,
-            ),
+              {
+                expectedSyncCredentialState:
+                  syncCredentialStateTransition.expectedState,
+                syncCredentialState: syncCredentialStateTransition.nextState,
+              },
+            );
+          },
         );
 
       await this.unlockedVaultSession.commitPersistedSnapshot(
@@ -319,6 +357,7 @@ export class ApplySyncResolutionUseCase {
           ...persistedSnapshot.snapshotVersionVector,
         },
         revisionTimestamp: persistedSnapshot.revisionTimestamp,
+        syncUpload: "complete",
       };
     }
 
@@ -355,7 +394,7 @@ export class ApplySyncResolutionUseCase {
       ...unlockedVault,
       vault: resolvedVault,
     };
-    const { persistedSnapshot, preparedRestore } =
+    const { persistedSnapshot, preparedRestore, persistedSyncCredentialState } =
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
         params.vaultId,
@@ -364,6 +403,12 @@ export class ApplySyncResolutionUseCase {
             await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
               localSnapshot,
               unlockedVault,
+            );
+          const syncCredentialStateTransition =
+            await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
+              params.vaultId,
+              unlockedVault,
+              { allowPendingSnapshotUpload: true },
             );
           const persistedSnapshot =
             await this.vaultSnapshot.persistUnlockedVault(
@@ -375,45 +420,38 @@ export class ApplySyncResolutionUseCase {
                   localSnapshot.metadata.snapshotVersionVector,
                   remoteSnapshotDescriptor.snapshotVersionVector,
                 ),
+                uploadExpectedRemoteSnapshotIdentity: remoteSnapshotIdentity,
+                expectedSyncCredentialState:
+                  syncCredentialStateTransition.expectedState,
+                syncCredentialState: syncCredentialStateTransition.nextState,
               },
             );
 
-          return { persistedSnapshot, preparedRestore };
+          return {
+            persistedSnapshot,
+            preparedRestore,
+            persistedSyncCredentialState:
+              syncCredentialStateTransition.nextState,
+          };
         },
       );
 
-    try {
-      await this.syncProvider.uploadVaultSnapshot(
-        syncAccess,
-        persistedSnapshot.snapshot,
-        cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
-      );
-    } catch (error) {
-      const rollbackResult =
-        await this.unlockedVaultSession.restorePersistedState(
-          sessionId,
-          params.vaultId,
-          sourceSnapshotVersionVector,
-          async () => {
-            await this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-              preparedRestore,
-              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
-            );
-          },
-        );
+    const syncUpload = await this.vaultSyncGuard.uploadPersistedSnapshot({
+      vaultId: params.vaultId,
+      syncAccess,
+      persistedSnapshot: persistedSnapshot.snapshot,
+      expectedRemoteSnapshotIdentity: remoteSnapshotIdentity,
+      previousSnapshotVersionVector: sourceSnapshotVersionVector,
+      persistedSnapshotDigest:
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      checkpoint: persistedSnapshot.checkpoint,
+      persistedSyncCredentialState,
+      unlockedVault: updatedUnlockedVault,
+      preparedRestore,
+      sessionId,
+    });
 
-      if (rollbackResult === "rollback_failed") {
-        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
-      }
-
-      if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(params.vaultId);
-      }
-
-      throw error;
-    }
-
-    await this.unlockedVaultSession.commitPersistedSnapshot(
+    await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
       sessionId,
       {
         ...updatedUnlockedVault,
@@ -427,6 +465,7 @@ export class ApplySyncResolutionUseCase {
         ...persistedSnapshot.snapshotVersionVector,
       },
       revisionTimestamp: persistedSnapshot.revisionTimestamp,
+      syncUpload,
     };
   }
 }

--- a/packages/core/src/use-cases/sync/apply-sync-resolution.ts
+++ b/packages/core/src/use-cases/sync/apply-sync-resolution.ts
@@ -325,7 +325,7 @@ export class ApplySyncResolutionUseCase {
               await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
                 params.vaultId,
                 unlockedVault,
-                { allowPendingSnapshotUpload: true },
+                { discardPendingSnapshotUpload: true },
               );
 
             return this.vaultSnapshot.persistVerifiedRemoteSnapshot(
@@ -408,7 +408,7 @@ export class ApplySyncResolutionUseCase {
             await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
               params.vaultId,
               unlockedVault,
-              { allowPendingSnapshotUpload: true },
+              { discardPendingSnapshotUpload: true },
             );
           const persistedSnapshot =
             await this.vaultSnapshot.persistUnlockedVault(

--- a/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
+++ b/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
@@ -319,30 +319,64 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
   it("restores the old encrypted credential when intent staging fails after completion persistence", async () => {
     const ctx = createContext();
     const stagingError = new Error("completion intent staging failed");
+    const encrypt = vi.mocked(
+      ctx.ports.crypto.encryptDeviceSyncCredentialState,
+    );
     const decrypt = vi.mocked(
       ctx.ports.crypto.decryptDeviceSyncCredentialState,
     );
+    const encryptImplementation = encrypt.getMockImplementation();
     const decryptImplementation = decrypt.getMockImplementation();
 
-    if (decryptImplementation === undefined) {
-      throw new Error("Expected credential decryption fixture implementation.");
+    if (
+      encryptImplementation === undefined ||
+      decryptImplementation === undefined
+    ) {
+      throw new Error("Expected credential codec fixture implementations.");
     }
 
-    let decryptCalls = 0;
-    decrypt.mockImplementation(async (...args) => {
-      decryptCalls += 1;
+    let completedCredentialState:
+      | typeof ctx.values.encryptedDeviceSyncCredentialState
+      | undefined;
+    encrypt.mockImplementation(async (...args) => {
+      const encryptedState = await encryptImplementation(...args);
+      const [state] = args;
 
-      if (decryptCalls === 3) {
+      if (
+        state.previousCredentials === undefined &&
+        state.pendingSnapshotUpload === undefined
+      ) {
+        completedCredentialState = encryptedState;
+      }
+
+      return encryptedState;
+    });
+    decrypt.mockImplementation(async (...args) => {
+      const state = await decryptImplementation(...args);
+
+      if (
+        completedCredentialState !== undefined &&
+        args[0] === completedCredentialState &&
+        ctx.saved.deviceSyncCredentialState === completedCredentialState
+      ) {
         throw stagingError;
       }
 
-      return decryptImplementation(...args);
+      return state;
     });
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).rejects.toBe(stagingError);
 
+    expect(completedCredentialState).toBeDefined();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        syncCredentialState: completedCredentialState,
+      }),
+    );
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
     expect(ctx.saved.deviceSyncCredentialState).toBe(
       ctx.values.replacementEncryptedDeviceSyncCredentialState,

--- a/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
+++ b/packages/core/src/use-cases/sync/complete-provider-credential-revocation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
-import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
+import { captureVaultSnapshotFromNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import { InvalidDeviceRevocationTransitionError } from "../../errors/device-revocation.errors";
@@ -8,6 +8,7 @@ import {
   InvalidSyncProviderOutcomeError,
   PreviousSyncCredentialStillActiveError,
   RemoteVaultSnapshotChangedError,
+  SyncConflictDetectedError,
 } from "../../errors/sync.errors";
 import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
@@ -96,18 +97,9 @@ function createContext() {
 }
 
 describe("CompleteProviderCredentialRevocationUseCase", () => {
-  it("uploads the signed completion even when local storage replaces it after save", async () => {
+  it("uploads the exact signed completion persisted by the local save", async () => {
     const ctx = createContext();
-    const replacedSnapshot = ctx.saved.vaultSnapshot;
-
-    if (replacedSnapshot === undefined) {
-      throw new Error("Expected an existing local snapshot.");
-    }
-
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      replacedSnapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
     await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
@@ -115,8 +107,6 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
-    expect(ctx.saved.vaultSnapshot).toBe(replacedSnapshot);
   });
 
   it("removes previous credentials only after provider authentication rejects them", async () => {
@@ -124,7 +114,10 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
-    ).resolves.toEqual({ providerCredentialRevocation: "complete" });
+    ).resolves.toEqual({
+      providerCredentialRevocation: "complete",
+      syncUpload: "complete",
+    });
 
     expect(ctx.ports.syncProvider.checkVaultAccess).toHaveBeenCalledWith(
       {
@@ -133,7 +126,7 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
       },
       ctx.values.vaultId,
     );
-    expect(ctx.saved.deviceSyncCredentialState).toBe(
+    expect(ctx.saved.deviceSyncCredentialState).toEqual(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
     expect(
@@ -233,7 +226,10 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
-    ).resolves.toEqual({ providerCredentialRevocation: "complete" });
+    ).resolves.toEqual({
+      providerCredentialRevocation: "complete",
+      syncUpload: "complete",
+    });
 
     expect(ctx.ports.syncProvider.checkVaultAccess).not.toHaveBeenCalled();
   });
@@ -247,6 +243,7 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).resolves.toEqual({
       providerCredentialRevocation: "pending_external_deletion",
+      syncUpload: "complete",
     });
 
     expect(ctx.ports.syncProvider.checkVaultAccess).not.toHaveBeenCalled();
@@ -270,11 +267,23 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).resolves.toEqual({
       providerCredentialRevocation: "pending_external_deletion",
+      syncUpload: "complete",
     });
 
-    expect(ctx.saved.deviceSyncCredentialState).toBe(
-      ctx.values.encryptedDeviceSyncCredentialState,
-    );
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual({
+      currentCredentials: ctx.values.replacementSyncCredentials,
+    });
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault
         .providerCredentialRevocationPending,
@@ -287,9 +296,9 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
 
   it("restores the marker and old credential when completion upload fails", async () => {
     const ctx = createContext();
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValue(
-      new Error("upload failed"),
-    );
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValue(new Error("upload failed"));
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
@@ -305,6 +314,110 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
       revokedDeviceIds: [ctx.values.pendingDeviceId],
       vaultKeyGeneration: 2,
     });
+  });
+
+  it("restores the old encrypted credential when intent staging fails after completion persistence", async () => {
+    const ctx = createContext();
+    const stagingError = new Error("completion intent staging failed");
+    const decrypt = vi.mocked(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState,
+    );
+    const decryptImplementation = decrypt.getMockImplementation();
+
+    if (decryptImplementation === undefined) {
+      throw new Error("Expected credential decryption fixture implementation.");
+    }
+
+    let decryptCalls = 0;
+    decrypt.mockImplementation(async (...args) => {
+      decryptCalls += 1;
+
+      if (decryptCalls === 3) {
+        throw stagingError;
+      }
+
+      return decryptImplementation(...args);
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(stagingError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.replacementEncryptedDeviceSyncCredentialState,
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault
+        .providerCredentialRevocationPending,
+    ).toEqual({
+      revokedDeviceIds: [ctx.values.pendingDeviceId],
+      vaultKeyGeneration: 2,
+    });
+    expect(ctx.saved.unlockedVaultSession).toBeDefined();
+  });
+
+  it("keeps credential completion and reports pending when upload outcome is unknown", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+
+    expect(result).toEqual({
+      providerCredentialRevocation: "complete",
+      syncUpload: "pending",
+    });
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.replacementSyncCredentials,
+        pendingSnapshotUpload: expect.any(Object),
+      }),
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault
+        .providerCredentialRevocationPending,
+    ).toBeUndefined();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("restores credential completion when upload is definitely not committed", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+    expect(ctx.saved.deviceSyncCredentialState).toBe(
+      ctx.values.replacementEncryptedDeviceSyncCredentialState,
+    );
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault
+        .providerCredentialRevocationPending,
+    ).toBeDefined();
   });
 
   it("retains the old credential when the remote vault has advanced", async () => {
@@ -375,6 +488,91 @@ describe("CompleteProviderCredentialRevocationUseCase", () => {
 
     expect(ctx.saved.deviceSyncCredentialState).toBe(
       ctx.values.replacementEncryptedDeviceSyncCredentialState,
+    );
+  });
+
+  it("does not erase a concurrently staged upload intent during provider verification", async () => {
+    const ctx = createContext();
+    let installedPendingState:
+      | typeof ctx.values.encryptedDeviceSyncCredentialState
+      | undefined;
+
+    vi.mocked(ctx.ports.syncProvider.checkVaultAccess).mockImplementationOnce(
+      async () => {
+        const snapshot = ctx.saved.vaultSnapshot;
+        const checkpoint = ctx.saved.localVaultTrustCheckpoint;
+
+        if (snapshot === undefined || checkpoint === undefined) {
+          throw new Error("Expected persisted snapshot security state.");
+        }
+
+        installedPendingState =
+          await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+            {
+              currentCredentials: ctx.values.replacementSyncCredentials,
+              previousCredentials: {
+                credentials: ctx.values.syncCredentials,
+                revokedDeviceIds: [ctx.values.pendingDeviceId],
+                vaultKeyGeneration: 2,
+              },
+              pendingSnapshotUpload: {
+                candidateSnapshotIdentity: {
+                  descriptor: toVaultSnapshotDescriptor(
+                    ctx.values.vaultId,
+                    snapshot,
+                  ),
+                  snapshotDigest: ctx.values.vaultSnapshotDigest,
+                },
+                expectedRemoteSnapshotIdentity: {
+                  descriptor: toVaultSnapshotDescriptor(
+                    ctx.values.vaultId,
+                    snapshot,
+                  ),
+                  snapshotDigest: ctx.values.vaultSnapshotDigest,
+                },
+              },
+            },
+            ctx.values.deviceLocalProtectionKey,
+            {
+              vaultId: ctx.values.vaultId,
+              deviceId: ctx.values.deviceId,
+              provider: ctx.values.syncTarget.provider,
+              target: ctx.values.syncTarget,
+            },
+          );
+        await ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+          expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+          expectedCheckpoint: checkpoint,
+          expectedSyncCredentialState:
+            ctx.values.replacementEncryptedDeviceSyncCredentialState,
+          snapshot,
+          checkpoint,
+          syncCredentialState: installedPendingState,
+        });
+
+        return "authentication_rejected";
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotChangedError);
+
+    expect(installedPendingState).toBeDefined();
+    expect(ctx.saved.deviceSyncCredentialState).toBe(installedPendingState);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ pendingSnapshotUpload: expect.any(Object) }),
     );
   });
 });

--- a/packages/core/src/use-cases/sync/complete-provider-credential-revocation.ts
+++ b/packages/core/src/use-cases/sync/complete-provider-credential-revocation.ts
@@ -8,13 +8,11 @@ import {
   LocalSyncCredentialsMissingError,
   PreviousSyncCredentialStillActiveError,
   RemoteVaultSnapshotChangedError,
+  RemoteVaultSnapshotIntegrityError,
   RemoteVaultSnapshotNotFoundError,
-  SyncConflictDetectedError,
   SyncNotConfiguredError,
 } from "../../errors/sync.errors";
 import { InvalidDeviceRevocationTransitionError } from "../../errors/device-revocation.errors";
-import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
-import { LocalVaultTrustCheckpointNotFoundError } from "../../errors/vault-trust.errors";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import type { VaultLocalRepositoryPort } from "../../ports/vault/vault-local-repository.port";
@@ -22,6 +20,7 @@ import type { UnlockedVaultSessionService } from "../../services/session/unlocke
 import type { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import type { VaultSyncGuardService } from "../../services/sync";
 import { requireSyncProviderAccessOutcome } from "../../services/sync/sync-provider-outcome.policy";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type CompleteProviderCredentialRevocationCommandParams = {
   readonly vaultId: string;
@@ -57,6 +56,7 @@ export class CompleteProviderCredentialRevocationUseCase {
     readonly providerCredentialRevocation:
       | "complete"
       | "pending_external_deletion";
+    readonly syncUpload: SyncUploadStatus;
   }> {
     const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
@@ -93,6 +93,13 @@ export class CompleteProviderCredentialRevocationUseCase {
       context,
     );
 
+    if (state.pendingSnapshotUpload !== undefined) {
+      await this.vaultSyncGuard.requireSnapshotUploadReconciled(
+        params.vaultId,
+        unlockedVault,
+      );
+    }
+
     const sharedPending =
       unlockedVault.vault.providerCredentialRevocationPending;
 
@@ -102,6 +109,7 @@ export class CompleteProviderCredentialRevocationUseCase {
           sharedPending === undefined
             ? "complete"
             : "pending_external_deletion",
+        syncUpload: "complete",
       };
     }
 
@@ -148,13 +156,11 @@ export class CompleteProviderCredentialRevocationUseCase {
 
     if (!sharedMarkerMatches) {
       const checkpoint =
-        await this.vaultLocalRepository.getLocalVaultTrustCheckpoint(
+        await this.vaultSnapshot.requireCurrentCheckpointForUnlockedVault(
           params.vaultId,
+          snapshot,
+          unlockedVault,
         );
-
-      if (checkpoint === null) {
-        throw new LocalVaultTrustCheckpointNotFoundError(params.vaultId);
-      }
 
       await this.unlockedVaultSession.persistForActiveSession(
         sessionId,
@@ -163,6 +169,8 @@ export class CompleteProviderCredentialRevocationUseCase {
           this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
             expectedSnapshotDigest:
               unlockedVault.trustedSnapshotContext.snapshotDigest,
+            expectedCheckpoint: checkpoint,
+            expectedSyncCredentialState: encryptedState,
             snapshot,
             checkpoint,
             syncCredentialState: completedState,
@@ -174,6 +182,7 @@ export class CompleteProviderCredentialRevocationUseCase {
           sharedPending === undefined
             ? "complete"
             : "pending_external_deletion",
+        syncUpload: "complete",
       };
     }
 
@@ -200,6 +209,24 @@ export class CompleteProviderCredentialRevocationUseCase {
       throw new RemoteVaultSnapshotChangedError(params.vaultId);
     }
 
+    const remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+      currentSyncAccess,
+      remoteSnapshotDescriptor,
+    );
+    const remoteSnapshotDigest =
+      await this.crypto.digestVaultSnapshot(remoteSnapshot);
+
+    if (
+      remoteSnapshotDigest !==
+      unlockedVault.trustedSnapshotContext.snapshotDigest
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: remoteSnapshotDescriptor,
+      snapshotDigest: remoteSnapshotDigest,
+    };
+
     const completedUnlockedVault = {
       ...unlockedVault,
       vault: clearVaultProviderCredentialRevocationPending(unlockedVault.vault),
@@ -220,44 +247,34 @@ export class CompleteProviderCredentialRevocationUseCase {
               params.vaultId,
               completedUnlockedVault,
               sourceSnapshotVersionVector,
-              { syncCredentialState: completedState },
+              {
+                uploadExpectedRemoteSnapshotIdentity:
+                  expectedRemoteSnapshotIdentity,
+                expectedSyncCredentialState: encryptedState,
+                syncCredentialState: completedState,
+              },
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
-    try {
-      await this.syncProvider.uploadVaultSnapshot(
-        currentSyncAccess,
-        persistedSnapshot.snapshot,
-        remoteSnapshotDescriptor,
-      );
-    } catch (error) {
-      const rollbackResult =
-        await this.unlockedVaultSession.restorePersistedState(
-          sessionId,
-          params.vaultId,
-          sourceSnapshotVersionVector,
-          async () =>
-            this.vaultSnapshot.restorePreparedLocalVaultSnapshot(
-              preparedRestore,
-              persistedSnapshot.trustedSnapshotContext.snapshotDigest,
-            ),
-        );
+    const syncUpload = await this.vaultSyncGuard.uploadPersistedSnapshot({
+      vaultId: params.vaultId,
+      syncAccess: currentSyncAccess,
+      persistedSnapshot: persistedSnapshot.snapshot,
+      expectedRemoteSnapshotIdentity,
+      previousSnapshotVersionVector: sourceSnapshotVersionVector,
+      persistedSnapshotDigest:
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+      checkpoint: persistedSnapshot.checkpoint,
+      persistedSyncCredentialState: completedState,
+      unlockedVault: completedUnlockedVault,
+      preparedRestore,
+      sessionId,
+    });
 
-      if (rollbackResult === "rollback_failed") {
-        throw new PersistedVaultRollbackIncompleteError(params.vaultId, error);
-      }
-
-      if (error instanceof RemoteVaultSnapshotChangedError) {
-        throw new SyncConflictDetectedError(params.vaultId);
-      }
-
-      throw error;
-    }
-
-    await this.unlockedVaultSession.commitPersistedSnapshot(
+    await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
       sessionId,
       {
         ...completedUnlockedVault,
@@ -266,6 +283,6 @@ export class CompleteProviderCredentialRevocationUseCase {
       persistedSnapshot.snapshotVersionVector,
     );
 
-    return { providerCredentialRevocation: "complete" };
+    return { providerCredentialRevocation: "complete", syncUpload };
   }
 }

--- a/packages/core/src/use-cases/sync/disable-sync.test.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.test.ts
@@ -7,11 +7,13 @@ import type {
 } from "../../domain/device-trust";
 import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import {
+  LocalVaultSnapshotAheadError,
   ProviderCredentialRevocationPendingError,
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotAheadError,
   RemoteVaultSnapshotIntegrityError,
 } from "../../errors/sync.errors";
+import { LocalVaultSnapshotChangedError } from "../../errors/vault-snapshot.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
 import { DisableSyncUseCase } from "./disable-sync";
@@ -135,19 +137,60 @@ function configureMultiDeviceSync(ctx: ReturnType<typeof createContext>): void {
 }
 
 describe("DisableSyncUseCase", () => {
+  it("blocks fresh sync removal while a snapshot upload is pending reconciliation", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.deviceSyncCredentialState =
+      await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+        {
+          ...ctx.values.deviceSyncCredentialState,
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                ctx.vaultSnapshot,
+              ),
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+            expectedRemoteSnapshotIdentity: null,
+          },
+        },
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+    expect(ctx.saved.unlockedVaultSession).toBe(session);
+  });
+
   it("removes remote state, local target, and local credentials", async () => {
     const ctx = createContext();
-    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
-      ctx.values.vaultId,
-      ctx.vaultSnapshot,
-    );
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+      ),
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
 
     await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
     expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       ctx.values.vaultId,
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
     );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
@@ -213,10 +256,13 @@ describe("DisableSyncUseCase", () => {
   it("retains pending removal when a remote failure has an unknown outcome", async () => {
     const ctx = createContext();
     const removalError = new Error("remove failed");
-    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
-      ctx.values.vaultId,
-      ctx.vaultSnapshot,
-    );
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+      ),
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
     vi.mocked(
       ctx.ports.syncProvider.removeVaultSnapshots,
     ).mockRejectedValueOnce(removalError);
@@ -228,7 +274,7 @@ describe("DisableSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
     ).toEqual({
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
       rollbackSnapshot: ctx.vaultSnapshot,
     });
     expect(ctx.saved.deviceSyncCredentialState).toBe(
@@ -251,10 +297,13 @@ describe("DisableSyncUseCase", () => {
   it("retains pending removal when exact snapshot restoration fails", async () => {
     const ctx = createContext();
     const restorationError = new Error("snapshot restoration failed");
-    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
-      ctx.values.vaultId,
-      ctx.vaultSnapshot,
-    );
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+      ),
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
     const saveSnapshot = vi.mocked(
       ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
     );
@@ -283,7 +332,7 @@ describe("DisableSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
     ).toEqual({
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
       rollbackSnapshot: ctx.vaultSnapshot,
     });
     expect(ctx.saved.deviceSyncCredentialState).toBe(
@@ -291,28 +340,52 @@ describe("DisableSyncUseCase", () => {
     );
   });
 
-  it("conditions removal on remote state remaining absent after preflight", async () => {
+  it("requires upload reconciliation before a fresh removal when remote state is absent", async () => {
     const ctx = createContext();
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockResolvedValue(null);
 
-    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
 
-    expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
-      ctx.values.syncAccess,
-      ctx.values.vaultId,
-      null,
-    );
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("requires upload reconciliation before a fresh removal when local state is ahead", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue({
+      ...toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+      snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+      revisionTimestamp: ctx.values.timestamp - 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
   });
 
   it("retains the pending transition when final local persistence fails", async () => {
     const ctx = createContext();
     const finalPersistError = new Error("final persistence failed");
-    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
-      ctx.values.vaultId,
-      ctx.vaultSnapshot,
-    );
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+      ),
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
     vi.mocked(ctx.ports.crypto.encryptVaultSnapshotContent)
       .mockResolvedValueOnce(ctx.values.encryptedVault)
       .mockRejectedValueOnce(finalPersistError);
@@ -324,7 +397,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       ctx.values.vaultId,
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
     );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
@@ -332,7 +405,7 @@ describe("DisableSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncRemovalPending,
     ).toEqual({
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
       rollbackSnapshot: ctx.vaultSnapshot,
     });
     expect(ctx.saved.deviceSyncCredentialState).toBe(
@@ -369,6 +442,43 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
   });
 
+  it("does not erase replayed old-credential evidence after validating a clean record", async () => {
+    const ctx = createContext();
+    const cleanCredentialState = ctx.saved.deviceSyncCredentialState!;
+    const replayedCredentialState =
+      await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+        {
+          currentCredentials: ctx.values.replacementSyncCredentials,
+          previousCredentials: {
+            credentials: ctx.values.syncCredentials,
+            revokedDeviceIds: [ctx.values.pendingDeviceId],
+            vaultKeyGeneration: 1,
+          },
+        },
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      );
+    vi.mocked(
+      ctx.ports.vaultLocalRepository.getDeviceSyncCredentialState,
+    ).mockImplementationOnce(async () => {
+      ctx.saved.deviceSyncCredentialState = replayedCredentialState;
+      return cleanCredentialState;
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotChangedError);
+
+    expect(ctx.saved.deviceSyncCredentialState).toBe(replayedCredentialState);
+    expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+  });
+
   it("rejects remote state that is ahead of the local snapshot", async () => {
     const ctx = createContext();
     vi.mocked(
@@ -401,13 +511,53 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
   });
 
-  it("resumes remote cleanup without repeating the preflight", async () => {
+  it("rejects same-descriptor remote bytes before staging removal", async () => {
+    const ctx = createContext();
+    const verification = vi
+      .spyOn(VaultSnapshotService.prototype, "verifyCandidateSnapshotTrust")
+      .mockResolvedValue({
+        chain: ctx.values.vaultTrustChain,
+        state: ctx.values.verifiedVaultTrustState,
+        snapshotDigest: "substituted-remote-snapshot-digest",
+      });
+
+    try {
+      await expect(
+        ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+    } finally {
+      verification.mockRestore();
+    }
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("rejects a local-ahead descriptor from another vault before removal", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue({
+      vaultId: "other-vault-id",
+      snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+      revisionTimestamp: ctx.values.timestamp - 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("rejects a persisted descriptor from another vault before resumed removal", async () => {
     const ctx = createContext();
     const session = ctx.saved.unlockedVaultSession;
-    const expectedRemoteSnapshotDescriptor = toVaultSnapshotDescriptor(
-      ctx.values.vaultId,
-      ctx.vaultSnapshot,
-    );
 
     if (session === undefined) {
       throw new Error("Expected an unlocked test session.");
@@ -420,7 +570,102 @@ describe("DisableSyncUseCase", () => {
         vault: {
           ...session.unlockedVault.vault,
           syncRemovalPending: {
-            expectedRemoteSnapshotDescriptor,
+            expectedRemoteSnapshotIdentity: {
+              descriptor: {
+                vaultId: "other-vault-id",
+                snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+                revisionTimestamp: ctx.values.timestamp - 1,
+              },
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+            rollbackSnapshot: ctx.vaultSnapshot,
+          },
+        },
+      },
+    };
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    ).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("does not start remote removal after the session is removed during provider preparation", async () => {
+    const ctx = createContext();
+    let signalPreparationStarted: () => void = () => undefined;
+    let resumePreparation: () => void = () => undefined;
+    const preparationStarted = new Promise<void>((resolve) => {
+      signalPreparationStarted = resolve;
+    });
+    const preparationCanContinue = new Promise<void>((resolve) => {
+      resumePreparation = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotRemoval,
+    ).mockImplementationOnce(
+      async (syncAccess, vaultId, expectedRemoteSnapshotIdentity) => {
+        signalPreparationStarted();
+        await preparationCanContinue;
+        return {
+          status: "ready",
+          start: () => ({
+            outcome: ctx.ports.syncProvider.removeVaultSnapshots(
+              syncAccess,
+              vaultId,
+              expectedRemoteSnapshotIdentity,
+            ),
+          }),
+        };
+      },
+    );
+
+    const execution = ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    const rejectedExecution = expect(execution).rejects.toThrow();
+    await preparationStarted;
+
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    resumePreparation();
+    await rejectedExecution;
+
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.ports.syncProvider.removeVaultSnapshots).not.toHaveBeenCalled();
+    expect(
+      vi
+        .mocked(ctx.ports.crypto.encryptVaultSnapshotContent)
+        .mock.calls.some(([vault]) => vault.syncRemovalPending !== undefined),
+    ).toBe(true);
+  });
+
+  it("resumes remote cleanup without repeating the preflight", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession;
+    const expectedRemoteSnapshotIdentity = {
+      descriptor: toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.vaultSnapshot,
+      ),
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
+
+    if (session === undefined) {
+      throw new Error("Expected an unlocked test session.");
+    }
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncRemovalPending: {
+            expectedRemoteSnapshotIdentity,
             rollbackSnapshot: ctx.vaultSnapshot,
           },
         },
@@ -435,7 +680,7 @@ describe("DisableSyncUseCase", () => {
     expect(ctx.ports.syncProvider.removeVaultSnapshots).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       ctx.values.vaultId,
-      expectedRemoteSnapshotDescriptor,
+      expectedRemoteSnapshotIdentity,
     );
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -74,7 +74,7 @@ export class DisableSyncUseCase {
         params.vaultId,
         unlockedVault,
         {
-          allowPendingSnapshotUpload: false,
+          discardPendingSnapshotUpload: false,
           requireProviderCredentialRevocationCompleteFor: "disable sync",
         },
       );

--- a/packages/core/src/use-cases/sync/disable-sync.ts
+++ b/packages/core/src/use-cases/sync/disable-sync.ts
@@ -5,6 +5,7 @@ import {
   areVaultSnapshotDescriptorsEqual,
   compareVaultSnapshotDescriptors,
   toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 import {
   clearVaultSyncRemovalPending,
@@ -13,6 +14,7 @@ import {
 } from "../../domain/vault/vault-sync-config.mutations";
 import { removeOtherDeviceProfilesFromVault } from "../../domain/vault/vault-device.mutations";
 import {
+  LocalVaultSnapshotAheadError,
   RemoteVaultSnapshotAheadError,
   RemoteVaultSnapshotChangedError,
   RemoteVaultSnapshotIntegrityError,
@@ -67,15 +69,16 @@ export class DisableSyncUseCase {
       throw new SyncNotConfiguredError(params.vaultId, "disable sync");
     }
 
-    await this.vaultSyncGuard.requireProviderCredentialRevocationComplete(
-      params.vaultId,
-      unlockedVault,
-      "disable sync",
-    );
-    const syncAccess = await this.vaultSyncGuard.requireSyncAccess(
-      params.vaultId,
-      unlockedVault,
-    );
+    const syncCredentialStateTransition =
+      await this.vaultSyncGuard.prepareSyncCredentialStateWithoutPending(
+        params.vaultId,
+        unlockedVault,
+        {
+          allowPendingSnapshotUpload: false,
+          requireProviderCredentialRevocationCompleteFor: "disable sync",
+        },
+      );
+    const { syncAccess } = syncCredentialStateTransition;
     let currentUnlockedVault = unlockedVault;
     let currentSnapshotVersionVector = sourceSnapshotVersionVector;
     let currentSnapshot =
@@ -85,48 +88,122 @@ export class DisableSyncUseCase {
         currentSnapshotVersionVector,
       );
 
-    let expectedRemoteSnapshotDescriptor =
-      currentUnlockedVault.vault.syncRemovalPending
-        ?.expectedRemoteSnapshotDescriptor;
+    const syncRemovalPending = currentUnlockedVault.vault.syncRemovalPending;
+    let expectedRemoteSnapshotIdentity =
+      syncRemovalPending?.expectedRemoteSnapshotIdentity;
 
-    if (expectedRemoteSnapshotDescriptor === undefined) {
-      expectedRemoteSnapshotDescriptor =
+    if (expectedRemoteSnapshotIdentity === undefined) {
+      const remoteSnapshotDescriptor =
         await this.syncProvider.getLatestVaultSnapshotDescriptor(
           syncAccess,
           params.vaultId,
         );
 
-      if (expectedRemoteSnapshotDescriptor !== null) {
+      if (remoteSnapshotDescriptor === null) {
+        expectedRemoteSnapshotIdentity = null;
+      } else {
         const localSnapshotDescriptor = toVaultSnapshotDescriptor(
           params.vaultId,
           currentSnapshot,
         );
         const relation = compareVaultSnapshotDescriptors(
           localSnapshotDescriptor,
-          expectedRemoteSnapshotDescriptor,
+          remoteSnapshotDescriptor,
         );
 
         if (relation === "remote_ahead") {
           throw new RemoteVaultSnapshotAheadError(params.vaultId);
         }
 
+        if (relation === "local_ahead") {
+          throw new LocalVaultSnapshotAheadError(params.vaultId);
+        }
+
         if (
           relation === "broken" ||
-          (relation === "equal" &&
-            !areVaultSnapshotDescriptorsEqual(
-              expectedRemoteSnapshotDescriptor,
-              localSnapshotDescriptor,
-            ))
+          !areVaultSnapshotDescriptorsEqual(
+            remoteSnapshotDescriptor,
+            localSnapshotDescriptor,
+          )
         ) {
           throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
         }
+
+        const remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+          syncAccess,
+          remoteSnapshotDescriptor,
+        );
+        const remoteTrust =
+          await this.vaultSnapshot.verifyCandidateSnapshotTrust(
+            params.vaultId,
+            remoteSnapshot,
+            currentUnlockedVault,
+          );
+
+        if (
+          remoteTrust.snapshotDigest !==
+          currentUnlockedVault.trustedSnapshotContext.snapshotDigest
+        ) {
+          throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+        }
+
+        expectedRemoteSnapshotIdentity = toVaultSnapshotIdentity(
+          params.vaultId,
+          remoteSnapshot,
+          remoteTrust.snapshotDigest,
+        );
+
+        if (
+          !areVaultSnapshotDescriptorsEqual(
+            expectedRemoteSnapshotIdentity.descriptor,
+            remoteSnapshotDescriptor,
+          )
+        ) {
+          throw new RemoteVaultSnapshotChangedError(params.vaultId);
+        }
+      }
+    }
+
+    if (expectedRemoteSnapshotIdentity === null) {
+      if (syncRemovalPending === undefined) {
+        throw new LocalVaultSnapshotAheadError(params.vaultId);
+      }
+    } else {
+      const localSnapshotDescriptor = toVaultSnapshotDescriptor(
+        params.vaultId,
+        currentSnapshot,
+      );
+      const relation = compareVaultSnapshotDescriptors(
+        localSnapshotDescriptor,
+        expectedRemoteSnapshotIdentity.descriptor,
+      );
+
+      if (relation === "remote_ahead") {
+        throw new RemoteVaultSnapshotAheadError(params.vaultId);
       }
 
+      if (relation === "local_ahead" && syncRemovalPending === undefined) {
+        throw new LocalVaultSnapshotAheadError(params.vaultId);
+      }
+
+      if (
+        relation === "broken" ||
+        (relation === "equal" &&
+          !areVaultSnapshotDescriptorsEqual(
+            expectedRemoteSnapshotIdentity.descriptor,
+            localSnapshotDescriptor,
+          ))
+      ) {
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+      }
+    }
+
+    if (syncRemovalPending === undefined) {
       const pendingUnlockedVault = {
         ...unlockedVault,
         vault: markVaultSyncRemovalPending(
           unlockedVault.vault,
-          expectedRemoteSnapshotDescriptor,
+          expectedRemoteSnapshotIdentity,
           currentSnapshot,
         ),
       };
@@ -139,6 +216,12 @@ export class DisableSyncUseCase {
               params.vaultId,
               pendingUnlockedVault,
               sourceSnapshotVersionVector,
+              {
+                expectedSyncCredentialState:
+                  syncCredentialStateTransition.expectedState,
+                syncCredentialState:
+                  syncCredentialStateTransition.expectedState,
+              },
             ),
         );
 
@@ -157,11 +240,12 @@ export class DisableSyncUseCase {
     }
 
     try {
-      await this.syncProvider.removeVaultSnapshots(
+      await this.vaultSyncGuard.removeTrackedRemoteSnapshot({
+        sessionId,
+        vaultId: params.vaultId,
         syncAccess,
-        params.vaultId,
-        expectedRemoteSnapshotDescriptor,
-      );
+        expectedRemoteSnapshotIdentity,
+      });
     } catch (error) {
       if (!(error instanceof RemoteVaultSnapshotChangedError)) {
         throw error;
@@ -294,6 +378,8 @@ export class DisableSyncUseCase {
                   chain: nextTrust.chain,
                   state: nextTrust.trust,
                 },
+                expectedSyncCredentialState:
+                  syncCredentialStateTransition.expectedState,
                 syncCredentialState: null,
               },
             ),

--- a/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import { singlePasswordEntry } from "../../__tests__/fixtures/vault-entries";
-import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
+import {
+  toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
+} from "../../domain/snapshot";
 import { VaultTrustStateInvalidError } from "../../errors/vault-trust.errors";
 import {
   InvalidVaultSyncReviewError,
@@ -144,8 +147,12 @@ describe("PrepareSyncReviewUseCase", () => {
     });
 
     expect(result).toMatchObject({
-      reviewedSnapshotDescriptors: {
-        local: toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+      reviewedSnapshotIdentities: {
+        local: toVaultSnapshotIdentity(
+          ctx.values.vaultId,
+          ctx.vaultSnapshot,
+          ctx.values.vaultSnapshotDigest,
+        ),
       },
       relation: "remote_ahead",
       review: {
@@ -160,7 +167,7 @@ describe("PrepareSyncReviewUseCase", () => {
       },
     });
 
-    result.reviewedSnapshotDescriptors.local.snapshotVersionVector[
+    result.reviewedSnapshotIdentities.local.descriptor.snapshotVersionVector[
       ctx.values.deviceId
     ] = 99;
 
@@ -192,7 +199,7 @@ describe("PrepareSyncReviewUseCase", () => {
     downloadDescriptor.snapshotVersionVector[ctx.values.deviceId] = 98;
 
     expect(
-      result.reviewedSnapshotDescriptors.remote.snapshotVersionVector,
+      result.reviewedSnapshotIdentities.remote.descriptor.snapshotVersionVector,
     ).toEqual({ [ctx.values.deviceId]: 2 });
   });
 
@@ -278,17 +285,37 @@ describe("PrepareSyncReviewUseCase", () => {
     expect(ctx.ports.crypto.decryptVaultSnapshotContent).not.toHaveBeenCalled();
   });
 
-  it("skips download for exactly equal descriptors", async () => {
+  it("verifies exact bytes for equal descriptors", async () => {
     const ctx = createContext();
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockResolvedValue(
       toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
     );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      ctx.vaultSnapshot,
+    );
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).resolves.toMatchObject({ relation: "equal", review: null });
+    expect(ctx.ports.syncProvider.downloadVaultSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a remote-ahead descriptor from another vault before download", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue({
+      vaultId: "other-vault-id",
+      snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+      revisionTimestamp: ctx.values.timestamp + 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
     expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
   });
 
@@ -375,7 +402,7 @@ describe("PrepareSyncReviewUseCase", () => {
     vi.mocked(ctx.ports.crypto.decryptVaultSnapshotContent).mockResolvedValue({
       ...session.unlockedVault.vault,
       syncRemovalPending: {
-        expectedRemoteSnapshotDescriptor: null,
+        expectedRemoteSnapshotIdentity: null,
         rollbackSnapshot: ctx.vaultSnapshot,
       },
     });

--- a/packages/core/src/use-cases/sync/prepare-sync-review.ts
+++ b/packages/core/src/use-cases/sync/prepare-sync-review.ts
@@ -1,11 +1,13 @@
-import type { ReviewedVaultSnapshotDescriptors } from "../../domain/snapshot/vault-snapshot-descriptor.type";
+import type { ReviewedVaultSnapshotIdentities } from "../../domain/snapshot/vault-snapshot-descriptor.type";
 import { areJsonEqual } from "../../domain/common";
 import type { VersionVectorRelation } from "../../domain/versioning/version-vector.type";
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
   cloneVaultSnapshotDescriptor,
   compareVaultSnapshotDescriptors,
   toVaultSnapshotDescriptor,
+  toVaultSnapshotIdentity,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
 
 import {
@@ -40,7 +42,7 @@ export type PrepareSyncReviewCommandParams = {
 };
 
 export type PrepareSyncReviewResult = {
-  readonly reviewedSnapshotDescriptors: ReviewedVaultSnapshotDescriptors;
+  readonly reviewedSnapshotIdentities: ReviewedVaultSnapshotIdentities;
   readonly relation: VersionVectorRelation;
   readonly review: VaultSyncReview | null;
 };
@@ -120,6 +122,11 @@ export class PrepareSyncReviewUseCase {
       params.vaultId,
       localSnapshot,
     );
+    const localSnapshotIdentity = toVaultSnapshotIdentity(
+      params.vaultId,
+      localSnapshot,
+      unlockedVault.trustedSnapshotContext.snapshotDigest,
+    );
     const relation = compareVaultSnapshotDescriptors(
       localSnapshotDescriptor,
       remoteSnapshotDescriptor,
@@ -133,6 +140,21 @@ export class PrepareSyncReviewUseCase {
       throw new LocalVaultSnapshotAheadError(params.vaultId);
     }
 
+    const remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+      syncAccess,
+      cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
+    );
+    const remoteTrust = await this.vaultSnapshot.verifyCandidateSnapshotTrust(
+      params.vaultId,
+      remoteSnapshot,
+      unlockedVault,
+    );
+    const remoteSnapshotIdentity = toVaultSnapshotIdentity(
+      params.vaultId,
+      remoteSnapshot,
+      remoteTrust.snapshotDigest,
+    );
+
     if (relation === "equal") {
       if (
         !areVaultSnapshotDescriptorsEqual(
@@ -143,25 +165,24 @@ export class PrepareSyncReviewUseCase {
         throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
       }
 
+      if (
+        !areVaultSnapshotIdentitiesEqual(
+          remoteSnapshotIdentity,
+          localSnapshotIdentity,
+        )
+      ) {
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+      }
+
       return {
-        reviewedSnapshotDescriptors: {
-          local: localSnapshotDescriptor,
-          remote: cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
+        reviewedSnapshotIdentities: {
+          local: localSnapshotIdentity,
+          remote: remoteSnapshotIdentity,
         },
         relation,
         review: null,
       };
     }
-
-    const remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
-      syncAccess,
-      cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
-    );
-    const remoteTrust = await this.vaultSnapshot.verifyCandidateSnapshotTrust(
-      params.vaultId,
-      remoteSnapshot,
-      unlockedVault,
-    );
 
     if (
       remoteTrust.state.generation !==
@@ -266,9 +287,9 @@ export class PrepareSyncReviewUseCase {
     );
 
     return {
-      reviewedSnapshotDescriptors: {
-        local: localSnapshotDescriptor,
-        remote: cloneVaultSnapshotDescriptor(remoteSnapshotDescriptor),
+      reviewedSnapshotIdentities: {
+        local: localSnapshotIdentity,
+        remote: remoteSnapshotIdentity,
       },
       relation,
       review: {

--- a/packages/core/src/use-cases/sync/setup-sync.test.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUnlockVaultTestContext } from "../../__tests__/fixtures/unlock-vault";
-import { replaceVaultSnapshotAfterNextSave } from "../../__tests__/fixtures/ports";
+import { captureVaultSnapshotFromNextSave } from "../../__tests__/fixtures/ports";
 import { createUnlockedVaultWithEntries } from "../../__tests__/fixtures/vault-entries";
 import {
   InvalidSyncConfigError,
@@ -43,14 +43,11 @@ function createContext() {
 }
 
 describe("SetupSyncUseCase", () => {
-  it("uploads the signed initial-sync snapshot when local storage replaces it after save", async () => {
+  it("uploads the exact signed initial-sync snapshot persisted by the local save", async () => {
     const ctx = createContext();
-    const getPersistedSnapshot = replaceVaultSnapshotAfterNextSave(
-      ctx.ports,
-      ctx.vaultSnapshot,
-    );
+    const getPersistedSnapshot = captureVaultSnapshotFromNextSave(ctx.ports);
 
-    await ctx.useCase.execute({
+    const result = await ctx.useCase.execute({
       vaultId: ctx.values.vaultId,
       syncConfig: ctx.values.syncConfigInput,
     });
@@ -59,8 +56,7 @@ describe("SetupSyncUseCase", () => {
       ctx.ports.syncProvider.uploadVaultSnapshot,
     ).mock.calls[0]?.[1];
     expect(uploadedSnapshot).toBe(getPersistedSnapshot());
-    expect(uploadedSnapshot).not.toBe(ctx.saved.vaultSnapshot);
-    expect(ctx.saved.vaultSnapshot).toBe(ctx.vaultSnapshot);
+    expect(result).toEqual({ syncUpload: "complete" });
   });
 
   it("stores only the target in the vault and encrypts credentials locally", async () => {
@@ -74,7 +70,7 @@ describe("SetupSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
     ).toEqual(ctx.values.syncTarget);
-    expect(ctx.saved.deviceSyncCredentialState).toBe(
+    expect(ctx.saved.deviceSyncCredentialState).toEqual(
       ctx.values.encryptedDeviceSyncCredentialState,
     );
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
@@ -127,9 +123,9 @@ describe("SetupSyncUseCase", () => {
 
   it("restores the target and credentials together when initial upload fails", async () => {
     const ctx = createContext();
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValue(
-      new Error("upload failed"),
-    );
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValue(new Error("upload failed"));
 
     await expect(
       ctx.useCase.execute({
@@ -143,5 +139,234 @@ describe("SetupSyncUseCase", () => {
     expect(
       ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
     ).toBeUndefined();
+  });
+
+  it("retains the candidate and intent when a started upload outcome rejects", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
+      new Error("response lost after upload start"),
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+    expect(ctx.saved.vaultSnapshot).not.toEqual(ctx.vaultSnapshot);
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
+    ).toEqual(ctx.values.syncTarget);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        pendingSnapshotUpload: expect.objectContaining({
+          expectedRemoteSnapshotIdentity: null,
+        }),
+      }),
+    );
+  });
+
+  it("treats a synchronous start failure as an unknown upload outcome", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockResolvedValueOnce({
+      status: "ready",
+      start: () => {
+        throw new Error("upload start failed");
+      },
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+
+    expect(ctx.saved.vaultSnapshot).not.toEqual(ctx.vaultSnapshot);
+    expect(ctx.saved.deviceSyncCredentialState).toBeDefined();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("restores the pre-setup state when pending-intent staging fails", async () => {
+    const ctx = createContext();
+    const stagingError = new Error("credential staging failed");
+    vi.mocked(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState,
+    ).mockRejectedValueOnce(stagingError);
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        syncConfig: ctx.values.syncConfigInput,
+      }),
+    ).rejects.toBe(stagingError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.saved.deviceSyncCredentialState).toBeUndefined();
+    expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(ctx.saved.localVaultTrustCheckpoint).toEqual(
+      ctx.values.localVaultTrustCheckpoint,
+    );
+    expect(ctx.saved.unlockedVaultSession).toBeDefined();
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
+    ).toBeUndefined();
+  });
+
+  it("does not let session removal wipe the key during intent staging or start a later upload", async () => {
+    const ctx = createContext();
+    const decrypt = vi.mocked(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState,
+    );
+    const decryptImplementation = decrypt.getMockImplementation();
+
+    if (decryptImplementation === undefined) {
+      throw new Error("Expected credential decryption fixture implementation.");
+    }
+
+    let signalStagingStarted: () => void = () => undefined;
+    let resumeStaging: () => void = () => undefined;
+    const stagingStarted = new Promise<void>((resolve) => {
+      signalStagingStarted = resolve;
+    });
+    const stagingCanContinue = new Promise<void>((resolve) => {
+      resumeStaging = resolve;
+    });
+    decrypt.mockImplementationOnce(async (...args) => {
+      signalStagingStarted();
+      await stagingCanContinue;
+      return decryptImplementation(...args);
+    });
+
+    const execution = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+    const rejectedExecution = expect(execution).rejects.toThrow();
+    await stagingStarted;
+
+    let removalCompleted = false;
+    const removal = ctx.ports.sessionServices.unlockedVaultSession
+      .remove()
+      .then(() => {
+        removalCompleted = true;
+      });
+    await Promise.resolve();
+
+    expect(removalCompleted).toBe(false);
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+
+    resumeStaging();
+    await removal;
+    await rejectedExecution;
+
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.saved.deviceSyncCredentialState).toBeUndefined();
+    expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not start an upload after the session is removed during provider preparation", async () => {
+    const ctx = createContext();
+    let signalPreparationStarted: () => void = () => undefined;
+    let resumePreparation: () => void = () => undefined;
+    const preparationStarted = new Promise<void>((resolve) => {
+      signalPreparationStarted = resolve;
+    });
+    const preparationCanContinue = new Promise<void>((resolve) => {
+      resumePreparation = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockImplementationOnce(
+      async (syncAccess, snapshot, expectedRemoteSnapshotIdentity) => {
+        signalPreparationStarted();
+        await preparationCanContinue;
+        return {
+          status: "ready",
+          start: () => ({
+            outcome: ctx.ports.syncProvider.uploadVaultSnapshot(
+              syncAccess,
+              snapshot,
+              expectedRemoteSnapshotIdentity,
+            ),
+          }),
+        };
+      },
+    );
+
+    const execution = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+    const rejectedExecution = expect(execution).rejects.toThrow();
+    await preparationStarted;
+
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    resumePreparation();
+    await rejectedExecution;
+
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.saved.deviceSyncCredentialState).toBeUndefined();
+    expect(ctx.saved.vaultSnapshot).toEqual(ctx.vaultSnapshot);
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps configured sync and reports pending when initial upload outcome is unknown", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      syncConfig: ctx.values.syncConfigInput,
+    });
+
+    expect(result).toEqual({ syncUpload: "pending" });
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.syncTarget,
+    ).toEqual(ctx.values.syncTarget);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        currentCredentials: ctx.values.syncCredentials,
+        pendingSnapshotUpload: expect.objectContaining({
+          expectedRemoteSnapshotIdentity: null,
+        }),
+      }),
+    );
+    expect(ctx.saved.vaultSnapshot).not.toEqual(ctx.vaultSnapshot);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/use-cases/sync/setup-sync.ts
+++ b/packages/core/src/use-cases/sync/setup-sync.ts
@@ -2,6 +2,7 @@ import type {
   SyncAccess,
   SyncSetupInput,
 } from "../../domain/sync/sync-config.type";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import type { CryptoPort } from "../../ports/crypto/crypto.port";
 import type { SyncProviderPort } from "../../ports/sync/sync-provider.port";
 import {
@@ -16,6 +17,10 @@ import type { VaultSyncGuardService } from "../../services/sync";
 export type SetupSyncCommandParams = {
   readonly vaultId: string;
   readonly syncConfig: SyncSetupInput;
+};
+
+export type SetupSyncResult = {
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class SetupSyncUseCase {
@@ -39,7 +44,7 @@ export class SetupSyncUseCase {
     this.crypto = crypto;
   }
 
-  async execute(params: SetupSyncCommandParams): Promise<void> {
+  async execute(params: SetupSyncCommandParams): Promise<SetupSyncResult> {
     const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
@@ -112,24 +117,32 @@ export class SetupSyncUseCase {
               params.vaultId,
               updatedUnlockedVault,
               sourceSnapshotVersionVector,
-              { syncCredentialState: encryptedCredentialState },
+              {
+                uploadExpectedRemoteSnapshotIdentity: null,
+                expectedSyncCredentialState: null,
+                syncCredentialState: encryptedCredentialState,
+              },
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
-    await this.vaultSyncGuard.uploadPersistedInitialSyncSnapshot(
-      params.vaultId,
-      syncAccess,
-      syncState.localSnapshot,
-      persistedSnapshot.snapshot,
-      persistedSnapshot.trustedSnapshotContext.snapshotDigest,
-      preparedRestore,
-      sessionId,
-    );
+    const syncUpload =
+      await this.vaultSyncGuard.uploadPersistedInitialSyncSnapshot(
+        params.vaultId,
+        syncAccess,
+        syncState.localSnapshot,
+        persistedSnapshot.snapshot,
+        persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        persistedSnapshot.checkpoint,
+        encryptedCredentialState,
+        updatedUnlockedVault,
+        preparedRestore,
+        sessionId,
+      );
 
-    await this.unlockedVaultSession.commitPersistedSnapshot(
+    await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
       sessionId,
       {
         ...updatedUnlockedVault,
@@ -137,5 +150,7 @@ export class SetupSyncUseCase {
       },
       persistedSnapshot.snapshotVersionVector,
     );
+
+    return { syncUpload };
   }
 }

--- a/packages/core/src/use-cases/sync/sync-upload.test.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.test.ts
@@ -5,6 +5,9 @@ import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import {
   LocalSyncCredentialsMissingError,
   RemoteVaultSnapshotAheadError,
+  RemoteVaultSnapshotIntegrityError,
+  SyncConflictDetectedError,
+  SyncProviderUploadRejectedError,
 } from "../../errors/sync.errors";
 import { VaultSnapshotService } from "../../services/snapshot/vault-snapshot.service";
 import { VaultSyncGuardService } from "../../services/sync";
@@ -12,6 +15,13 @@ import { SyncUploadUseCase } from "./sync-upload";
 
 function createContext() {
   const ctx = createUnlockVaultTestContext();
+  const vaultSnapshot = {
+    ...ctx.vaultSnapshot,
+    metadata: {
+      ...ctx.vaultSnapshot.metadata,
+      uploadExpectedRemoteSnapshotIdentity: null,
+    },
+  };
   const unlockedVault = createUnlockedVaultWithEntries(ctx.values, []);
   ctx.saved.deviceSyncCredentialState =
     ctx.values.encryptedDeviceSyncCredentialState;
@@ -24,9 +34,9 @@ function createContext() {
         syncTarget: ctx.values.syncTarget,
       },
     },
-    sourceSnapshotVersionVector:
-      ctx.vaultSnapshot.metadata.snapshotVersionVector,
+    sourceSnapshotVersionVector: vaultSnapshot.metadata.snapshotVersionVector,
   };
+  ctx.saved.vaultSnapshot = vaultSnapshot;
   const snapshotService = new VaultSnapshotService(
     ctx.ports.crypto,
     ctx.ports.clock,
@@ -46,20 +56,21 @@ function createContext() {
     guard,
   );
 
-  return { ...ctx, useCase };
+  return { ...ctx, vaultSnapshot, useCase };
 }
 
 describe("SyncUploadUseCase", () => {
   it("uploads using local encrypted credentials", async () => {
     const ctx = createContext();
 
-    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    const result = await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       ctx.vaultSnapshot,
       null,
     );
+    expect(result).toEqual({ syncUpload: "complete" });
   });
 
   it("does not upload an exactly equal remote descriptor", async () => {
@@ -69,14 +80,29 @@ describe("SyncUploadUseCase", () => {
     ).mockResolvedValue(
       toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
     );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      ctx.vaultSnapshot,
+    );
 
-    await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    const result = await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(result).toEqual({ syncUpload: "complete" });
   });
 
   it("uploads a local-ahead snapshot using the remote descriptor as the expected state", async () => {
     const ctx = createContext();
+    const remoteSnapshotDescriptor = {
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: {
+        [ctx.values.deviceId]: 1,
+      },
+      revisionTimestamp: ctx.values.timestamp,
+    };
+    const remoteSnapshotIdentity = {
+      descriptor: remoteSnapshotDescriptor,
+      snapshotDigest: ctx.values.vaultSnapshotDigest,
+    };
     const localSnapshot = {
       ...ctx.vaultSnapshot,
       metadata: {
@@ -85,14 +111,8 @@ describe("SyncUploadUseCase", () => {
         snapshotVersionVector: {
           [ctx.values.deviceId]: 2,
         },
+        uploadExpectedRemoteSnapshotIdentity: remoteSnapshotIdentity,
       },
-    };
-    const remoteSnapshotDescriptor = {
-      vaultId: ctx.values.vaultId,
-      snapshotVersionVector: {
-        [ctx.values.deviceId]: 1,
-      },
-      revisionTimestamp: ctx.values.timestamp,
     };
     const session = ctx.saved.unlockedVaultSession!;
     ctx.saved.vaultSnapshot = localSnapshot;
@@ -103,29 +123,168 @@ describe("SyncUploadUseCase", () => {
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockResolvedValue(remoteSnapshotDescriptor);
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      ctx.vaultSnapshot,
+    );
 
     await ctx.useCase.execute({ vaultId: ctx.values.vaultId });
 
     expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledWith(
       ctx.values.syncAccess,
       localSnapshot,
-      remoteSnapshotDescriptor,
+      remoteSnapshotIdentity,
     );
   });
 
   it("blocks upload when remote is ahead", async () => {
     const ctx = createContext();
-    vi.mocked(
-      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
-    ).mockResolvedValue({
+    const remoteSnapshotDescriptor = {
       vaultId: ctx.values.vaultId,
       snapshotVersionVector: { [ctx.values.deviceId]: 2 },
       revisionTimestamp: ctx.values.timestamp + 1,
-    });
+    };
+    const localSnapshot = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        ...ctx.vaultSnapshot.metadata,
+        uploadExpectedRemoteSnapshotIdentity: {
+          descriptor: remoteSnapshotDescriptor,
+          snapshotDigest: ctx.values.vaultSnapshotDigest,
+        },
+      },
+    };
+    ctx.saved.vaultSnapshot = localSnapshot;
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue(remoteSnapshotDescriptor);
 
     await expect(
       ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
     ).rejects.toBeInstanceOf(RemoteVaultSnapshotAheadError);
+  });
+
+  it.each(["fresh", "pending retry"] as const)(
+    "rejects a same-descriptor historical remote with different bytes during a %s upload",
+    async (attemptKind) => {
+      const ctx = createContext();
+      const expectedRemoteSnapshotDescriptor = {
+        vaultId: ctx.values.vaultId,
+        snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+        revisionTimestamp: ctx.values.timestamp,
+      };
+      const expectedRemoteSnapshotIdentity = {
+        descriptor: expectedRemoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      };
+      const localSnapshot = {
+        ...ctx.vaultSnapshot,
+        metadata: {
+          ...ctx.vaultSnapshot.metadata,
+          revisionTimestamp: ctx.values.timestamp + 1,
+          snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+          uploadExpectedRemoteSnapshotIdentity: expectedRemoteSnapshotIdentity,
+        },
+      };
+      const session = ctx.saved.unlockedVaultSession!;
+      ctx.saved.vaultSnapshot = localSnapshot;
+      ctx.saved.unlockedVaultSession = {
+        ...session,
+        sourceSnapshotVersionVector:
+          localSnapshot.metadata.snapshotVersionVector,
+      };
+      vi.mocked(
+        ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+      ).mockResolvedValue(expectedRemoteSnapshotDescriptor);
+      vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+        ctx.vaultSnapshot,
+      );
+
+      if (attemptKind === "pending retry") {
+        ctx.saved.deviceSyncCredentialState =
+          await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+            {
+              ...ctx.values.deviceSyncCredentialState,
+              pendingSnapshotUpload: {
+                candidateSnapshotIdentity: {
+                  descriptor: toVaultSnapshotDescriptor(
+                    ctx.values.vaultId,
+                    localSnapshot,
+                  ),
+                  snapshotDigest: ctx.values.vaultSnapshotDigest,
+                },
+                expectedRemoteSnapshotIdentity,
+              },
+            },
+            ctx.values.deviceLocalProtectionKey,
+            {
+              vaultId: ctx.values.vaultId,
+              deviceId: ctx.values.deviceId,
+              provider: ctx.values.syncTarget.provider,
+              target: ctx.values.syncTarget,
+            },
+          );
+      }
+
+      const verification = vi
+        .spyOn(VaultSnapshotService.prototype, "verifyHistoricalSnapshotTrust")
+        .mockResolvedValue({
+          chain: ctx.values.vaultTrustChain,
+          state: ctx.values.verifiedVaultTrustState,
+          snapshotDigest: "substituted-remote-snapshot-digest",
+        });
+
+      try {
+        await expect(
+          ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+        ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+      } finally {
+        verification.mockRestore();
+      }
+
+      expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a local-ahead descriptor from another vault before upload", async () => {
+    const ctx = createContext();
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue({
+      vaultId: "other-vault-id",
+      snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+      revisionTimestamp: ctx.values.timestamp - 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before upload when the signed remote expectation is absent", async () => {
+    const ctx = createContext();
+    const snapshotWithoutExpectation = {
+      ...ctx.vaultSnapshot,
+      metadata: {
+        id: ctx.vaultSnapshot.metadata.id,
+        schemaVersion: ctx.vaultSnapshot.metadata.schemaVersion,
+        vaultCreationTimestamp:
+          ctx.vaultSnapshot.metadata.vaultCreationTimestamp,
+        revisionTimestamp: ctx.vaultSnapshot.metadata.revisionTimestamp,
+        snapshotVersionVector: ctx.vaultSnapshot.metadata.snapshotVersionVector,
+        algorithmSuiteId: ctx.vaultSnapshot.metadata.algorithmSuiteId,
+        createdByDeviceId: ctx.vaultSnapshot.metadata.createdByDeviceId,
+        vaultKeyGeneration: ctx.vaultSnapshot.metadata.vaultKeyGeneration,
+      },
+    };
+    ctx.saved.vaultSnapshot = snapshotWithoutExpectation;
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
   });
 
   it("fails before provider access when local credentials are missing", async () => {
@@ -140,4 +299,558 @@ describe("SyncUploadUseCase", () => {
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).not.toHaveBeenCalled();
   });
+
+  it("reports conflict when upload is definitely not committed", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(ctx.values.deviceSyncCredentialState);
+  });
+
+  it("clears a freshly staged intent when the provider definitely rejects the upload", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "provider_rejected",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncProviderUploadRejectedError);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(ctx.values.deviceSyncCredentialState);
+  });
+
+  it("clears a freshly staged intent after a pre-write provider rejection", async () => {
+    const ctx = createContext();
+    const uploadError = new Error("upload validation failed");
+    vi.mocked(
+      ctx.ports.syncProvider.prepareVaultSnapshotUpload,
+    ).mockRejectedValueOnce(uploadError);
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBe(uploadError);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(ctx.values.deviceSyncCredentialState);
+  });
+
+  it("reports pending and recognizes exact equality when an unknown upload committed remotely", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+    expect(
+      ctx.ports.crypto.encryptDeviceSyncCredentialState,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pendingSnapshotUpload: {
+          candidateSnapshotIdentity: {
+            descriptor: toVaultSnapshotDescriptor(
+              ctx.values.vaultId,
+              ctx.vaultSnapshot,
+            ),
+            snapshotDigest: ctx.values.vaultSnapshotDigest,
+          },
+          expectedRemoteSnapshotIdentity: null,
+        },
+      }),
+      ctx.values.deviceLocalProtectionKey,
+      expect.any(Object),
+    );
+
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+    );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      ctx.vaultSnapshot,
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "complete" });
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("does not report complete while a matching pending intent remains after a concurrent upload", async () => {
+    const ctx = createContext();
+    const candidateDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.vaultSnapshot,
+    );
+    let resolveFirstLookup!: () => void;
+    let signalFirstLookupStarted!: () => void;
+    const firstLookup = new Promise<typeof candidateDescriptor>((resolve) => {
+      resolveFirstLookup = () => resolve(candidateDescriptor);
+    });
+    const firstLookupStarted = new Promise<void>((resolve) => {
+      signalFirstLookupStarted = resolve;
+    });
+    vi.mocked(ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor)
+      .mockImplementationOnce(async () => {
+        signalFirstLookupStarted();
+        return firstLookup;
+      })
+      .mockResolvedValueOnce(null);
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      ctx.vaultSnapshot,
+    );
+
+    const equalityCheck = ctx.useCase.execute({ vaultId: ctx.values.vaultId });
+    await firstLookupStarted;
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+    resolveFirstLookup();
+
+    await expect(equalityCheck).resolves.toEqual({ syncUpload: "complete" });
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(ctx.values.deviceSyncCredentialState);
+  });
+
+  it("retains pending reconciliation for a same-descriptor remote snapshot with a different digest", async () => {
+    const ctx = createContext();
+    const remoteSnapshot = { ...ctx.vaultSnapshot };
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, remoteSnapshot),
+    );
+    vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+      remoteSnapshot,
+    );
+    vi.mocked(ctx.ports.crypto.digestVaultSnapshot).mockImplementation(
+      async (snapshot) =>
+        snapshot === remoteSnapshot
+          ? "different-remote-snapshot-digest"
+          : ctx.values.vaultSnapshotDigest,
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ pendingSnapshotUpload: expect.any(Object) }),
+    );
+  });
+
+  it("retries the same snapshot when an unknown upload definitely did not commit", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot)
+      .mockResolvedValueOnce({ status: "outcome_unknown" })
+      .mockResolvedValueOnce({ status: "committed" });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "complete" });
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledTimes(2);
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenNthCalledWith(
+      2,
+      ctx.values.syncAccess,
+      ctx.vaultSnapshot,
+      null,
+    );
+  });
+
+  it("reports pending without rollback when clearing a committed upload intent races", async () => {
+    const ctx = createContext();
+    const save = vi.mocked(
+      ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+    );
+    const saveImplementation = save.getMockImplementation();
+
+    if (saveImplementation === undefined) {
+      throw new Error("Expected the repository save fixture implementation.");
+    }
+
+    save
+      .mockImplementationOnce(saveImplementation)
+      .mockRejectedValueOnce(new Error("clear raced"));
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ pendingSnapshotUpload: expect.any(Object) }),
+    );
+  });
+
+  it("retains the original intent when a reconciliation retry is rejected before commit", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot)
+      .mockResolvedValueOnce({ status: "outcome_unknown" })
+      .mockResolvedValueOnce({
+        status: "definitely_not_committed",
+        reason: "provider_rejected",
+      });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncProviderUploadRejectedError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledTimes(2);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ pendingSnapshotUpload: expect.any(Object) }),
+    );
+  });
+
+  it("rejects a pending intent whose candidate digest no longer matches local state", async () => {
+    const ctx = createContext();
+    ctx.saved.deviceSyncCredentialState =
+      await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+        {
+          ...ctx.values.deviceSyncCredentialState,
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                ctx.vaultSnapshot,
+              ),
+              snapshotDigest: "different-snapshot-digest",
+            },
+            expectedRemoteSnapshotIdentity: null,
+          },
+        },
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pending intent whose expected remote differs from the signed snapshot expectation", async () => {
+    const ctx = createContext();
+    ctx.saved.deviceSyncCredentialState =
+      await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+        {
+          ...ctx.values.deviceSyncCredentialState,
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                ctx.vaultSnapshot,
+              ),
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+            expectedRemoteSnapshotIdentity: {
+              descriptor: {
+                vaultId: ctx.values.vaultId,
+                snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+                revisionTimestamp: ctx.values.timestamp - 1,
+              },
+              snapshotDigest: "different-expected-remote-digest",
+            },
+          },
+        },
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      );
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, ctx.vaultSnapshot),
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.downloadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite a remote change discovered after an unknown upload", async () => {
+    const ctx = createContext();
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).resolves.toEqual({ syncUpload: "pending" });
+
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce({
+      vaultId: ctx.values.vaultId,
+      snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+      revisionTimestamp: ctx.values.timestamp + 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+    ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it.each(["deleted", "rolled back"] as const)(
+    "does not replace a %s remote snapshot after an unknown replacement upload",
+    async (remoteChange) => {
+      const ctx = createContext();
+      const expectedRemoteSnapshotDescriptor = {
+        vaultId: ctx.values.vaultId,
+        snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+        revisionTimestamp: ctx.values.timestamp,
+      };
+      const expectedRemoteSnapshotIdentity = {
+        descriptor: expectedRemoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      };
+      const localSnapshot = {
+        ...ctx.vaultSnapshot,
+        metadata: {
+          ...ctx.vaultSnapshot.metadata,
+          revisionTimestamp: ctx.values.timestamp + 1,
+          snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+          uploadExpectedRemoteSnapshotIdentity: expectedRemoteSnapshotIdentity,
+        },
+      };
+      const session = ctx.saved.unlockedVaultSession!;
+      ctx.saved.vaultSnapshot = localSnapshot;
+      ctx.saved.unlockedVaultSession = {
+        ...session,
+        sourceSnapshotVersionVector:
+          localSnapshot.metadata.snapshotVersionVector,
+      };
+      vi.mocked(ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor)
+        .mockResolvedValueOnce(expectedRemoteSnapshotDescriptor)
+        .mockResolvedValueOnce(
+          remoteChange === "deleted"
+            ? null
+            : {
+                vaultId: ctx.values.vaultId,
+                snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+                revisionTimestamp: ctx.values.timestamp - 1,
+              },
+        );
+      vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+        ctx.vaultSnapshot,
+      );
+      vi.mocked(
+        ctx.ports.syncProvider.uploadVaultSnapshot,
+      ).mockResolvedValueOnce({ status: "outcome_unknown" });
+
+      await expect(
+        ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ).resolves.toEqual({ syncUpload: "pending" });
+      await expect(
+        ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+      expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+      expect(
+        ctx.ports.crypto.encryptDeviceSyncCredentialState,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                localSnapshot,
+              ),
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+            expectedRemoteSnapshotIdentity,
+          },
+        }),
+        ctx.values.deviceLocalProtectionKey,
+        expect.any(Object),
+      );
+    },
+  );
+
+  it.each(["deleted", "rolled back"] as const)(
+    "does not overwrite a %s remote after the encrypted pending intent is replayed away",
+    async (remoteChange) => {
+      const ctx = createContext();
+      const preIntentCredentialState =
+        ctx.values.encryptedDeviceSyncCredentialState;
+      const expectedRemoteSnapshotDescriptor = {
+        vaultId: ctx.values.vaultId,
+        snapshotVersionVector: { [ctx.values.deviceId]: 1 },
+        revisionTimestamp: ctx.values.timestamp,
+      };
+      const expectedRemoteSnapshotIdentity = {
+        descriptor: expectedRemoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      };
+      const localSnapshot = {
+        ...ctx.vaultSnapshot,
+        metadata: {
+          ...ctx.vaultSnapshot.metadata,
+          revisionTimestamp: ctx.values.timestamp + 1,
+          snapshotVersionVector: { [ctx.values.deviceId]: 2 },
+          uploadExpectedRemoteSnapshotIdentity: expectedRemoteSnapshotIdentity,
+        },
+      };
+      const session = ctx.saved.unlockedVaultSession!;
+      ctx.saved.vaultSnapshot = localSnapshot;
+      ctx.saved.unlockedVaultSession = {
+        ...session,
+        sourceSnapshotVersionVector:
+          localSnapshot.metadata.snapshotVersionVector,
+      };
+      vi.mocked(ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor)
+        .mockResolvedValueOnce(expectedRemoteSnapshotDescriptor)
+        .mockResolvedValueOnce(
+          remoteChange === "deleted"
+            ? null
+            : {
+                vaultId: ctx.values.vaultId,
+                snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+                revisionTimestamp: ctx.values.timestamp - 1,
+              },
+        );
+      vi.mocked(ctx.ports.syncProvider.downloadVaultSnapshot).mockResolvedValue(
+        ctx.vaultSnapshot,
+      );
+      vi.mocked(
+        ctx.ports.syncProvider.uploadVaultSnapshot,
+      ).mockResolvedValueOnce({ status: "outcome_unknown" });
+
+      await expect(
+        ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ).resolves.toEqual({ syncUpload: "pending" });
+
+      ctx.saved.deviceSyncCredentialState = preIntentCredentialState;
+
+      await expect(
+        ctx.useCase.execute({ vaultId: ctx.values.vaultId }),
+      ).rejects.toBeInstanceOf(SyncConflictDetectedError);
+
+      expect(ctx.ports.syncProvider.uploadVaultSnapshot).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/packages/core/src/use-cases/sync/sync-upload.ts
+++ b/packages/core/src/use-cases/sync/sync-upload.ts
@@ -1,8 +1,14 @@
 import {
+  areVaultSnapshotIdentitiesEqual,
   areVaultSnapshotDescriptorsEqual,
   compareVaultSnapshotDescriptors,
   toVaultSnapshotDescriptor,
 } from "../../domain/snapshot/vault-snapshot-descriptor.utils";
+import type {
+  VaultSnapshotDescriptor,
+  VaultSnapshotIdentity,
+} from "../../domain/snapshot/vault-snapshot-descriptor.type";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 import {
   RemoteVaultSnapshotAheadError,
   RemoteVaultSnapshotChangedError,
@@ -18,6 +24,10 @@ import type { VaultSyncGuardService } from "../../services/sync";
 
 export type SyncUploadCommandParams = {
   readonly vaultId: string;
+};
+
+export type SyncUploadResult = {
+  readonly syncUpload: SyncUploadStatus;
 };
 
 export class SyncUploadUseCase {
@@ -38,8 +48,8 @@ export class SyncUploadUseCase {
     this.vaultSyncGuard = vaultSyncGuard;
   }
 
-  async execute(params: SyncUploadCommandParams): Promise<void> {
-    const { sourceSnapshotVersionVector, unlockedVault } =
+  async execute(params: SyncUploadCommandParams): Promise<SyncUploadResult> {
+    const { sessionId, sourceSnapshotVersionVector, unlockedVault } =
       await this.unlockedVaultSession.requireUnlockedVaultContext(
         params.vaultId,
         "sync upload",
@@ -64,33 +74,147 @@ export class SyncUploadUseCase {
       params.vaultId,
       unlockedVault,
     );
+    const pending = await this.vaultSyncGuard.getPendingSnapshotUpload(
+      params.vaultId,
+      unlockedVault,
+    );
     const remoteSnapshotDescriptor =
       await this.syncProvider.getLatestVaultSnapshotDescriptor(
         syncAccess,
         params.vaultId,
       );
+    const localSnapshotDescriptor = toVaultSnapshotDescriptor(
+      params.vaultId,
+      localSnapshot,
+    );
+    const signedExpectedRemoteSnapshotIdentity =
+      localSnapshot.metadata.uploadExpectedRemoteSnapshotIdentity;
 
-    if (remoteSnapshotDescriptor !== null) {
-      const localSnapshotDescriptor = toVaultSnapshotDescriptor(
-        params.vaultId,
+    if (
+      signedExpectedRemoteSnapshotIdentity === undefined ||
+      (signedExpectedRemoteSnapshotIdentity !== null &&
+        signedExpectedRemoteSnapshotIdentity.descriptor.vaultId !==
+          params.vaultId)
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+    const preparedSnapshot =
+      await this.vaultSnapshot.prepareLocalVaultSnapshotRestore(
         localSnapshot,
+        unlockedVault,
       );
+
+    if (pending !== undefined) {
+      requirePendingSnapshotUploadMatchesLocal(
+        params.vaultId,
+        pending,
+        localSnapshotDescriptor,
+        unlockedVault.trustedSnapshotContext.snapshotDigest,
+        signedExpectedRemoteSnapshotIdentity,
+      );
+    }
+
+    if (
+      remoteSnapshotDescriptor !== null &&
+      areVaultSnapshotDescriptorsEqual(
+        remoteSnapshotDescriptor,
+        localSnapshotDescriptor,
+      )
+    ) {
+      await this.requireRemoteSnapshotMatchesLocalCandidate({
+        vaultId: params.vaultId,
+        syncAccess,
+        remoteSnapshotDescriptor,
+        unlockedVault,
+        expectedSnapshotDigest:
+          unlockedVault.trustedSnapshotContext.snapshotDigest,
+      });
+      const currentPending = await this.vaultSyncGuard.getPendingSnapshotUpload(
+        params.vaultId,
+        unlockedVault,
+      );
+
+      if (currentPending === undefined) {
+        return { syncUpload: "complete" };
+      }
+
+      requirePendingSnapshotUploadMatchesLocal(
+        params.vaultId,
+        currentPending,
+        localSnapshotDescriptor,
+        unlockedVault.trustedSnapshotContext.snapshotDigest,
+        signedExpectedRemoteSnapshotIdentity,
+      );
+      const cleared = await this.vaultSyncGuard.clearPendingSnapshotUpload({
+        sessionId,
+        vaultId: params.vaultId,
+        unlockedVault,
+        snapshot: localSnapshot,
+        snapshotDigest: unlockedVault.trustedSnapshotContext.snapshotDigest,
+        checkpoint: preparedSnapshot.checkpoint,
+        pending: currentPending,
+      });
+
+      return { syncUpload: cleared ? "complete" : "pending" };
+    }
+
+    if (
+      !areNullableVaultSnapshotDescriptorsEqual(
+        remoteSnapshotDescriptor,
+        signedExpectedRemoteSnapshotIdentity?.descriptor ?? null,
+      )
+    ) {
+      if (
+        remoteSnapshotDescriptor !== null &&
+        remoteSnapshotDescriptor.vaultId !== params.vaultId
+      ) {
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+      }
+
+      throw new SyncConflictDetectedError(params.vaultId);
+    }
+
+    if (signedExpectedRemoteSnapshotIdentity !== null) {
+      await this.requireHistoricalRemoteSnapshotMatchesIdentity({
+        vaultId: params.vaultId,
+        syncAccess,
+        remoteSnapshotIdentity: signedExpectedRemoteSnapshotIdentity,
+        currentSnapshot: localSnapshot,
+        unlockedVault,
+      });
+    }
+
+    if (pending !== undefined) {
+      try {
+        return {
+          syncUpload: await this.vaultSyncGuard.retryPendingSnapshotUpload({
+            sessionId,
+            vaultId: params.vaultId,
+            unlockedVault,
+            syncAccess,
+            snapshot: localSnapshot,
+            snapshotDigest: unlockedVault.trustedSnapshotContext.snapshotDigest,
+            checkpoint: preparedSnapshot.checkpoint,
+            pending,
+          }),
+        };
+      } catch (error) {
+        if (error instanceof RemoteVaultSnapshotChangedError) {
+          throw new SyncConflictDetectedError(params.vaultId);
+        }
+
+        throw error;
+      }
+    }
+
+    if (signedExpectedRemoteSnapshotIdentity !== null) {
       const relation = compareVaultSnapshotDescriptors(
         localSnapshotDescriptor,
-        remoteSnapshotDescriptor,
+        signedExpectedRemoteSnapshotIdentity.descriptor,
       );
 
       if (relation === "equal") {
-        if (
-          !areVaultSnapshotDescriptorsEqual(
-            remoteSnapshotDescriptor,
-            localSnapshotDescriptor,
-          )
-        ) {
-          throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
-        }
-
-        return;
+        throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
       }
 
       if (relation === "remote_ahead") {
@@ -102,11 +226,65 @@ export class SyncUploadUseCase {
       }
     }
 
+    let stagedIntent:
+      | Parameters<
+          VaultSyncGuardService["clearStagedSnapshotUploadIntent"]
+        >[0]["intent"]
+      | undefined;
+
     try {
-      await this.syncProvider.uploadVaultSnapshot(
-        syncAccess,
-        localSnapshot,
-        remoteSnapshotDescriptor,
+      return {
+        syncUpload: await this.vaultSyncGuard.uploadTrackedSnapshot({
+          sessionId,
+          vaultId: params.vaultId,
+          unlockedVault,
+          syncAccess,
+          snapshot: localSnapshot,
+          snapshotDigest: unlockedVault.trustedSnapshotContext.snapshotDigest,
+          checkpoint: preparedSnapshot.checkpoint,
+          expectedRemoteSnapshotIdentity: signedExpectedRemoteSnapshotIdentity,
+          onIntentStaged: (intent) => {
+            stagedIntent = intent;
+          },
+        }),
+      };
+    } catch (error) {
+      if (stagedIntent !== undefined) {
+        await this.vaultSyncGuard.clearStagedSnapshotUploadIntent({
+          sessionId,
+          vaultId: params.vaultId,
+          snapshot: localSnapshot,
+          snapshotDigest: unlockedVault.trustedSnapshotContext.snapshotDigest,
+          checkpoint: preparedSnapshot.checkpoint,
+          intent: stagedIntent,
+        });
+      }
+
+      if (error instanceof RemoteVaultSnapshotChangedError) {
+        throw new SyncConflictDetectedError(params.vaultId);
+      }
+
+      throw error;
+    }
+  }
+
+  private async requireRemoteSnapshotMatchesLocalCandidate(params: {
+    readonly vaultId: string;
+    readonly syncAccess: Parameters<
+      SyncProviderPort["downloadVaultSnapshot"]
+    >[0];
+    readonly remoteSnapshotDescriptor: VaultSnapshotDescriptor;
+    readonly unlockedVault: Awaited<
+      ReturnType<UnlockedVaultSessionService["requireUnlockedVaultContext"]>
+    >["unlockedVault"];
+    readonly expectedSnapshotDigest: string;
+  }): Promise<void> {
+    let remoteSnapshot;
+
+    try {
+      remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+        params.syncAccess,
+        params.remoteSnapshotDescriptor,
       );
     } catch (error) {
       if (error instanceof RemoteVaultSnapshotChangedError) {
@@ -115,5 +293,112 @@ export class SyncUploadUseCase {
 
       throw error;
     }
+
+    const verifiedRemoteSnapshot =
+      await this.vaultSnapshot.verifyCandidateSnapshotTrust(
+        params.vaultId,
+        remoteSnapshot,
+        params.unlockedVault,
+      );
+
+    if (
+      verifiedRemoteSnapshot.snapshotDigest !== params.expectedSnapshotDigest
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
   }
+
+  private async requireHistoricalRemoteSnapshotMatchesIdentity(params: {
+    readonly vaultId: string;
+    readonly syncAccess: Parameters<
+      SyncProviderPort["downloadVaultSnapshot"]
+    >[0];
+    readonly remoteSnapshotIdentity: VaultSnapshotIdentity;
+    readonly currentSnapshot: Parameters<
+      VaultSnapshotService["verifyHistoricalSnapshotTrust"]
+    >[2];
+    readonly unlockedVault: Awaited<
+      ReturnType<UnlockedVaultSessionService["requireUnlockedVaultContext"]>
+    >["unlockedVault"];
+  }): Promise<void> {
+    let remoteSnapshot;
+
+    try {
+      remoteSnapshot = await this.syncProvider.downloadVaultSnapshot(
+        params.syncAccess,
+        params.remoteSnapshotIdentity.descriptor,
+      );
+    } catch (error) {
+      if (error instanceof RemoteVaultSnapshotChangedError) {
+        throw new SyncConflictDetectedError(params.vaultId);
+      }
+
+      throw error;
+    }
+
+    const verifiedRemoteSnapshot =
+      await this.vaultSnapshot.verifyHistoricalSnapshotTrust(
+        params.vaultId,
+        remoteSnapshot,
+        params.currentSnapshot,
+        params.unlockedVault,
+      );
+
+    if (
+      verifiedRemoteSnapshot.snapshotDigest !==
+      params.remoteSnapshotIdentity.snapshotDigest
+    ) {
+      throw new RemoteVaultSnapshotIntegrityError(params.vaultId);
+    }
+  }
+}
+
+type PendingSnapshotUpload = NonNullable<
+  Awaited<ReturnType<VaultSyncGuardService["getPendingSnapshotUpload"]>>
+>;
+
+function requirePendingSnapshotUploadMatchesLocal(
+  vaultId: string,
+  pending: PendingSnapshotUpload,
+  localSnapshotDescriptor: VaultSnapshotDescriptor,
+  localSnapshotDigest: string,
+  signedExpectedRemoteSnapshotIdentity: VaultSnapshotIdentity | null,
+): void {
+  if (
+    !areVaultSnapshotIdentitiesEqual(
+      {
+        descriptor: localSnapshotDescriptor,
+        snapshotDigest: localSnapshotDigest,
+      },
+      pending.candidateSnapshotIdentity,
+    ) ||
+    !areNullableVaultSnapshotIdentitiesEqual(
+      signedExpectedRemoteSnapshotIdentity,
+      pending.expectedRemoteSnapshotIdentity,
+    )
+  ) {
+    throw new RemoteVaultSnapshotIntegrityError(vaultId);
+  }
+}
+
+function areNullableVaultSnapshotIdentitiesEqual(
+  left: VaultSnapshotIdentity | null,
+  right: VaultSnapshotIdentity | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === null && right === null;
+  }
+
+  return areVaultSnapshotIdentitiesEqual(left, right);
+}
+
+function areNullableVaultSnapshotDescriptorsEqual(
+  left: VaultSnapshotDescriptor | null,
+  right: VaultSnapshotDescriptor | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === null && right === null;
+  }
+
+  return areVaultSnapshotDescriptorsEqual(left, right);
 }

--- a/packages/core/src/use-cases/vault-entries/add-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.test.ts
@@ -7,12 +7,14 @@ import {
   createVaultSnapshotServiceMock,
   saveUnlockedVaultWithEntries,
 } from "../../__tests__/fixtures/vault-entries";
+import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import {
   LocalVaultSnapshotAheadError,
   RemoteVaultSnapshotAheadError,
-  RemoteVaultSnapshotChangedError,
+  RemoteVaultSnapshotIntegrityError,
   SyncRemovalPendingError,
   SyncConflictDetectedError,
+  SyncProviderUploadRejectedError,
 } from "../../errors/sync.errors";
 import {
   InvalidEntryUrlError,
@@ -20,7 +22,11 @@ import {
   PasswordEntryStrengthRequirementNotMetError,
 } from "../../errors/vault-entry.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
-import { PersistedVaultRollbackIncompleteError } from "../../errors/vault-snapshot.errors";
+import {
+  LocalVaultSnapshotChangedError,
+  PersistedVaultRollbackIncompleteError,
+} from "../../errors/vault-snapshot.errors";
+import type { SyncUploadOutcome } from "../../ports/sync/sync-provider.port";
 import { VaultSyncGuardService } from "../../services/sync";
 import { AddEntryUseCase } from "./add-entry";
 
@@ -78,6 +84,7 @@ describe("AddEntryUseCase", () => {
         [ctx.values.deviceId]: 2,
       },
       revisionTimestamp: ctx.values.timestamp + 1,
+      syncUpload: "complete",
     });
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [
@@ -113,6 +120,7 @@ describe("AddEntryUseCase", () => {
       {
         [ctx.values.deviceId]: 1,
       },
+      {},
     );
     expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual(
       ctx.saved.localVaultTrustCheckpoint?.payload.snapshotVersionVector,
@@ -286,7 +294,7 @@ describe("AddEntryUseCase", () => {
           ...session.unlockedVault.vault,
           syncTarget: ctx.values.syncTarget,
           syncRemovalPending: {
-            expectedRemoteSnapshotDescriptor: null,
+            expectedRemoteSnapshotIdentity: null,
             rollbackSnapshot,
           },
         },
@@ -426,6 +434,44 @@ describe("AddEntryUseCase", () => {
     );
   });
 
+  it("rejects a descriptor from another vault before extending synchronized state", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValue({
+      vaultId: "other-vault-id",
+      snapshotVersionVector: { [ctx.values.deviceId]: 0 },
+      revisionTimestamp: ctx.values.timestamp - 1,
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBeInstanceOf(RemoteVaultSnapshotIntegrityError);
+
+    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+  });
+
   it("uploads the persisted snapshot before committing a synced vault entry", async () => {
     const ctx = createContext();
     const remoteSnapshotDescriptor = {
@@ -470,7 +516,10 @@ describe("AddEntryUseCase", () => {
           },
         }),
       }),
-      remoteSnapshotDescriptor,
+      {
+        descriptor: remoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
@@ -484,9 +533,383 @@ describe("AddEntryUseCase", () => {
         .invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(
-        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+        ctx.ports.sessionServices.unlockedVaultSession
+          .commitPersistedSnapshotIfSessionIsActive,
       ).mock.invocationCallOrder[0],
     );
+  });
+
+  it.each([
+    ["an outcome-unknown result", { status: "outcome_unknown" }],
+    ["a malformed result", "malformed"],
+  ] as const)(
+    "keeps the local entry and reports pending for %s",
+    async (_description, uploadOutcome) => {
+      const ctx = createContext();
+      const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+        ctx.values.vaultId,
+        ctx.saved.vaultSnapshot!,
+      );
+      const session = ctx.saved.unlockedVaultSession!;
+      ctx.saved.unlockedVaultSession = {
+        ...session,
+        unlockedVault: {
+          ...session.unlockedVault,
+          vault: {
+            ...session.unlockedVault.vault,
+            syncTarget: ctx.values.syncTarget,
+          },
+        },
+      };
+      vi.mocked(
+        ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+      ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+      vi.mocked(
+        ctx.ports.syncProvider.uploadVaultSnapshot,
+      ).mockResolvedValueOnce(uploadOutcome as never);
+
+      const result = await ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "pending@example.com",
+          tags: [],
+          url: "https://example.com/pending",
+        },
+      });
+
+      expect(result.syncUpload).toBe("pending");
+      expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+        [ctx.values.deviceId]: 2,
+      });
+      expect(
+        ctx.saved.vaultSnapshot?.metadata.uploadExpectedRemoteSnapshotIdentity,
+      ).toEqual({
+        descriptor: remoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      });
+      expect(
+        ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries,
+      ).toEqual([
+        expect.objectContaining({
+          id: "entry-id",
+          login: "pending@example.com",
+        }),
+      ]);
+      expect(
+        ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+      ).not.toHaveBeenCalled();
+      expect(
+        ctx.ports.sessionServices.unlockedVaultSession
+          .commitPersistedSnapshotIfSessionIsActive,
+      ).toHaveBeenCalledOnce();
+      await expect(
+        ctx.ports.crypto.decryptDeviceSyncCredentialState(
+          ctx.saved.deviceSyncCredentialState!,
+          ctx.values.deviceLocalProtectionKey,
+          {
+            vaultId: ctx.values.vaultId,
+            deviceId: ctx.values.deviceId,
+            provider: ctx.values.syncTarget.provider,
+            target: ctx.values.syncTarget,
+          },
+        ),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                ctx.saved.vaultSnapshot!,
+              ),
+              snapshotDigest: ctx.saved.vaultSnapshotDigest!,
+            },
+            expectedRemoteSnapshotIdentity: {
+              descriptor: remoteSnapshotDescriptor,
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+          },
+        }),
+      );
+      expect(
+        vi.mocked(
+          ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint,
+        ).mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
+          .invocationCallOrder[0]!,
+      );
+    },
+  );
+
+  it("returns pending when the session is removed after upload start", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.saved.vaultSnapshot!,
+    );
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    let signalUploadStarted: () => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
+    const uploadStarted = new Promise<void>((resolve) => {
+      signalUploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
+          signalUploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entry: {
+        password: maximumStrengthPassword,
+        login: "locked@example.com",
+        tags: [],
+        url: "https://example.com/locked",
+      },
+    });
+    await uploadStarted;
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    resolveUpload({ status: "committed" });
+
+    await expect(execution).resolves.toMatchObject({ syncUpload: "pending" });
+    expect(ctx.saved.unlockedVaultSession).toBeUndefined();
+    expect(ctx.saved.deviceSyncCredentialState).toBeDefined();
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 2,
+    });
+  });
+
+  it("leaves a replacement session untouched after a started upload commits", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.saved.vaultSnapshot!,
+    );
+    const originalSession = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...originalSession,
+      unlockedVault: {
+        ...originalSession.unlockedVault,
+        vault: {
+          ...originalSession.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    let signalUploadStarted: () => void = () => undefined;
+    let resolveUpload: (outcome: SyncUploadOutcome) => void = () => undefined;
+    const uploadStarted = new Promise<void>((resolve) => {
+      signalUploadStarted = resolve;
+    });
+    vi.mocked(
+      ctx.ports.syncProvider.uploadVaultSnapshot,
+    ).mockImplementationOnce(
+      async () =>
+        new Promise<SyncUploadOutcome>((resolve) => {
+          resolveUpload = resolve;
+          signalUploadStarted();
+        }),
+    );
+
+    const execution = ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entry: {
+        password: maximumStrengthPassword,
+        login: "replacement@example.com",
+        tags: [],
+        url: "https://example.com/replacement",
+      },
+    });
+    await uploadStarted;
+    await ctx.ports.sessionServices.unlockedVaultSession.remove();
+    vi.mocked(ctx.ports.ids.generateId).mockResolvedValueOnce(
+      "replacement-session-id",
+    );
+    const activationGeneration =
+      await ctx.ports.sessionServices.unlockedVaultSession.requireVaultCanBeActivated(
+        ctx.values.vaultId,
+      );
+    await ctx.ports.sessionServices.unlockedVaultSession.activate(
+      activationGeneration,
+      originalSession.unlockedVault,
+      originalSession.sourceSnapshotVersionVector,
+    );
+    resolveUpload({ status: "committed" });
+
+    await expect(execution).resolves.toMatchObject({ syncUpload: "pending" });
+    expect(ctx.saved.unlockedVaultSession).toMatchObject({
+      sessionId: "replacement-session-id",
+      sourceSnapshotVersionVector: originalSession.sourceSnapshotVersionVector,
+    });
+  });
+
+  it("blocks a new mutation while an outcome-unknown snapshot upload is pending", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    const unlockedVault = {
+      ...session.unlockedVault,
+      vault: {
+        ...session.unlockedVault.vault,
+        syncTarget: ctx.values.syncTarget,
+      },
+    };
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault,
+    };
+    ctx.saved.deviceSyncCredentialState =
+      await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+        {
+          ...ctx.values.deviceSyncCredentialState,
+          pendingSnapshotUpload: {
+            candidateSnapshotIdentity: {
+              descriptor: toVaultSnapshotDescriptor(
+                ctx.values.vaultId,
+                ctx.saved.vaultSnapshot!,
+              ),
+              snapshotDigest: ctx.values.vaultSnapshotDigest,
+            },
+            expectedRemoteSnapshotIdentity: null,
+          },
+        },
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "blocked@example.com",
+          tags: [],
+          url: "https://example.com/blocked",
+        },
+      }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotAheadError);
+
+    expect(ctx.ports.ids.generateId).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).not.toHaveBeenCalled();
+    expect(ctx.vaultSnapshot.persistUnlockedVault).not.toHaveBeenCalled();
+  });
+
+  it("does not persist over an upload intent staged after mutation preflight", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    const snapshot = ctx.saved.vaultSnapshot!;
+    const checkpoint = ctx.saved.localVaultTrustCheckpoint!;
+    const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      snapshot,
+    );
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockImplementationOnce(async () => {
+      const pendingCredentialState =
+        await ctx.ports.crypto.encryptDeviceSyncCredentialState(
+          {
+            ...ctx.values.deviceSyncCredentialState,
+            pendingSnapshotUpload: {
+              candidateSnapshotIdentity: {
+                descriptor: remoteSnapshotDescriptor,
+                snapshotDigest: ctx.values.vaultSnapshotDigest,
+              },
+              expectedRemoteSnapshotIdentity: {
+                descriptor: remoteSnapshotDescriptor,
+                snapshotDigest: ctx.values.vaultSnapshotDigest,
+              },
+            },
+          },
+          ctx.values.deviceLocalProtectionKey,
+          {
+            vaultId: ctx.values.vaultId,
+            deviceId: ctx.values.deviceId,
+            provider: ctx.values.syncTarget.provider,
+            target: ctx.values.syncTarget,
+          },
+        );
+      await ctx.ports.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
+        expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+        expectedCheckpoint: checkpoint,
+        expectedSyncCredentialState:
+          ctx.values.encryptedDeviceSyncCredentialState,
+        snapshot,
+        checkpoint,
+        syncCredentialState: pendingCredentialState,
+      });
+      return remoteSnapshotDescriptor;
+    });
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "raced@example.com",
+          tags: [],
+          url: "https://example.com/raced",
+        },
+      }),
+    ).rejects.toBeInstanceOf(LocalVaultSnapshotChangedError);
+
+    expect(ctx.saved.vaultSnapshot).toBe(snapshot);
+    await expect(
+      ctx.ports.crypto.decryptDeviceSyncCredentialState(
+        ctx.saved.deviceSyncCredentialState!,
+        ctx.values.deviceLocalProtectionKey,
+        {
+          vaultId: ctx.values.vaultId,
+          deviceId: ctx.values.deviceId,
+          provider: ctx.values.syncTarget.provider,
+          target: ctx.values.syncTarget,
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ pendingSnapshotUpload: expect.any(Object) }),
+    );
+    expect(ctx.ports.syncProvider.uploadVaultSnapshot).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
   });
 
   it("restores the local snapshot and does not commit when synced upload races", async () => {
@@ -513,8 +936,11 @@ describe("AddEntryUseCase", () => {
     vi.mocked(
       ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
     ).mockResolvedValueOnce(remoteSnapshotDescriptor);
-    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockRejectedValueOnce(
-      new RemoteVaultSnapshotChangedError(ctx.values.vaultId),
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      },
     );
 
     await expect(
@@ -550,6 +976,8 @@ describe("AddEntryUseCase", () => {
         }),
       }),
       expect.any(String),
+      expect.any(Object),
+      expect.any(Object),
     );
     const persistedSnapshotDigest = vi.mocked(
       ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
@@ -575,6 +1003,51 @@ describe("AddEntryUseCase", () => {
       }),
     );
     expect(ctx.saved.vaultSnapshotDigest).toBe(ctx.values.vaultSnapshotDigest);
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("restores the local snapshot without reporting a conflict when the provider rejects the upload", async () => {
+    const ctx = createContext();
+    const session = ctx.saved.unlockedVaultSession!;
+    const snapshot = ctx.saved.vaultSnapshot!;
+
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(
+      toVaultSnapshotDescriptor(ctx.values.vaultId, snapshot),
+    );
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "definitely_not_committed",
+        reason: "provider_rejected",
+      },
+    );
+
+    await expect(
+      ctx.useCase.execute({
+        vaultId: ctx.values.vaultId,
+        entry: {
+          password: maximumStrengthPassword,
+          login: "user@example.com",
+          tags: [],
+          url: "https://example.com/login",
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyncProviderUploadRejectedError);
+
+    expect(ctx.saved.vaultSnapshot).toEqual(snapshot);
     expect(
       ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
     ).not.toHaveBeenCalled();
@@ -667,7 +1140,10 @@ describe("AddEntryUseCase", () => {
         originalSession.sourceSnapshotVersionVector,
       );
 
-      throw new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
     });
 
     await expect(
@@ -733,7 +1209,10 @@ describe("AddEntryUseCase", () => {
           snapshotDigest: concurrentSnapshotDigest,
         },
       };
-      throw new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
     });
 
     await expect(
@@ -773,7 +1252,6 @@ describe("AddEntryUseCase", () => {
       revisionTimestamp: ctx.values.timestamp,
     };
     const session = ctx.saved.unlockedVaultSession!;
-    const uploadError = new RemoteVaultSnapshotChangedError(ctx.values.vaultId);
 
     ctx.saved.unlockedVaultSession = {
       ...session,
@@ -795,7 +1273,10 @@ describe("AddEntryUseCase", () => {
         ctx.ports.unlockedVaultSessionMaterialRepository
           .getUnlockedVaultSessionMaterial,
       ).mockRejectedValueOnce(new Error("material read failed"));
-      throw uploadError;
+      return {
+        status: "definitely_not_committed",
+        reason: "remote_snapshot_changed",
+      };
     });
 
     await expect(
@@ -810,7 +1291,9 @@ describe("AddEntryUseCase", () => {
       }),
     ).rejects.toMatchObject({
       name: "PersistedVaultRollbackIncompleteError",
-      cause: uploadError,
+      cause: expect.objectContaining({
+        name: "RemoteVaultSnapshotChangedError",
+      }),
     });
 
     expect(

--- a/packages/core/src/use-cases/vault-entries/add-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/add-entry.ts
@@ -11,6 +11,7 @@ import type { VaultSnapshotService } from "../../services/snapshot/vault-snapsho
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { VaultSyncGuardService } from "../../services/sync";
 import { calculatePasswordStrength } from "../../lib/password-strength/password-strength.utils";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type AddEntryCommandParams = {
   vaultId: string;
@@ -27,6 +28,7 @@ export type AddEntryResult = {
   entryId: string;
   snapshotVersionVector: VersionVector;
   revisionTimestamp: number;
+  syncUpload: SyncUploadStatus;
 };
 
 export class AddEntryUseCase {
@@ -114,40 +116,63 @@ export class AddEntryUseCase {
               params.vaultId,
               updatedUnlockedVault,
               sourceSnapshotVersionVector,
+              syncState.remoteSnapshotIdentity === undefined
+                ? {}
+                : {
+                    uploadExpectedRemoteSnapshotIdentity:
+                      syncState.remoteSnapshotIdentity,
+                    expectedSyncCredentialState: syncState.syncCredentialState,
+                    syncCredentialState: syncState.syncCredentialState,
+                  },
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
+    let syncUpload: SyncUploadStatus = "complete";
+
     if (syncState.syncAccess !== undefined) {
       if (preparedRestore === undefined) {
         throw new Error("Synchronized mutation rollback was not prepared.");
       }
 
-      await this.vaultSyncGuard.uploadPersistedLocalMutation(
+      syncUpload = await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
         persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        persistedSnapshot.checkpoint,
+        updatedUnlockedVault,
         preparedRestore,
         sessionId,
       );
     }
 
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...updatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
+    const committedUnlockedVault = {
+      ...updatedUnlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    };
+
+    if (syncState.syncAccess === undefined) {
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    } else {
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    }
 
     return {
       entryId,
       snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
       revisionTimestamp: persistedSnapshot.revisionTimestamp,
+      syncUpload,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.test.ts
@@ -8,6 +8,7 @@ import {
   secondPasswordEntry,
   standardPasswordEntries,
 } from "../../__tests__/fixtures/vault-entries";
+import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import { PasswordEntryNotFoundError } from "../../errors/vault-entry.errors";
 import { VaultMustBeUnlockedError } from "../../errors/vault-session.errors";
 import { VaultSyncGuardService } from "../../services/sync";
@@ -55,6 +56,7 @@ describe("RemoveEntryUseCase", () => {
         [ctx.values.deviceId]: 2,
       },
       revisionTimestamp: ctx.values.timestamp + 1,
+      syncUpload: "complete",
     });
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [secondPasswordEntry],
@@ -74,6 +76,7 @@ describe("RemoveEntryUseCase", () => {
       {
         [ctx.values.deviceId]: 1,
       },
+      {},
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
@@ -124,16 +127,67 @@ describe("RemoveEntryUseCase", () => {
           },
         }),
       }),
-      remoteSnapshotDescriptor,
+      {
+        descriptor: remoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
     expect(
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(
-        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+        ctx.ports.sessionServices.unlockedVaultSession
+          .commitPersistedSnapshotIfSessionIsActive,
       ).mock.invocationCallOrder[0],
     );
+  });
+
+  it("keeps the local removal and reports pending when the upload outcome is unknown", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.saved.vaultSnapshot!,
+    );
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entryId: firstPasswordEntry.id,
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
+      [secondPasswordEntry],
+    );
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 2,
+    });
+    expect(
+      ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
   });
 
   it("fails when the target vault is not unlocked", async () => {

--- a/packages/core/src/use-cases/vault-entries/remove-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/remove-entry.ts
@@ -5,6 +5,7 @@ import type { VaultSnapshotService } from "../../services/snapshot/vault-snapsho
 import type { ClockPort } from "../../ports/system/clock.port";
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { VaultSyncGuardService } from "../../services/sync";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type RemoveEntryCommandParams = {
   vaultId: string;
@@ -15,6 +16,7 @@ export type RemoveEntryResult = {
   entryId: string;
   snapshotVersionVector: VersionVector;
   revisionTimestamp: number;
+  syncUpload: SyncUploadStatus;
 };
 
 export class RemoveEntryUseCase {
@@ -82,40 +84,63 @@ export class RemoveEntryUseCase {
               params.vaultId,
               updatedUnlockedVault,
               sourceSnapshotVersionVector,
+              syncState.remoteSnapshotIdentity === undefined
+                ? {}
+                : {
+                    uploadExpectedRemoteSnapshotIdentity:
+                      syncState.remoteSnapshotIdentity,
+                    expectedSyncCredentialState: syncState.syncCredentialState,
+                    syncCredentialState: syncState.syncCredentialState,
+                  },
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
+    let syncUpload: SyncUploadStatus = "complete";
+
     if (syncState.syncAccess !== undefined) {
       if (preparedRestore === undefined) {
         throw new Error("Synchronized mutation rollback was not prepared.");
       }
 
-      await this.vaultSyncGuard.uploadPersistedLocalMutation(
+      syncUpload = await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
         persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        persistedSnapshot.checkpoint,
+        updatedUnlockedVault,
         preparedRestore,
         sessionId,
       );
     }
 
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...updatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
+    const committedUnlockedVault = {
+      ...updatedUnlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    };
+
+    if (syncState.syncAccess === undefined) {
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    } else {
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    }
 
     return {
       entryId: params.entryId,
       snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
       revisionTimestamp: persistedSnapshot.revisionTimestamp,
+      syncUpload,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-entries/update-entry.test.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.test.ts
@@ -9,6 +9,7 @@ import {
   secondPasswordEntry,
   standardPasswordEntries,
 } from "../../__tests__/fixtures/vault-entries";
+import { toVaultSnapshotDescriptor } from "../../domain/snapshot";
 import {
   InvalidEntryUrlError,
   InvalidPasswordEntryError,
@@ -69,6 +70,7 @@ describe("UpdateEntryUseCase", () => {
         [ctx.values.deviceId]: 2,
       },
       revisionTimestamp: ctx.values.timestamp + 1,
+      syncUpload: "complete",
     });
     expect(ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries).toEqual(
       [
@@ -105,6 +107,7 @@ describe("UpdateEntryUseCase", () => {
       {
         [ctx.values.deviceId]: 1,
       },
+      {},
     );
     expect(
       vi.mocked(ctx.vaultSnapshot.persistUnlockedVault).mock
@@ -217,16 +220,73 @@ describe("UpdateEntryUseCase", () => {
           },
         }),
       }),
-      remoteSnapshotDescriptor,
+      {
+        descriptor: remoteSnapshotDescriptor,
+        snapshotDigest: ctx.values.vaultSnapshotDigest,
+      },
     );
     expect(
       vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mock
         .invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(
-        ctx.ports.sessionServices.unlockedVaultSession.commitPersistedSnapshot,
+        ctx.ports.sessionServices.unlockedVaultSession
+          .commitPersistedSnapshotIfSessionIsActive,
       ).mock.invocationCallOrder[0],
     );
+  });
+
+  it("keeps the local update and reports pending when the upload outcome is unknown", async () => {
+    const ctx = createContext();
+    const remoteSnapshotDescriptor = toVaultSnapshotDescriptor(
+      ctx.values.vaultId,
+      ctx.saved.vaultSnapshot!,
+    );
+    const session = ctx.saved.unlockedVaultSession!;
+    ctx.saved.unlockedVaultSession = {
+      ...session,
+      unlockedVault: {
+        ...session.unlockedVault,
+        vault: {
+          ...session.unlockedVault.vault,
+          syncTarget: ctx.values.syncTarget,
+        },
+      },
+    };
+    vi.mocked(
+      ctx.ports.syncProvider.getLatestVaultSnapshotDescriptor,
+    ).mockResolvedValueOnce(remoteSnapshotDescriptor);
+    vi.mocked(ctx.ports.syncProvider.uploadVaultSnapshot).mockResolvedValueOnce(
+      {
+        status: "outcome_unknown",
+      },
+    );
+
+    const result = await ctx.useCase.execute({
+      vaultId: ctx.values.vaultId,
+      entryId: firstPasswordEntry.id,
+      entry: {
+        password: maximumStrengthPassword,
+        login: "pending@example.com",
+        tags: [],
+        url: "https://example.com/pending",
+      },
+    });
+
+    expect(result.syncUpload).toBe("pending");
+    expect(
+      ctx.saved.unlockedVaultSession?.unlockedVault.vault.entries[0]?.login,
+    ).toBe("pending@example.com");
+    expect(ctx.saved.vaultSnapshot?.metadata.snapshotVersionVector).toEqual({
+      [ctx.values.deviceId]: 2,
+    });
+    expect(
+      ctx.vaultSnapshot.restorePreparedLocalVaultSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(
+      ctx.ports.sessionServices.unlockedVaultSession
+        .commitPersistedSnapshotIfSessionIsActive,
+    ).toHaveBeenCalledOnce();
   });
 
   it.each([undefined, true])(

--- a/packages/core/src/use-cases/vault-entries/update-entry.ts
+++ b/packages/core/src/use-cases/vault-entries/update-entry.ts
@@ -11,6 +11,7 @@ import type { VaultSnapshotService } from "../../services/snapshot/vault-snapsho
 import type { VersionVector } from "../../domain/versioning/version-vector.type";
 import type { VaultSyncGuardService } from "../../services/sync";
 import { calculatePasswordStrength } from "../../lib/password-strength/password-strength.utils";
+import type { SyncUploadStatus } from "../../domain/sync/sync-upload-status.type";
 
 export type UpdateEntryCommandParams = {
   vaultId: string;
@@ -28,6 +29,7 @@ export type UpdateEntryResult = {
   entryId: string;
   snapshotVersionVector: VersionVector;
   revisionTimestamp: number;
+  syncUpload: SyncUploadStatus;
 };
 
 export class UpdateEntryUseCase {
@@ -118,40 +120,63 @@ export class UpdateEntryUseCase {
               params.vaultId,
               updatedUnlockedVault,
               sourceSnapshotVersionVector,
+              syncState.remoteSnapshotIdentity === undefined
+                ? {}
+                : {
+                    uploadExpectedRemoteSnapshotIdentity:
+                      syncState.remoteSnapshotIdentity,
+                    expectedSyncCredentialState: syncState.syncCredentialState,
+                    syncCredentialState: syncState.syncCredentialState,
+                  },
             );
 
           return { persistedSnapshot, preparedRestore };
         },
       );
 
+    let syncUpload: SyncUploadStatus = "complete";
+
     if (syncState.syncAccess !== undefined) {
       if (preparedRestore === undefined) {
         throw new Error("Synchronized mutation rollback was not prepared.");
       }
 
-      await this.vaultSyncGuard.uploadPersistedLocalMutation(
+      syncUpload = await this.vaultSyncGuard.uploadPersistedLocalMutation(
         params.vaultId,
         syncState,
         persistedSnapshot.snapshot,
         persistedSnapshot.trustedSnapshotContext.snapshotDigest,
+        persistedSnapshot.checkpoint,
+        updatedUnlockedVault,
         preparedRestore,
         sessionId,
       );
     }
 
-    await this.unlockedVaultSession.commitPersistedSnapshot(
-      sessionId,
-      {
-        ...updatedUnlockedVault,
-        trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
-      },
-      persistedSnapshot.snapshotVersionVector,
-    );
+    const committedUnlockedVault = {
+      ...updatedUnlockedVault,
+      trustedSnapshotContext: persistedSnapshot.trustedSnapshotContext,
+    };
+
+    if (syncState.syncAccess === undefined) {
+      await this.unlockedVaultSession.commitPersistedSnapshot(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    } else {
+      await this.unlockedVaultSession.commitPersistedSnapshotIfSessionIsActive(
+        sessionId,
+        committedUnlockedVault,
+        persistedSnapshot.snapshotVersionVector,
+      );
+    }
 
     return {
       entryId: params.entryId,
       snapshotVersionVector: persistedSnapshot.snapshotVersionVector,
       revisionTimestamp: persistedSnapshot.revisionTimestamp,
+      syncUpload,
     };
   }
 }

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -254,8 +254,18 @@ describe("InitializeVaultUseCase", () => {
     ).rejects.toThrow("session failed");
 
     expect(
-      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches,
-    ).toHaveBeenCalledWith(ctx.values.vaultId, ctx.values.vaultSnapshotDigest);
+      ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vaultId: ctx.values.vaultId,
+        expectedDescriptor: expect.any(Object),
+        expectedDeviceAccessMaterial: expect.any(Object),
+        expectedDeviceAccessRecoveryBackup: expect.any(Object),
+        expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
+        expectedCheckpoint: expect.any(Object),
+        expectedSyncCredentialState: null,
+      }),
+    );
     expect(ctx.ports.scheduledTasks.cancelTask).toHaveBeenCalledWith({
       name: "lockVault",
       actionId: ctx.values.vaultLockActionId,

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.test.ts
@@ -253,16 +253,25 @@ describe("InitializeVaultUseCase", () => {
       }),
     ).rejects.toThrow("session failed");
 
+    const initializedParams = vi.mocked(
+      ctx.ports.vaultLocalRepository.saveInitializedLocalVault,
+    ).mock.calls[0]?.[0];
+
+    if (initializedParams === undefined) {
+      throw new Error("Expected initialized vault records.");
+    }
+
     expect(
       ctx.ports.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch,
     ).toHaveBeenCalledWith(
       expect.objectContaining({
         vaultId: ctx.values.vaultId,
-        expectedDescriptor: expect.any(Object),
-        expectedDeviceAccessMaterial: expect.any(Object),
-        expectedDeviceAccessRecoveryBackup: expect.any(Object),
+        expectedDescriptor: initializedParams.descriptor,
+        expectedDeviceAccessMaterial: initializedParams.deviceAccessMaterial,
+        expectedDeviceAccessRecoveryBackup:
+          initializedParams.deviceAccessRecoveryBackup,
         expectedSnapshotDigest: ctx.values.vaultSnapshotDigest,
-        expectedCheckpoint: expect.any(Object),
+        expectedCheckpoint: initializedParams.checkpoint,
         expectedSyncCredentialState: null,
       }),
     );

--- a/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/initialize-vault.ts
@@ -313,9 +313,17 @@ export class InitializeVaultUseCase {
             checkpoint,
           }),
         rollbackPreparedActivation: async () => {
-          await this.vaultLocalRepository.removePersistedLocalVaultIfSnapshotMatches(
-            vaultId,
-            unlockedVault.trustedSnapshotContext.snapshotDigest,
+          await this.vaultLocalRepository.removePersistedLocalVaultIfArtifactsMatch(
+            {
+              vaultId,
+              expectedDescriptor: localVaultDescriptor,
+              expectedDeviceAccessMaterial: deviceAccessMaterial,
+              expectedDeviceAccessRecoveryBackup: deviceAccessRecoveryBackup,
+              expectedSnapshotDigest:
+                unlockedVault.trustedSnapshotContext.snapshotDigest,
+              expectedCheckpoint: checkpoint,
+              expectedSyncCredentialState: null,
+            },
           );
         },
       });

--- a/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
+++ b/packages/core/src/use-cases/vault-lifecycle/unlock-vault.ts
@@ -282,6 +282,7 @@ export class UnlockVaultUseCase {
       if (checkpointRelation === "newer") {
         await this.vaultLocalRepository.saveVaultSnapshotWithCheckpoint({
           expectedSnapshotDigest: snapshotDigest,
+          expectedCheckpoint: checkpoint,
           snapshot: vaultSnapshot,
           checkpoint: await this.vaultTrust.createCheckpoint(
             vaultSnapshot,


### PR DESCRIPTION
## Summary

- enforce exact snapshot identity and trusted checkpoint checks across sync, conflict resolution, and device-trust workflows
- make persisted mutations, pending upload recovery, credential rotation, and session handoff rollback-safe with atomic CAS boundaries
- introduce phase-aware provider outcomes and conditional S3 upload/removal semantics, including uncertain post-start outcomes
- align security, design, and use-case documentation with the implemented multi-device lifecycle

## Validation

- core type-check
- 729 core tests
- extension type-check
- 407 extension tests
- extension lint
- extension production build
- git diff --check
- two consecutive clean independent review rounds followed by a no-change simplification audit

## Residual risk

- live AWS S3 conditional-write behavior was not exercised; adapter behavior is covered with mocked SDK tests
- fully coordinated local-storage rollback/ABA cannot be detected without an external trusted monotonic witness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sync operations now report whether uploads are **complete** or **pending**.
  - Added safer retry and reconciliation handling for uncertain upload results.
  - Snapshot reviews and sync changes now verify both snapshot details and cryptographic identity.
  - Device enrollment, revocation, vault changes, and sync setup now preserve pending work when completion cannot be confirmed.

- **Bug Fixes**
  - Prevented stale or mismatched local data from overwriting or deleting newer vault state.
  - Improved rollback and cleanup to avoid removing records that have changed concurrently.
  - Added clearer handling for provider rejections, conflicts, and integrity errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->