### PR TITLE
fix(extension): repair offscreen clipboard bridge

### DIFF
--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type ChromeOffscreenApi,
   type ChromeRuntimeMessenger,
-  type OffscreenClientDirectory,
   OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
   OFFSCREEN_CLIPBOARD_REASON,
   OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
@@ -17,55 +16,35 @@ function createContext(documentExists = false) {
   };
   let nextResponse: unknown;
   let respond = true;
-  const postMessage = vi.fn(
-    (request: { readonly operation?: unknown }, transfer: Transferable[]) => {
-      const responsePort = transfer[0];
+  const sendMessage = vi.fn((request: unknown): Promise<unknown> => {
+    if (!respond) {
+      return new Promise(() => undefined);
+    }
 
-      if (!(responsePort instanceof MessagePort)) {
-        throw new Error("Expected a response message port.");
-      }
-
-      if (!respond) {
-        return;
-      }
-
-      responsePort.postMessage(
-        nextResponse ??
-          (request.operation === "read"
-            ? { ok: true, value: "clipboard-value" }
-            : { ok: true }),
-      );
-      nextResponse = undefined;
-    },
-  );
-  const otherClientPostMessage = vi.fn();
+    const operation =
+      typeof request === "object" && request !== null
+        ? (request as Record<string, unknown>).operation
+        : undefined;
+    const response =
+      nextResponse ??
+      (operation === "read"
+        ? { ok: true, value: "clipboard-value" }
+        : { ok: true });
+    nextResponse = undefined;
+    return Promise.resolve(response);
+  });
   const documentUrl = "chrome-extension://extension-id/offscreen.html";
-  const matchAll = vi.fn(async () => [
-    {
-      url: "chrome-extension://extension-id/options.html",
-      postMessage: otherClientPostMessage,
-    },
-    { url: documentUrl, postMessage },
-  ]);
-  const clients: OffscreenClientDirectory = { matchAll };
   const getContexts = vi.fn(async () =>
     documentExists ? [{ contextType: OFFSCREEN_DOCUMENT_CONTEXT }] : [],
   );
-  const runtime: ChromeRuntimeMessenger = { getContexts };
-  const clipboard = new OffscreenClipboard(
-    offscreen,
-    runtime,
-    documentUrl,
-    clients,
-  );
+  const runtime: ChromeRuntimeMessenger = { getContexts, sendMessage };
+  const clipboard = new OffscreenClipboard(offscreen, runtime, documentUrl);
 
   return {
     clipboard,
     createDocument,
     getContexts,
-    matchAll,
-    otherClientPostMessage,
-    postMessage,
+    sendMessage,
     setNextResponse(response: unknown) {
       nextResponse = response;
     },
@@ -90,14 +69,9 @@ describe("OffscreenClipboard", () => {
       contextTypes: [OFFSCREEN_DOCUMENT_CONTEXT],
       documentUrls: ["chrome-extension://extension-id/offscreen.html"],
     });
-    expect(ctx.postMessage.mock.calls[0]?.[0]).toEqual({
+    expect(ctx.sendMessage).toHaveBeenCalledWith({
       target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "read",
-    });
-    expect(ctx.otherClientPostMessage).not.toHaveBeenCalled();
-    expect(ctx.matchAll).toHaveBeenCalledWith({
-      includeUncontrolled: true,
-      type: "window",
     });
   });
 
@@ -109,7 +83,7 @@ describe("OffscreenClipboard", () => {
     ).resolves.toBeUndefined();
 
     expect(ctx.createDocument).not.toHaveBeenCalled();
-    expect(ctx.postMessage.mock.calls[0]?.[0]).toEqual({
+    expect(ctx.sendMessage).toHaveBeenCalledWith({
       target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "write",
       value: "next-value",
@@ -128,12 +102,25 @@ describe("OffscreenClipboard", () => {
     );
   });
 
-  it("rejects when the offscreen document client is unavailable", async () => {
+  it("rejects when runtime messaging cannot reach the offscreen document", async () => {
     const ctx = createContext(true);
-    ctx.matchAll.mockResolvedValueOnce([]);
+    ctx.sendMessage.mockRejectedValueOnce(
+      new Error("Receiving end does not exist."),
+    );
 
     await expect(ctx.clipboard.readText()).rejects.toThrow(
-      "Offscreen clipboard document client is unavailable.",
+      "Receiving end does not exist.",
+    );
+  });
+
+  it("rejects a synchronous runtime messaging failure", async () => {
+    const ctx = createContext(true);
+    ctx.sendMessage.mockImplementationOnce(() => {
+      throw new Error("Runtime messaging is unavailable.");
+    });
+
+    await expect(ctx.clipboard.readText()).rejects.toThrow(
+      "Runtime messaging is unavailable.",
     );
   });
 
@@ -164,5 +151,28 @@ describe("OffscreenClipboard", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps concurrent runtime responses associated with their requests", async () => {
+    const ctx = createContext(true);
+    let resolveFirstResponse:
+      | ((response: { readonly ok: true; readonly value: string }) => void)
+      | undefined;
+    const firstResponse = new Promise<{
+      readonly ok: true;
+      readonly value: string;
+    }>((resolve) => {
+      resolveFirstResponse = resolve;
+    });
+    ctx.sendMessage
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValueOnce({ ok: true, value: "second-value" });
+
+    const firstRead = ctx.clipboard.readText();
+    const secondRead = ctx.clipboard.readText();
+
+    await expect(secondRead).resolves.toBe("second-value");
+    resolveFirstResponse?.({ ok: true, value: "first-value" });
+    await expect(firstRead).resolves.toBe("first-value");
   });
 });

--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.test.ts
@@ -72,6 +72,7 @@ describe("OffscreenClipboard", () => {
     expect(ctx.sendMessage).toHaveBeenCalledWith({
       target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "read",
+      deadlineEpochMs: expect.any(Number),
     });
   });
 
@@ -87,6 +88,7 @@ describe("OffscreenClipboard", () => {
       target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "write",
       value: "next-value",
+      deadlineEpochMs: expect.any(Number),
     });
   });
 

--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
@@ -36,33 +36,8 @@ export type ChromeRuntimeMessenger = {
     readonly contextTypes: chrome.runtime.ContextType[];
     readonly documentUrls: string[];
   }) => Promise<readonly unknown[]>;
+  sendMessage: (message: unknown) => Promise<unknown>;
 };
-
-export type OffscreenDocumentClient = {
-  readonly url: string;
-  postMessage(message: unknown, transfer: Transferable[]): void;
-};
-
-export type OffscreenClientDirectory = {
-  matchAll(options: {
-    readonly includeUncontrolled: true;
-    readonly type: "window";
-  }): Promise<readonly OffscreenDocumentClient[]>;
-};
-
-type MessageChannelFactory = () => MessageChannel;
-
-function getServiceWorkerClients(): OffscreenClientDirectory {
-  const serviceWorkerScope = globalThis as typeof globalThis & {
-    readonly clients?: OffscreenClientDirectory;
-  };
-
-  if (serviceWorkerScope.clients === undefined) {
-    throw new Error("Offscreen clipboard requires a service-worker context.");
-  }
-
-  return serviceWorkerScope.clients;
-}
 
 function isOffscreenClipboardResponse(
   response: unknown,
@@ -84,22 +59,16 @@ export class OffscreenClipboard implements ClipboardPort {
   private readonly offscreen: ChromeOffscreenApi;
   private readonly runtime: ChromeRuntimeMessenger;
   private readonly documentUrl: string;
-  private readonly clients: OffscreenClientDirectory;
-  private readonly createMessageChannel: MessageChannelFactory;
   private documentCreation: Promise<void> | undefined;
 
   constructor(
     offscreen: ChromeOffscreenApi = chrome.offscreen,
     runtime: ChromeRuntimeMessenger = chrome.runtime,
     documentUrl = chrome.runtime.getURL(OFFSCREEN_CLIPBOARD_DOCUMENT_PATH),
-    clients: OffscreenClientDirectory = getServiceWorkerClients(),
-    createMessageChannel: MessageChannelFactory = () => new MessageChannel(),
   ) {
     this.offscreen = offscreen;
     this.runtime = runtime;
     this.documentUrl = documentUrl;
-    this.clients = clients;
-    this.createMessageChannel = createMessageChannel;
   }
 
   async readText(): Promise<string> {
@@ -139,53 +108,46 @@ export class OffscreenClipboard implements ClipboardPort {
   private async sendToOffscreenDocument(
     request: OffscreenClipboardRequest,
   ): Promise<OffscreenClipboardResponse> {
-    const documentClients = await this.clients.matchAll({
-      includeUncontrolled: true,
-      type: "window",
-    });
-    const documentClient = documentClients.find(
-      (candidate) => candidate.url === this.documentUrl,
-    );
-
-    if (documentClient === undefined) {
-      throw new Error("Offscreen clipboard document client is unavailable.");
-    }
-
     return new Promise((resolve, reject) => {
-      const channel = this.createMessageChannel();
+      let completed = false;
       const responseTimeout = globalThis.setTimeout(() => {
-        channel.port1.close();
+        completed = true;
         reject(new Error("Offscreen clipboard response timed out."));
       }, OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS);
 
-      const closeResponsePort = () => {
-        globalThis.clearTimeout(responseTimeout);
-        channel.port1.close();
-      };
-
-      channel.port1.onmessage = (event) => {
-        closeResponsePort();
-
-        if (!isOffscreenClipboardResponse(event.data)) {
-          reject(
-            new Error("Offscreen clipboard returned an invalid response."),
-          );
+      const complete = (callback: () => void) => {
+        if (completed) {
           return;
         }
 
-        resolve(event.data);
-      };
-      channel.port1.onmessageerror = () => {
-        closeResponsePort();
-        reject(new Error("Offscreen clipboard response could not be decoded."));
+        completed = true;
+        globalThis.clearTimeout(responseTimeout);
+        callback();
       };
 
-      try {
-        documentClient.postMessage(request, [channel.port2]);
-      } catch (error) {
-        closeResponsePort();
-        reject(error);
-      }
+      void Promise.resolve()
+        .then(() => this.runtime.sendMessage(request))
+        .then(
+          (response) => {
+            complete(() => {
+              if (!isOffscreenClipboardResponse(response)) {
+                reject(
+                  new Error(
+                    "Offscreen clipboard returned an invalid response.",
+                  ),
+                );
+                return;
+              }
+
+              resolve(response);
+            });
+          },
+          (error: unknown) => {
+            complete(() => {
+              reject(error);
+            });
+          },
+        );
     });
   }
 

--- a/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
+++ b/apps/extension/src/adapters/clipboard/offscreen-clipboard.ts
@@ -8,16 +8,19 @@ export const OFFSCREEN_DOCUMENT_CONTEXT =
   "OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType;
 export const OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS = 5_000;
 
-export type OffscreenClipboardRequest =
+type OffscreenClipboardOperation =
   | {
-      readonly target: typeof OFFSCREEN_CLIPBOARD_MESSAGE_TARGET;
       readonly operation: "read";
     }
   | {
-      readonly target: typeof OFFSCREEN_CLIPBOARD_MESSAGE_TARGET;
       readonly operation: "write";
       readonly value: string;
     };
+
+export type OffscreenClipboardRequest = OffscreenClipboardOperation & {
+  readonly target: typeof OFFSCREEN_CLIPBOARD_MESSAGE_TARGET;
+  readonly deadlineEpochMs: number;
+};
 
 export type OffscreenClipboardResponse =
   | { readonly ok: true; readonly value?: string }
@@ -73,7 +76,6 @@ export class OffscreenClipboard implements ClipboardPort {
 
   async readText(): Promise<string> {
     const response = await this.send({
-      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "read",
     });
 
@@ -86,16 +88,20 @@ export class OffscreenClipboard implements ClipboardPort {
 
   async writeText(value: string): Promise<void> {
     await this.send({
-      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "write",
       value,
     });
   }
 
   private async send(
-    request: OffscreenClipboardRequest,
+    operation: OffscreenClipboardOperation,
   ): Promise<{ readonly ok: true; readonly value?: string }> {
     await this.ensureDocument();
+    const request: OffscreenClipboardRequest = {
+      ...operation,
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      deadlineEpochMs: Date.now() + OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
+    };
     const response = await this.sendToOffscreenDocument(request);
 
     if (!response.ok) {

--- a/apps/extension/src/extension/offscreen/clipboard-document.test.ts
+++ b/apps/extension/src/extension/offscreen/clipboard-document.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   type ClipboardCommandExecutor,
+  type ClipboardCopyEventTarget,
   type ClipboardTransferControl,
   readClipboardText,
   writeClipboardText,
@@ -38,30 +39,100 @@ describe("offscreen clipboard document", () => {
 
   it("writes through the selected transfer control and clears plaintext", () => {
     const transferControl = createControl();
-    const observedValues: string[] = [];
-    const commandExecutor: ClipboardCommandExecutor = {
-      execCommand: vi.fn(() => {
-        observedValues.push(transferControl.value);
-        return true;
-      }),
-    };
+    let copyListener: ((event: ClipboardEvent) => void) | undefined;
+    const setData = vi.fn();
+    const preventDefault = vi.fn();
+    const commandExecutor: ClipboardCommandExecutor & ClipboardCopyEventTarget =
+      {
+        addEventListener: vi.fn((_type, listener) => {
+          copyListener = listener;
+        }),
+        execCommand: vi.fn(() => {
+          copyListener?.({
+            clipboardData: { setData },
+            preventDefault,
+          } as unknown as ClipboardEvent);
+          return true;
+        }),
+        removeEventListener: vi.fn(),
+      };
 
     writeClipboardText(commandExecutor, transferControl, "password");
 
-    expect(observedValues).toEqual(["password"]);
+    expect(setData).toHaveBeenCalledWith("text/plain", "password");
+    expect(preventDefault).toHaveBeenCalledOnce();
     expect(commandExecutor.execCommand).toHaveBeenCalledWith("copy");
+    expect(commandExecutor.removeEventListener).toHaveBeenCalledWith(
+      "copy",
+      copyListener,
+    );
+    expect(transferControl.value).toBe("");
+  });
+
+  it("overwrites the clipboard with an exact empty value", () => {
+    const transferControl = createControl();
+    let copyListener: ((event: ClipboardEvent) => void) | undefined;
+    const setData = vi.fn();
+    const commandExecutor: ClipboardCommandExecutor & ClipboardCopyEventTarget =
+      {
+        addEventListener: vi.fn((_type, listener) => {
+          copyListener = listener;
+        }),
+        execCommand: vi.fn(() => {
+          expect(transferControl.value).toBe(" ");
+          copyListener?.({
+            clipboardData: { setData },
+            preventDefault: vi.fn(),
+          } as unknown as ClipboardEvent);
+          return true;
+        }),
+        removeEventListener: vi.fn(),
+      };
+
+    writeClipboardText(commandExecutor, transferControl, "");
+
+    expect(setData).toHaveBeenCalledWith("text/plain", "");
     expect(transferControl.value).toBe("");
   });
 
   it("clears plaintext when the browser rejects a clipboard command", () => {
     const transferControl = createControl();
-    const commandExecutor: ClipboardCommandExecutor = {
-      execCommand: vi.fn(() => false),
-    };
+    const commandExecutor: ClipboardCommandExecutor & ClipboardCopyEventTarget =
+      {
+        addEventListener: vi.fn(),
+        execCommand: vi.fn(() => false),
+        removeEventListener: vi.fn(),
+      };
 
     expect(() =>
       writeClipboardText(commandExecutor, transferControl, "password"),
     ).toThrow("Clipboard copy command failed.");
+    expect(commandExecutor.removeEventListener).toHaveBeenCalledOnce();
+    expect(transferControl.value).toBe("");
+  });
+
+  it("rejects a copy event without writable clipboard data", () => {
+    const transferControl = createControl();
+    let copyListener: ((event: ClipboardEvent) => void) | undefined;
+    const commandExecutor: ClipboardCommandExecutor & ClipboardCopyEventTarget =
+      {
+        addEventListener: vi.fn((_type, listener) => {
+          copyListener = listener;
+        }),
+        execCommand: vi.fn(() => {
+          copyListener?.({
+            clipboardData: null,
+            preventDefault: vi.fn(),
+          } as unknown as ClipboardEvent);
+          return true;
+        }),
+        removeEventListener: vi.fn(),
+      };
+
+    expect(() =>
+      writeClipboardText(commandExecutor, transferControl, "password"),
+    ).toThrow("Clipboard copy event did not expose writable data.");
+    expect(commandExecutor.removeEventListener).toHaveBeenCalledOnce();
     expect(transferControl.value).toBe("");
   });
 

--- a/apps/extension/src/extension/offscreen/clipboard-document.ts
+++ b/apps/extension/src/extension/offscreen/clipboard-document.ts
@@ -8,6 +8,17 @@ export interface ClipboardCommandExecutor {
   execCommand(command: "copy" | "paste"): boolean;
 }
 
+export interface ClipboardCopyEventTarget {
+  addEventListener(
+    type: "copy",
+    listener: (event: ClipboardEvent) => void,
+  ): void;
+  removeEventListener(
+    type: "copy",
+    listener: (event: ClipboardEvent) => void,
+  ): void;
+}
+
 function executeClipboardCommand(
   commandExecutor: ClipboardCommandExecutor,
   transferControl: ClipboardTransferControl,
@@ -36,15 +47,32 @@ export function readClipboardText(
 }
 
 export function writeClipboardText(
-  commandExecutor: ClipboardCommandExecutor,
+  commandExecutor: ClipboardCommandExecutor & ClipboardCopyEventTarget,
   transferControl: ClipboardTransferControl,
   value: string,
 ): void {
-  transferControl.value = value;
+  let copiedExactValue = false;
+  const handleCopy = (event: ClipboardEvent) => {
+    if (event.clipboardData === null) {
+      return;
+    }
+
+    event.clipboardData.setData("text/plain", value);
+    event.preventDefault();
+    copiedExactValue = true;
+  };
+
+  commandExecutor.addEventListener("copy", handleCopy);
+  transferControl.value = value.length === 0 ? " " : value;
 
   try {
     executeClipboardCommand(commandExecutor, transferControl, "copy");
+
+    if (!copiedExactValue) {
+      throw new Error("Clipboard copy event did not expose writable data.");
+    }
   } finally {
+    commandExecutor.removeEventListener("copy", handleCopy);
     transferControl.value = "";
   }
 }

--- a/apps/extension/src/extension/offscreen/offscreen.test.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   OFFSCREEN_CLIPBOARD_DOCUMENT_PATH,
   OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+  OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
 } from "../../adapters/clipboard/offscreen-clipboard";
 
 class FakeTextAreaElement {
@@ -91,10 +92,82 @@ describe("offscreen clipboard bridge", () => {
       target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
       operation: "write",
       value: "bridge-value",
+      deadlineEpochMs: expect.any(Number),
     });
     expect(execCommand).toHaveBeenCalledWith("copy");
     expect(addDocumentEventListener).toHaveBeenCalledOnce();
     expect(removeDocumentEventListener).toHaveBeenCalledOnce();
     expect(transferControl.value).toBe("");
+  });
+
+  it("does not write when delivery occurs after the request deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-20T12:00:00.000Z"));
+
+    try {
+      const transferControl = new FakeTextAreaElement();
+      const addDocumentEventListener = vi.fn();
+      const removeDocumentEventListener = vi.fn();
+      const execCommand = vi.fn(() => true);
+      let offscreenListener: RuntimeMessageListener | undefined;
+      const addListener = vi.fn((listener: RuntimeMessageListener) => {
+        offscreenListener = listener;
+      });
+      const documentUrl = `chrome-extension://extension-id/${OFFSCREEN_CLIPBOARD_DOCUMENT_PATH}`;
+      let delayedMessage: unknown;
+      const sendMessage = vi.fn((message: unknown) => {
+        delayedMessage = message;
+        return new Promise<unknown>(() => undefined);
+      });
+
+      vi.stubGlobal("HTMLTextAreaElement", FakeTextAreaElement);
+      vi.stubGlobal("document", {
+        addEventListener: addDocumentEventListener,
+        getElementById: vi.fn(() => transferControl),
+        execCommand,
+        removeEventListener: removeDocumentEventListener,
+      });
+      vi.stubGlobal("chrome", {
+        offscreen: { createDocument: vi.fn(async () => undefined) },
+        runtime: {
+          getContexts: vi.fn(async () => [
+            { contextType: "OFFSCREEN_DOCUMENT" },
+          ]),
+          getURL: vi.fn(() => documentUrl),
+          onMessage: { addListener },
+          sendMessage,
+        },
+      });
+
+      await import("./offscreen");
+      const { OffscreenClipboard } =
+        await import("../../adapters/clipboard/offscreen-clipboard");
+      const clipboard = new OffscreenClipboard();
+      const pendingWrite = expect(
+        clipboard.writeText("expired-value"),
+      ).rejects.toThrow("Offscreen clipboard response timed out.");
+
+      await vi.advanceTimersByTimeAsync(
+        OFFSCREEN_CLIPBOARD_RESPONSE_TIMEOUT_MS,
+      );
+      await pendingWrite;
+
+      const sendResponse = vi.fn();
+      offscreenListener?.(
+        delayedMessage,
+        { id: "extension-id" } as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        ok: false,
+        error: "Clipboard request expired.",
+      });
+      expect(execCommand).not.toHaveBeenCalled();
+      expect(addDocumentEventListener).not.toHaveBeenCalled();
+      expect(transferControl.value).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/extension/src/extension/offscreen/offscreen.test.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.test.ts
@@ -10,6 +10,12 @@ class FakeTextAreaElement {
   readonly select = vi.fn();
 }
 
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+) => boolean | undefined;
+
 describe("offscreen clipboard bridge", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -18,52 +24,58 @@ describe("offscreen clipboard bridge", () => {
 
   it("routes a service-worker clipboard request through the production listener", async () => {
     const transferControl = new FakeTextAreaElement();
-    const execCommand = vi.fn(() => true);
-    let offscreenListener: ((event: MessageEvent) => void) | undefined;
-    let responsePort: MessagePort | undefined;
-    const addEventListener = vi.fn(
-      (eventName: string, listener: (event: MessageEvent) => void) => {
-        expect(eventName).toBe("message");
-        offscreenListener = listener;
+    let copyListener: ((event: ClipboardEvent) => void) | undefined;
+    const addDocumentEventListener = vi.fn(
+      (_type: "copy", listener: (event: ClipboardEvent) => void) => {
+        copyListener = listener;
       },
     );
+    const removeDocumentEventListener = vi.fn();
+    const execCommand = vi.fn(() => {
+      copyListener?.({
+        clipboardData: { setData: vi.fn() },
+        preventDefault: vi.fn(),
+      } as unknown as ClipboardEvent);
+      return true;
+    });
+    let offscreenListener: RuntimeMessageListener | undefined;
+    const addListener = vi.fn((listener: RuntimeMessageListener) => {
+      offscreenListener = listener;
+    });
     const documentUrl = `chrome-extension://extension-id/${OFFSCREEN_CLIPBOARD_DOCUMENT_PATH}`;
-    const clientPostMessage = vi.fn(
-      (message: unknown, transfer: Transferable[]) => {
-        const transferredPort = transfer[0];
+    const sendMessage = vi.fn(
+      (message: unknown) =>
+        new Promise<unknown>((resolve, reject) => {
+          if (offscreenListener === undefined) {
+            reject(new Error("Offscreen listener is unavailable."));
+            return;
+          }
 
-        if (!(transferredPort instanceof MessagePort)) {
-          throw new Error("Expected an offscreen response port.");
-        }
-
-        responsePort = transferredPort;
-        offscreenListener?.({
-          data: message,
-          ports: [transferredPort],
-        } as unknown as MessageEvent);
-      },
+          offscreenListener(
+            message,
+            { id: "extension-id" } as chrome.runtime.MessageSender,
+            resolve,
+          );
+        }),
     );
-    const matchAll = vi.fn(async () => [
-      { url: documentUrl, postMessage: clientPostMessage },
-    ]);
     const getContexts = vi.fn(async () => [
       { contextType: "OFFSCREEN_DOCUMENT" },
     ]);
 
     vi.stubGlobal("HTMLTextAreaElement", FakeTextAreaElement);
     vi.stubGlobal("document", {
+      addEventListener: addDocumentEventListener,
       getElementById: vi.fn(() => transferControl),
       execCommand,
+      removeEventListener: removeDocumentEventListener,
     });
-    vi.stubGlobal("navigator", {
-      serviceWorker: { addEventListener },
-    });
-    vi.stubGlobal("clients", { matchAll });
     vi.stubGlobal("chrome", {
       offscreen: { createDocument: vi.fn(async () => undefined) },
       runtime: {
         getContexts,
         getURL: vi.fn(() => documentUrl),
+        onMessage: { addListener },
+        sendMessage,
       },
     });
 
@@ -74,22 +86,15 @@ describe("offscreen clipboard bridge", () => {
 
     await expect(clipboard.writeText("bridge-value")).resolves.toBeUndefined();
 
-    expect(addEventListener).toHaveBeenCalledOnce();
-    expect(matchAll).toHaveBeenCalledWith({
-      includeUncontrolled: true,
-      type: "window",
+    expect(addListener).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith({
+      target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
+      operation: "write",
+      value: "bridge-value",
     });
-    expect(clientPostMessage).toHaveBeenCalledWith(
-      {
-        target: OFFSCREEN_CLIPBOARD_MESSAGE_TARGET,
-        operation: "write",
-        value: "bridge-value",
-      },
-      [expect.any(MessagePort)],
-    );
     expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(addDocumentEventListener).toHaveBeenCalledOnce();
+    expect(removeDocumentEventListener).toHaveBeenCalledOnce();
     expect(transferControl.value).toBe("");
-
-    responsePort?.close();
   });
 });

--- a/apps/extension/src/extension/offscreen/offscreen.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.ts
@@ -27,12 +27,21 @@ function isOffscreenClipboardRequest(
 
   return (
     record.target === OFFSCREEN_CLIPBOARD_MESSAGE_TARGET &&
+    typeof record.deadlineEpochMs === "number" &&
+    Number.isFinite(record.deadlineEpochMs) &&
     (record.operation === "read" ||
       (record.operation === "write" && typeof record.value === "string"))
   );
 }
 
 function handleClipboardRequest(request: OffscreenClipboardRequest) {
+  if (Date.now() >= request.deadlineEpochMs) {
+    return {
+      ok: false as const,
+      error: "Clipboard request expired.",
+    };
+  }
+
   if (request.operation === "read") {
     return {
       ok: true as const,

--- a/apps/extension/src/extension/offscreen/offscreen.ts
+++ b/apps/extension/src/extension/offscreen/offscreen.ts
@@ -44,19 +44,19 @@ function handleClipboardRequest(request: OffscreenClipboardRequest) {
   return { ok: true as const };
 }
 
-navigator.serviceWorker.addEventListener("message", (event) => {
-  const responsePort = event.ports[0];
+chrome.runtime.onMessage.addListener(
+  (request: unknown, _sender, sendResponse) => {
+    if (!isOffscreenClipboardRequest(request)) {
+      return;
+    }
 
-  if (responsePort === undefined || !isOffscreenClipboardRequest(event.data)) {
-    return;
-  }
-
-  try {
-    responsePort.postMessage(handleClipboardRequest(event.data));
-  } catch {
-    responsePort.postMessage({
-      ok: false,
-      error: "Clipboard operation failed.",
-    });
-  }
-});
+    try {
+      sendResponse(handleClipboardRequest(request));
+    } catch {
+      sendResponse({
+        ok: false,
+        error: "Clipboard operation failed.",
+      });
+    }
+  },
+);


### PR DESCRIPTION
## What changed

- Replace the `WindowClient` and `MessageChannel` bridge with `chrome.runtime.sendMessage` and `chrome.runtime.onMessage`.
- Keep response validation, delivery errors, and the five-second response timeout.
- Write clipboard data through the `copy` event so an empty value actually replaces the previous clipboard contents.
- Cover rejected and malformed responses, timeouts, synchronous failures, concurrent requests, exact empty writes, and listener cleanup.

## Why

Chrome offscreen documents are not service-worker-controlled window clients. The old bridge worked only in tests that supplied fake `clients` and `navigator.serviceWorker` globals.

A real Chromium run also exposed a second failure. Copying an empty textarea returned success without replacing the existing clipboard value. The alarm removed its task, but the password remained on the clipboard. The copy-event handler now sets the exact requested text, including an empty string.

## Verification

- `pnpm core:type-check`
- `pnpm core:test -- --run` - 731 tests passed
- `pnpm core:verify-common-passwords`
- `pnpm --filter @lfspm/extension run type-check`
- `pnpm ext:lint`
- `pnpm ext:test -- --run` - 411 tests passed
- `pnpm ext:build`
- Loaded the production build as an unpacked MV3 extension in Chromium. The production alarm handler copied a sentinel, cleared it to an exact empty string, removed its task metadata, and canceled the retry alarm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clipboard copying reliability across supported browsers.
  - Preserved exact clipboard text, including empty values.
  - Added safer handling for missing clipboard data and failed requests.
  - Prevented late or duplicate responses from affecting completed operations.
  - Ensured temporary clipboard listeners and controls are consistently cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->